### PR TITLE
Fix bug in AbstractStringBuilder.delete

### DIFF
--- a/teavm-classlib/src/main/java/org/teavm/classlib/java/lang/TAbstractStringBuilder.java
+++ b/teavm-classlib/src/main/java/org/teavm/classlib/java/lang/TAbstractStringBuilder.java
@@ -693,7 +693,7 @@ class TAbstractStringBuilder extends TObject implements TSerializable, TCharSequ
     }
 
     public TAbstractStringBuilder delete(int start, int end) {
-        if (start > end || start >= length) {
+        if (start > end || start > length) {
             throw new TStringIndexOutOfBoundsException();
         }
         if (start == end) {

--- a/teavm-classlib/src/test/java/org/teavm/classlib/java/lang/StringBuilderTest.java
+++ b/teavm-classlib/src/test/java/org/teavm/classlib/java/lang/StringBuilderTest.java
@@ -311,6 +311,13 @@ public class StringBuilderTest {
     }
 
     @Test
+    public void deletesNothing() {
+        StringBuilder sb = new StringBuilder();
+        sb.delete(0, 0);
+        assertEquals(0, sb.length());
+    }
+
+    @Test
     public void replacesRangeWithSequenceOfSameLength() {
         StringBuilder sb = new StringBuilder();
         for (int i = 0; i <= 9; ++i) {


### PR DESCRIPTION
AbstractStringBuilder.delete

```
     * @throws     StringIndexOutOfBoundsException  if {@code start}
     *             is negative, greater than {@code length()}, or
     *             greater than {@code end}.
```

So if start=length exception shouldn't been thrown.
