### PR TITLE
Fixed StringBuilder.deleteCharAt

### DIFF
--- a/teavm-classlib/src/main/java/org/teavm/classlib/java/lang/TAbstractStringBuilder.java
+++ b/teavm-classlib/src/main/java/org/teavm/classlib/java/lang/TAbstractStringBuilder.java
@@ -686,7 +686,6 @@ class TAbstractStringBuilder extends TObject implements TSerializable, TCharSequ
         for (int i = index; i < length; ++i) {
             buffer[i] = buffer[i + 1];
         }
-        --length;
         return this;
     }
 


### PR DESCRIPTION
This fixes an issue with deleteCharAt deleting too many characters.