### PR TITLE
Fix the order comparison is applied in for binarySearch to match the …

### DIFF
--- a/teavm-classlib/src/main/java/org/teavm/classlib/java/util/TCollections.java
+++ b/teavm-classlib/src/main/java/org/teavm/classlib/java/util/TCollections.java
@@ -259,10 +259,10 @@ public class TCollections extends TObject {
         while (true) {
             int i = (l + u) / 2;
             T e = list.get(i);
-            int cmp = -1 * c.compare(e, key);
+            int cmp = c.compare(e, key);
             if (cmp == 0) {
                 return i;
-            } else if (cmp < 0) {
+            } else if (cmp > 0) {
                 u = i - 1;
                 if (u < l) {
                     return -i - 1;

--- a/teavm-classlib/src/main/java/org/teavm/classlib/java/util/TCollections.java
+++ b/teavm-classlib/src/main/java/org/teavm/classlib/java/util/TCollections.java
@@ -259,7 +259,7 @@ public class TCollections extends TObject {
         while (true) {
             int i = (l + u) / 2;
             T e = list.get(i);
-            int cmp = c.compare(key, e);
+            int cmp = -1 * c.compare(e, key);
             if (cmp == 0) {
                 return i;
             } else if (cmp < 0) {


### PR DESCRIPTION
…JDK.

This is necessary since accoding to the method signature of binarySearch
only the elements of the list must implement Comparable<T>, not the key
itself.