### PR TITLE
Using less cryptic prefix for the teavm-maven-plugin

### DIFF
--- a/tools/maven/plugin/pom.xml
+++ b/tools/maven/plugin/pom.xml
@@ -88,7 +88,7 @@
         <version>3.3</version>
         <configuration>
           <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
-          <goalPrefix>mysql-jdbc-compliance</goalPrefix>
+          <goalPrefix>teavm</goalPrefix>
         </configuration>
         <executions>
           <execution>

--- a/tools/maven/plugin/src/main/java/org/teavm/maven/BuildJavascriptTestMojo.java
+++ b/tools/maven/plugin/src/main/java/org/teavm/maven/BuildJavascriptTestMojo.java
@@ -93,6 +93,9 @@ public class BuildJavascriptTestMojo extends AbstractJavascriptMojo {
 
         setupTool(tool);
         try {
+            if (!testFiles.isDirectory()) {
+                throw new MojoFailureException("Directory with tests doesn't exist: " + testFiles);
+            }
             getLog().info("Searching for tests in the directory `" + testFiles.getAbsolutePath() + "'");
             tool.setAdapter(createAdapter(classLoader));
             findTestClasses(classLoader, testFiles, "");


### PR DESCRIPTION
For a while I couldn't find the right goal to execute. My IDE was showing teavm-maven-plugin goals with "mysql-something" prefix. That is probably not what you want. Offering PR with more suitable prefix.