### PR TITLE
Declare resources in pom.xml

### DIFF
--- a/html4j/pom.xml
+++ b/html4j/pom.xml
@@ -81,6 +81,7 @@
               <targetDirectory>${project.build.directory}/javascript-test</targetDirectory>
               <debugInformationGenerated>true</debugInformationGenerated>
               <sourceMapsGenerated>true</sourceMapsGenerated>
+              <resources>**/*.txt</resources>
             </configuration>
           </execution>
           <execution>

--- a/html4j/src/main/java/org/teavm/html4j/HTML4jResourceSupplier.java
+++ b/html4j/src/main/java/org/teavm/html4j/HTML4jResourceSupplier.java
@@ -15,8 +15,7 @@
  */
 package org.teavm.html4j;
 
-import java.util.HashSet;
-import java.util.Set;
+import java.io.File;
 import org.teavm.classlib.ResourceSupplier;
 import org.teavm.model.ListableClassReaderSource;
 
@@ -27,17 +26,10 @@ import org.teavm.model.ListableClassReaderSource;
 public class HTML4jResourceSupplier implements ResourceSupplier {
     @Override
     public String[] supplyResources(ClassLoader classLoader, ListableClassReaderSource classSource) {
-        Set<String> resources = new HashSet<>();
-        for (String className : classSource.getClassNames()) {
-            final int lastDot = className.lastIndexOf('.');
-            if (lastDot == -1) {
-                continue;
-            }
-            String packageName = className.substring(0, lastDot);
-            String resourceName = packageName.replace('.', '/') + "/" + "jvm.txt";
-            resources.add(resourceName);
+        String resources = System.getProperty("resourcesSupplier");
+        if (resources == null) {
+            return null;
         }
-
-        return resources.toArray(new String[0]);
+        return resources.split(File.pathSeparator);
     }
 }


### PR DESCRIPTION
It makes more sense for the applications using TeaVM (like https://github.com/controlsjs/controls4j) to specify the resources to include in the generated script in pom.xml. It is easier for them and their end-users to control pom.xml than write their own Java written supplier.