### PR TITLE
Using slightly faster version of bck2brwsr in the JBox2D benchmark.

### DIFF
--- a/samples/benchmark/README.md
+++ b/samples/benchmark/README.md
@@ -1,5 +1,5 @@
-TeaVM, GWT, HotSport JBox2D Benchmark
-=====================================
+TeaVM, GWT, HotSpot, Bck2Brwsr JBox2D Benchmark
+===============================================
 
 Compares the speed of execution on a complex [JBox2D](http://www.jbox2d.org/) CPU extensive
 computation. JavaScript produced by TeaVM and GWT can be compared by running 

--- a/samples/benchmark/pom.xml
+++ b/samples/benchmark/pom.xml
@@ -19,7 +19,7 @@
   <description>Compares performance of the JavaScript code produced by TeaVM and GWT</description>
   
   <properties>
-      <bck2brwsr.version>0.14</bck2brwsr.version>
+      <bck2brwsr.version>0.17</bck2brwsr.version>
   </properties>
 
   <dependencies>
@@ -63,13 +63,6 @@
       <groupId>com.dukescript.canvas</groupId>
       <artifactId>html5-canvas</artifactId>
       <version>0.7.2</version>
-    </dependency>
-    <dependency>
-      <groupId>com.dukescript.canvas</groupId>
-      <artifactId>canvas-api</artifactId>
-      <version>0.7.2</version>
-      <classifier>bck2brwsr</classifier>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apidesign.bck2brwsr</groupId>


### PR DESCRIPTION
The previous version was embarrassingly slow. This one is able to animate the example and make it look relatively OK.