### PR TITLE
Logging info fix

### DIFF
--- a/classlib/src/main/java/org/teavm/classlib/java/util/logging/TLogger.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/util/logging/TLogger.java
@@ -65,7 +65,7 @@ public class TLogger {
         } else if (record.getLevel().intValue() >= TLevel.WARNING.intValue()) {
             warn(message);
         } else {
-            info(message);
+            inf(message);
         }
     }
 
@@ -142,6 +142,10 @@ public class TLogger {
         log(TLevel.WARNING, msg);
     }
 
+    public void info(TString msg) {
+        log(TLevel.INFO, msg);
+    }
+
     public void config(TString msg) {
         log(TLevel.CONFIG, msg);
     }
@@ -178,7 +182,7 @@ public class TLogger {
             + "if (console) {"
                 + "console.info(message);"
             + "}")
-    public static native void info(TString message);
+    private static native void inf(TString message);
 
     @JSBody(params = "message", script = ""
             + "if (console) {"

--- a/tests/src/test/java/org/teavm/classlib/java/util/logging/LoggerTest.java
+++ b/tests/src/test/java/org/teavm/classlib/java/util/logging/LoggerTest.java
@@ -1,0 +1,33 @@
+/*
+ *  Copyright 2014 Alexey Andreev.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.teavm.classlib.java.util.logging;
+
+import static org.junit.Assert.*;
+import java.util.logging.*;
+import org.junit.Test;
+
+/**
+ * Simple Tests for the java.util.logging.Logger
+ *
+ * @author Sebastian Bauer
+ */
+public class LoggerTest {
+    @Test
+    public void loggerInfoWorks() {
+        Logger logger = Logger.getLogger("");
+        logger.info("It works!");
+    }
+}


### PR DESCRIPTION
This PR fixes a problem when using info() method for a logger:
```
[WARNING] Test built with errors: org.teavm.classlib.java.util.logging.LoggerTest.loggerInfoWorks()V
[ERROR] Method java.util.logging.Logger.info(Ljava/lang/String;)V is not a proper native JavaScript method  declaration. It is non-static and declared on a non-overlay class java.util.logging.Logger
    at org.teavm.classlib.java.util.logging.LoggerTest.loggerInfoWorks(LoggerTest.java:31)
    at org.teavm.tooling.testing.TestEntryPoint.launchTest
    at org.teavm.tooling.testing.TestEntryPoint.lambda$run$0(TestEntryPoint.java:31)
    at $$LAMBDA0$$.launch
    at org.teavm.testing.SimpleTestRunner.run(SimpleTestRunner.java:25)
    at org.teavm.tooling.testing.TestEntryPoint.run(TestEntryPoint.java:31)
```

The first commit introduces a test case demonstrating the problem (the test runs through though, the problem is visible only in the Maven output). The second commit will change the class library Logging implementation. The real problem may be at a different level though (e.g., compiler).