### PR TITLE
Implemented Gradle plugin.

### DIFF
--- a/tools/gradle/.gitignore
+++ b/tools/gradle/.gitignore
@@ -1,0 +1,6 @@
+bin/
+.classpath
+.project
+.settings/
+.gradle/
+build/

--- a/tools/gradle/README.md
+++ b/tools/gradle/README.md
@@ -1,0 +1,33 @@
+# Gradle plugin for TeaVM
+
+Somewhat based on [the Kotlin version](https://github.com/edibleday/teavm-gradle-plugin), refactored and translated to Java for TeaVM code consistency.
+
+## Using the plugin
+
+Add build script dependency:
+```
+buildscript {
+    repositories {
+        mavenLocal()
+        mavenCentral()
+    }
+    dependencies {
+        classpath "org.teavm:teavm-gradle-plugin:0.4.3"
+    }
+}
+```
+
+Apply plugin:
+```
+apply plugin: "teavm"
+```
+
+Use `compileTeaVM` task to compile your application.
+
+## Working with the source
+
+Run `gradle eclipse` or `gradle idea` to generate IDE project.
+
+### Publishing
+
+Use `gradle build install` to publish the plugin into local Maven repository. If you want to publish to Maven Central, fill `gradle.properties` file with signing and logging data. (Be careful not to commit the changes! Hint: you can keep a separate `gradle.properties` file with your Maven Central data in your [Gradle home folder](http://mrhaki.blogspot.com/2015/10/gradle-goodness-setting-global.html).) Use `gradle uploadArchives` to publish the artifact. Changing the `isSnapshot` property to `-SNAPSHOT` or '' (empty string) allows to choose whether a snapshot or final version should be published.

--- a/tools/gradle/build.gradle
+++ b/tools/gradle/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'eclipse'
 apply plugin: 'idea'
 apply plugin: 'maven'
 apply plugin: 'signing'
+apply plugin: 'checkstyle'
 
 sourceCompatibility = 1.6
 

--- a/tools/gradle/build.gradle
+++ b/tools/gradle/build.gradle
@@ -1,0 +1,111 @@
+apply plugin: 'java-gradle-plugin'
+apply plugin: 'eclipse'
+apply plugin: 'idea'
+apply plugin: 'maven'
+apply plugin: 'signing'
+
+sourceCompatibility = 1.6
+
+ext {
+    libVersion = '0.4.3'
+    isSnapshot = '-SNAPSHOT'
+}
+
+group = projectGroupId
+archivesBaseName = "teavm-gradle-plugin"
+version = "$libVersion$isSnapshot"
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+    jcenter()
+}
+
+configurations {
+    deployerJars
+}
+
+dependencies {
+    compile gradleApi()
+    compile "org.teavm:teavm-core:$libVersion"
+    compile "org.teavm:teavm-tooling:$libVersion"
+    deployerJars "org.apache.maven.wagon:wagon-ssh:2.2"
+    deployerJars "org.apache.maven.wagon:wagon-http:2.2"
+}
+
+jar {
+    from project.sourceSets.main.allSource
+    from project.sourceSets.main.output
+    baseName = 'teavm-gradle-plugin'
+}
+
+javadoc {
+    options.addStringOption("sourcepath", "")
+}
+
+task javadocJar(type: Jar) {
+    classifier = 'javadoc'
+    from javadoc
+}
+
+task sourcesJar(type: Jar) {
+    classifier = 'sources'
+    from sourceSets.main.allSource
+}
+
+artifacts {
+    archives javadocJar, sourcesJar
+}
+
+signing {
+    sign configurations.archives
+}
+
+uploadArchives {
+  repositories {
+    mavenDeployer {
+      beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
+
+      repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
+        authentication(userName: ossrhUsername, password: ossrhPassword)
+      }
+
+      snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
+        authentication(userName: ossrhUsername, password: ossrhPassword)
+      }
+
+      pom.project {
+        name 'TeaVM Gradle Plugin'
+        packaging 'jar'
+        description 'Gradle plugin for TeaVM projects.'
+        url 'http://github.com/konsoletyper/teavm'
+
+        licenses {
+          license {
+            name 'The Apache License, Version 2.0'
+            url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+          }
+        }
+        
+        scm {
+          connection 'scm:git:git@github.com:konsoletyper/teavm.git'
+          developerConnection 'scm:git:git@github.com:konsoletyper/teavm.git'
+          url 'http://github.com/konsoletyper/teavm/'
+        }
+
+        developers {
+          developer {
+            id 'mj'
+            name 'MJ'
+            email 'john.hervicc@gmail.com'
+          }
+          developer {
+            id 'aa'
+            name 'Alexey Andreev'
+            email 'konsoletyper@gmail.com'
+          }
+        }
+      }
+    }
+  }
+}

--- a/tools/gradle/config/checkstyle/checkstyle.xml
+++ b/tools/gradle/config/checkstyle/checkstyle.xml
@@ -1,0 +1,90 @@
+<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.2//EN"
+    "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="AnnotationUseStyle"/>
+    <module name="MissingOverride">
+      <property name="javaFiveCompatibility" value="true"/>
+    </module>
+    <module name="EmptyBlock">
+      <property name="option" value="text"/>
+      <property name="tokens" value="LITERAL_CATCH"/>
+    </module>
+    <module name="EmptyBlock">
+      <property name="tokens" value="LITERAL_DO, LITERAL_ELSE, LITERAL_FINALLY, LITERAL_IF,
+          LITERAL_FOR, LITERAL_TRY, LITERAL_WHILE, STATIC_INIT"/>
+      <property name="option" value="text"/>
+    </module>
+    <module name="LeftCurly"/>
+    <module name="NeedBraces"/>
+    <module name="RightCurly"/>
+    <module name="InterfaceIsType"/>
+    <module name="HideUtilityClassConstructor"/>
+    <module name="EmptyStatement"/>
+    <module name="EqualsHashCode"/>
+    <module name="InnerAssignment"/>
+    <module name="SimplifyBooleanExpression"/>
+    <module name="SimplifyBooleanReturn"/>
+    <module name="StringLiteralEquality"/>
+    <module name="IllegalThrows">
+      <property name="illegalClassNames" value="java.lang.Error, java.lang.RuntimeException"/>
+    </module>
+    <module name="ExplicitInitialization"/>
+    <module name="DefaultComesLast"/>
+    <module name="FallThrough"/>
+    <module name="MultipleVariableDeclarations"/>
+    <module name="UnnecessaryParentheses"/>
+    <module name="RedundantImport"/>
+    <module name="UnusedImports">
+      <property name="processJavadoc" value="true"/>
+    </module>
+    <module name="ImportOrder">
+      <property name="option" value="top"/>
+    </module>
+    <module name="UpperEll"/>
+    <module name="ArrayTypeStyle"/>
+    <module name="RedundantModifier">
+      <property name="tokens" value="METHOD_DEF,VARIABLE_DEF,ANNOTATION_FIELD_DEF,INTERFACE_DEF,CLASS_DEF,ENUM_DEF"/>
+    </module>
+    <module name="ClassTypeParameterName"/>
+    <module name="LocalFinalVariableName"/>
+    <module name="LocalVariableName"/>
+    <module name="MemberName"/>
+    <module name="MethodName">
+      <property name="format" value="^(([A-Z][A-Z0-9]+)|([a-z][a-z0-9]*))([A-Z][a-z0-9]*)*"/>
+    </module>
+    <module name="MethodTypeParameterName"/>
+    <module name="PackageName"/>
+    <module name="ParameterName"/>
+    <module name="StaticVariableName"/>
+    <module name="TypeName"/>
+    <module name="LineLength">
+      <property name="max" value="120"/>
+    </module>
+    <module name="GenericWhitespace"/>
+    <module name="EmptyForInitializerPad"/>
+    <module name="EmptyForIteratorPad"/>
+    <module name="MethodParamPad"/>
+    <module name="NoWhitespaceAfter">
+       <property name="tokens" value="BNOT,DEC,DOT,INC,LNOT,UNARY_MINUS,UNARY_PLUS"/>
+    </module>
+    <module name="NoWhitespaceBefore">
+      <property name="allowLineBreaks" value="true"/>
+      <property name="tokens" value="SEMI,POST_DEC,POST_INC"/>
+    </module>
+    <module name="OperatorWrap"/>
+    <module name="ParenPad"/>
+    <module name="TypecastParenPad"/>
+    <module name="WhitespaceAfter">
+      <property name="tokens" value="COMMA,SEMI,TYPECAST"/>
+    </module>
+    <module name="WhitespaceAround"/>
+  </module>
+  <module name="RegexpHeader">
+    <property name="headerFile" value="config/checkstyle/license-regexp.txt"/>
+    <property name="fileExtensions" value="java"/>
+  </module>
+  <module name="FileTabCharacter">
+    <property name="fileExtensions" value="java"/>
+  </module>
+</module>

--- a/tools/gradle/config/checkstyle/license-regexp.txt
+++ b/tools/gradle/config/checkstyle/license-regexp.txt
@@ -1,0 +1,15 @@
+/\*
+ \*  Copyright 2[0-9]{3}(\-2[0-9]{3})? .+
+ \*
+ \*  Licensed under the Apache License, Version 2.0 \(the "License"\);
+ \*  you may not use this file except in compliance with the License.
+ \*  You may obtain a copy of the License at
+ \*
+ \*       http://www\.apache\.org/licenses/LICENSE-2.0
+ \*
+ \*  Unless required by applicable law or agreed to in writing, software
+ \*  distributed under the License is distributed on an "AS IS" BASIS,
+ \*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ \*  See the License for the specific language governing permissions and
+ \*  limitations under the License.
+ \*/

--- a/tools/gradle/example/README.md
+++ b/tools/gradle/example/README.md
@@ -1,0 +1,3 @@
+# Gradle plugin usage example
+
+Run `gradle compileTeaVM`, check `build/dist` folder.

--- a/tools/gradle/example/build.gradle
+++ b/tools/gradle/example/build.gradle
@@ -17,28 +17,43 @@ apply plugin: "teavm"
 mainClassName = "org.teavm.example.Client"
 
 teavm {
+    // True to automatically include basic TeaVM dependencies.
+    includeDependencies = true
     // Version of automatically included TeaVM libs.
-    version = "0.4.3";
+    version = "0.4.3"
     // Directory in the build folder with compiled TeaVM sources.
-    targetDirectory = "dist";
+    targetDirectory = "javascript"
+    // Name of the generated JS file.
+    targetFileName = "classes.js"
+    // True to minify generated JS file.
+    minifying = true
+    // True to generate TeaVM debugging info.
+    debugInformationGenerated = true
+    // True to generate source maps for debugging in browsers.
+    sourceMapsGenerated = true
+    // True to copy source files to build folder.
+    sourceFilesCopied = true
+    // True to run in incremental mode. Not advised in production mode.
+    incremental = false
     // TeaVM cache directory in build folder.
     cacheDirectory = "teavm-cache";
-    // Name of the generated JS file.
-    targetFile = "app.js";
+    // Map (string to string) with compiler properties.
+    // See: http://groovy-lang.org/groovy-dev-kit.html#Collections-Maps
+    properties = [:]
     /* Runtime javascript inclusion:
-        NONE: don't include runtime.
-        MERGED: merge runtime into main javascript file.
-        SEPARATE: include runtime as separated file.
-     */
-    runtime org.teavm.tooling.RuntimeCopyOperation.SEPARATE
-    // True to minify generated JS file.
-    minify = true;
-    // True to enerate TeaVM debugging info.
-    debugInfo = true;
-    // True to generate JS-to-Java source maps for debugging in browsers.
-    sourceMaps = true;
-    // True to copy source files to build folder.
-    sourceFilesCopied = true;
+        NONE: don't include runtime.js.
+        MERGED: merge runtime.js into main javascript file.
+        SEPARATE: include runtime.js as separate file.
+    */
+    runtime = org.teavm.tooling.RuntimeCopyOperation.SEPARATE
     // True to include a simple HTML page.
-    mainPageIncluded = true;
+    mainPageIncluded = true
+    // List of classes implementing ClassHolderTransformer interface.
+    transformers = []
+    // Map of class names to their aliases in generated JS file.
+    classAliases = ["org.teavm.example.Client": "Client"]
+    // List of maps with method aliases properties. Each properties map
+    // should contain 5 entries -  4 string values: alias, className,
+    // methodName, descriptor and 1 list of strings: types.
+    methodAliases = []
 }

--- a/tools/gradle/example/build.gradle
+++ b/tools/gradle/example/build.gradle
@@ -1,0 +1,44 @@
+buildscript {
+    repositories {
+        mavenLocal()
+        mavenCentral()
+    }
+    dependencies {
+        classpath "org.teavm:teavm-gradle-plugin:0.4.3-SNAPSHOT"
+    }
+}
+repositories {
+    mavenCentral()
+}
+
+apply plugin: "eclipse"
+apply plugin: "teavm"
+
+mainClassName = "org.teavm.example.Client"
+
+teavm {
+    // Version of automatically included TeaVM libs.
+    version = "0.4.3";
+    // Directory in the build folder with compiled TeaVM sources.
+    targetDirectory = "dist";
+    // TeaVM cache directory in build folder.
+    cacheDirectory = "teavm-cache";
+    // Name of the generated JS file.
+    targetFile = "app.js";
+    /* Runtime javascript inclusion:
+        NONE: don't include runtime.
+        MERGED: merge runtime into main javascript file.
+        SEPARATE: include runtime as separated file.
+     */
+    runtime org.teavm.tooling.RuntimeCopyOperation.SEPARATE
+    // True to minify generated JS file.
+    minify = true;
+    // True to enerate TeaVM debugging info.
+    debugInfo = true;
+    // True to generate JS-to-Java source maps for debugging in browsers.
+    sourceMaps = true;
+    // True to copy source files to build folder.
+    sourceFilesCopied = true;
+    // True to include a simple HTML page.
+    mainPageIncluded = true;
+}

--- a/tools/gradle/example/src/main/java/org/teavm/example/Client.java
+++ b/tools/gradle/example/src/main/java/org/teavm/example/Client.java
@@ -1,0 +1,13 @@
+package org.teavm.example;
+
+import org.teavm.jso.dom.html.HTMLDocument;
+import org.teavm.jso.dom.html.HTMLElement;
+
+public class Client {
+    public static void main(String[] args) {
+        HTMLDocument document = HTMLDocument.current();
+        HTMLElement div = document.createElement("div");
+        div.appendChild(document.createTextNode("TeaVM generated element"));
+        document.getBody().appendChild(div);
+    }
+}

--- a/tools/gradle/gradle.properties
+++ b/tools/gradle/gradle.properties
@@ -1,0 +1,11 @@
+## Group ID:
+projectGroupId=org.teavm
+
+## JAR signing properties:
+#signing.keyId=
+#signing.password=
+#signing.secretKeyRingFile=
+
+## Maven Central logging data:
+#ossrhUsername=
+#ossrhPassword=

--- a/tools/gradle/src/main/java/org/teavm/gradle/TeaVMPlugin.java
+++ b/tools/gradle/src/main/java/org/teavm/gradle/TeaVMPlugin.java
@@ -1,3 +1,19 @@
+/*
+ *  Copyright 2016 MJ.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package org.teavm.gradle;
 
 import java.util.HashMap;
@@ -52,7 +68,11 @@ public class TeaVMPlugin implements Plugin<Project> {
             @Override
             public void beforeResolve(final ResolvableDependencies resolvableDependencies) {
                 final DependencyHandler handler = project.getDependencies();
-                final String version = project.getExtensions().getByType(TeaVMExtension.class).getVersion();
+                final TeaVMExtension extension = project.getExtensions().getByType(TeaVMExtension.class);
+                if (!extension.isIncludeDependencies()) {
+                    return;
+                }
+                final String version = extension.getVersion();
                 compileDependencies.add(handler.create("org.teavm:teavm-classlib:" + version));
                 compileDependencies.add(handler.create("org.teavm:teavm-jso:" + version));
                 compileDependencies.add(handler.create("org.teavm:teavm-jso-apis:" + version));

--- a/tools/gradle/src/main/java/org/teavm/gradle/TeaVMPlugin.java
+++ b/tools/gradle/src/main/java/org/teavm/gradle/TeaVMPlugin.java
@@ -1,0 +1,80 @@
+package org.teavm.gradle;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.Task;
+import org.gradle.api.artifacts.DependencyResolutionListener;
+import org.gradle.api.artifacts.DependencySet;
+import org.gradle.api.artifacts.ResolvableDependencies;
+import org.gradle.api.artifacts.dsl.DependencyHandler;
+import org.teavm.gradle.extension.TeaVMExtension;
+import org.teavm.gradle.task.CompileTask;
+
+/** Gradle plugin for TeaVM applications.
+ * <p>
+ * Adds "teavm" dependency configuration for TeaVM sources to copy. Adds "teavm" extension with plugin's settings. Adds
+ * "compileTeaVM" task that compiles the sources.
+ *
+ * @author MJ */
+public class TeaVMPlugin implements Plugin<Project> {
+    /** Name of the configuration added by the compilation task to the application's sources. Should reference only
+     * source dependencies. */
+    public static final String TEAVM_CONFIGURATION = "teavm";
+    /** Name of the extension which contains plugin's settings.
+     *
+     * @see TeaVMExtension */
+    public static final String TEAVM_EXTENSION = "teavm";
+
+    @Override
+    public void apply(final Project project) {
+        applyPlugin(project, "java");
+        applyPlugin(project, "application");
+        project.getConfigurations().create(TEAVM_CONFIGURATION);
+        project.getExtensions().create(TEAVM_EXTENSION, TeaVMExtension.class);
+        addDependencies(project);
+        addTasks(project);
+    }
+
+    private static void applyPlugin(final Project project, final String pluginName) {
+        final Map<String, String> plugin = new HashMap<String, String>();
+        plugin.put("plugin", pluginName);
+        project.apply(plugin);
+    }
+
+    private static void addDependencies(final Project project) {
+        final DependencySet compileDependencies = project.getConfigurations().getByName("compile").getDependencies();
+        final DependencySet sourceDependencies = project.getConfigurations().getByName(TEAVM_CONFIGURATION)
+                .getDependencies();
+        project.getGradle().addListener(new DependencyResolutionListener() {
+            @Override
+            public void beforeResolve(final ResolvableDependencies resolvableDependencies) {
+                final DependencyHandler handler = project.getDependencies();
+                final String version = project.getExtensions().getByType(TeaVMExtension.class).getVersion();
+                compileDependencies.add(handler.create("org.teavm:teavm-classlib:" + version));
+                compileDependencies.add(handler.create("org.teavm:teavm-jso:" + version));
+                compileDependencies.add(handler.create("org.teavm:teavm-jso-apis:" + version));
+                sourceDependencies.add(handler.create("org.teavm:teavm-platform:" + version + ":sources"));
+                sourceDependencies.add(handler.create("org.teavm:teavm-classlib:" + version + ":sources"));
+                sourceDependencies.add(handler.create("org.teavm:teavm-jso:" + version + ":sources"));
+                sourceDependencies.add(handler.create("org.teavm:teavm-jso-apis:" + version + ":sources"));
+                project.getGradle().removeListener(this);
+            }
+
+            @Override
+            public void afterResolve(final ResolvableDependencies resolvableDependencies) {
+            }
+        });
+    }
+
+    private static void addTasks(final Project project) {
+        final Map<String, Object> taskData = new HashMap<String, Object>();
+        taskData.put(Task.TASK_TYPE, CompileTask.class);
+        taskData.put(Task.TASK_DEPENDS_ON, "build");
+        taskData.put(Task.TASK_DESCRIPTION, "Compiles TeaVM application.");
+        taskData.put(Task.TASK_GROUP, "build");
+        project.task(taskData, "compileTeaVM");
+    }
+}

--- a/tools/gradle/src/main/java/org/teavm/gradle/extension/MethodAliasUtils.java
+++ b/tools/gradle/src/main/java/org/teavm/gradle/extension/MethodAliasUtils.java
@@ -1,0 +1,51 @@
+/*
+ *  Copyright 2016 MJ.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.teavm.gradle.extension;
+
+import java.util.List;
+import java.util.Map;
+
+import org.teavm.tooling.MethodAlias;
+
+/** Allows to convert {@link Map} with properties into a {@link MethodAlias}.
+ *
+ * @author MJ */
+public class MethodAliasUtils {
+    private static final String ALIAS = "alias";
+    private static final String CLASS_NAME = "className";
+    private static final String METHOD_NAME = "methodName";
+    private static final String DESCRIPTOR = "descriptor";
+    private static final String TYPES = "types";
+
+    private MethodAliasUtils() {
+    }
+
+    public static MethodAlias convert(final Map<String, Object> data) {
+        final MethodAlias alias = new MethodAlias();
+        alias.setAlias(data.get(ALIAS).toString());
+        alias.setClassName(data.get(CLASS_NAME).toString());
+        alias.setMethodName(data.get(METHOD_NAME).toString());
+        alias.setDescriptor(data.get(DESCRIPTOR).toString());
+        @SuppressWarnings("unchecked") final List<String> types = (List<String>) data.get(TYPES);
+        if (types != null) {
+            alias.setTypes(types.toArray(new String[types.size()]));
+        } else {
+            alias.setTypes(new String[] {});
+        }
+        return alias;
+    }
+}

--- a/tools/gradle/src/main/java/org/teavm/gradle/extension/TeaVMExtension.java
+++ b/tools/gradle/src/main/java/org/teavm/gradle/extension/TeaVMExtension.java
@@ -1,0 +1,96 @@
+package org.teavm.gradle.extension;
+
+import org.teavm.tooling.RuntimeCopyOperation;
+
+public class TeaVMExtension {
+    private String targetDirectory = "dist";
+    private String cacheDirectory = "teavm-cache";
+    private String targetFile = "app.js";
+    private String version = "0.4.3";
+    private RuntimeCopyOperation runtime = RuntimeCopyOperation.SEPARATE;
+    private boolean minify = true;
+    private boolean debugInfo = true;
+    private boolean sourceMaps = true;
+    private boolean sourceFilesCopied = true;
+    private boolean mainPageIncluded = true;
+
+    public String getTargetDirectory() {
+        return targetDirectory;
+    }
+
+    public void setTargetDirectory(final String targetDirectory) {
+        this.targetDirectory = targetDirectory;
+    }
+
+    public String getCacheDirectory() {
+        return cacheDirectory;
+    }
+
+    public void setCacheDirectory(final String cacheDirectory) {
+        this.cacheDirectory = cacheDirectory;
+    }
+
+    public String getTargetFile() {
+        return targetFile;
+    }
+
+    public void setTargetFile(final String targetFile) {
+        this.targetFile = targetFile;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(final String version) {
+        this.version = version;
+    }
+
+    public RuntimeCopyOperation getRuntime() {
+        return runtime;
+    }
+
+    public void setRuntime(final RuntimeCopyOperation runtime) {
+        this.runtime = runtime;
+    }
+
+    public boolean isMinify() {
+        return minify;
+    }
+
+    public void setMinify(final boolean minify) {
+        this.minify = minify;
+    }
+
+    public boolean isDebugInfo() {
+        return debugInfo;
+    }
+
+    public void setDebugInfo(final boolean debugInfo) {
+        this.debugInfo = debugInfo;
+    }
+
+    public boolean isSourceMaps() {
+        return sourceMaps;
+    }
+
+    public void setSourceMaps(final boolean sourceMaps) {
+        this.sourceMaps = sourceMaps;
+    }
+
+    public boolean isSourceFilesCopied() {
+        return sourceFilesCopied;
+    }
+
+    public void setSourceFilesCopied(final boolean sourceFilesCopied) {
+        this.sourceFilesCopied = sourceFilesCopied;
+    }
+
+    public boolean isMainPageIncluded() {
+        return mainPageIncluded;
+    }
+
+    public void setMainPageIncluded(final boolean mainPageIncluded) {
+        this.mainPageIncluded = mainPageIncluded;
+    }
+}

--- a/tools/gradle/src/main/java/org/teavm/gradle/extension/TeaVMExtension.java
+++ b/tools/gradle/src/main/java/org/teavm/gradle/extension/TeaVMExtension.java
@@ -1,41 +1,58 @@
+/*
+ *  Copyright 2016 MJ.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package org.teavm.gradle.extension;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import org.teavm.tooling.RuntimeCopyOperation;
 
+/** POJO file with TeaVM plugin settings.
+ *
+ * @author MJ
+ * @see <a href=
+ *      "https://github.com/konsoletyper/teavm/wiki/Building-JavaScript-with-Maven-and-TeaVM#the-build-javascript-goal">
+ *      Maven properties</a> */
 public class TeaVMExtension {
-    private String targetDirectory = "dist";
-    private String cacheDirectory = "teavm-cache";
-    private String targetFile = "app.js";
+    private boolean includeDependencies = true;
     private String version = "0.4.3";
+    private String targetDirectory = "javascript";
+    private String targetFileName = "classes.js";
+    private boolean minifying = true;
+    private boolean debugInformationGenerated;
+    private boolean sourceMapsGenerated;
+    private boolean sourceFilesCopied;
+    private boolean incremental;
+    private String cacheDirectory = "teavm-cache";
+    private Map<String, String> properties = new HashMap<String, String>();
     private RuntimeCopyOperation runtime = RuntimeCopyOperation.SEPARATE;
-    private boolean minify = true;
-    private boolean debugInfo = true;
-    private boolean sourceMaps = true;
-    private boolean sourceFilesCopied = true;
-    private boolean mainPageIncluded = true;
+    private boolean mainPageIncluded;
+    private List<String> transformers;
+    private Map<String, String> classAliases = new HashMap<String, String>();
+    private List<Map<String, Object>> methodAliases = new ArrayList<Map<String, Object>>();
 
-    public String getTargetDirectory() {
-        return targetDirectory;
+    public boolean isIncludeDependencies() {
+        return includeDependencies;
     }
 
-    public void setTargetDirectory(final String targetDirectory) {
-        this.targetDirectory = targetDirectory;
-    }
-
-    public String getCacheDirectory() {
-        return cacheDirectory;
-    }
-
-    public void setCacheDirectory(final String cacheDirectory) {
-        this.cacheDirectory = cacheDirectory;
-    }
-
-    public String getTargetFile() {
-        return targetFile;
-    }
-
-    public void setTargetFile(final String targetFile) {
-        this.targetFile = targetFile;
+    public void setIncludeDependencies(final boolean includeDependencies) {
+        this.includeDependencies = includeDependencies;
     }
 
     public String getVersion() {
@@ -46,36 +63,44 @@ public class TeaVMExtension {
         this.version = version;
     }
 
-    public RuntimeCopyOperation getRuntime() {
-        return runtime;
+    public String getTargetDirectory() {
+        return targetDirectory;
     }
 
-    public void setRuntime(final RuntimeCopyOperation runtime) {
-        this.runtime = runtime;
+    public void setTargetDirectory(final String targetDirectory) {
+        this.targetDirectory = targetDirectory;
     }
 
-    public boolean isMinify() {
-        return minify;
+    public String getTargetFileName() {
+        return targetFileName;
     }
 
-    public void setMinify(final boolean minify) {
-        this.minify = minify;
+    public void setTargetFileName(final String targetFileName) {
+        this.targetFileName = targetFileName;
     }
 
-    public boolean isDebugInfo() {
-        return debugInfo;
+    public boolean isMinifying() {
+        return minifying;
     }
 
-    public void setDebugInfo(final boolean debugInfo) {
-        this.debugInfo = debugInfo;
+    public void setMinifying(final boolean minifying) {
+        this.minifying = minifying;
     }
 
-    public boolean isSourceMaps() {
-        return sourceMaps;
+    public boolean isDebugInformationGenerated() {
+        return debugInformationGenerated;
     }
 
-    public void setSourceMaps(final boolean sourceMaps) {
-        this.sourceMaps = sourceMaps;
+    public void setDebugInformationGenerated(final boolean debugInformationGenerated) {
+        this.debugInformationGenerated = debugInformationGenerated;
+    }
+
+    public boolean isSourceMapsGenerated() {
+        return sourceMapsGenerated;
+    }
+
+    public void setSourceMapsGenerated(final boolean sourceMapsGenerated) {
+        this.sourceMapsGenerated = sourceMapsGenerated;
     }
 
     public boolean isSourceFilesCopied() {
@@ -86,11 +111,67 @@ public class TeaVMExtension {
         this.sourceFilesCopied = sourceFilesCopied;
     }
 
+    public boolean isIncremental() {
+        return incremental;
+    }
+
+    public void setIncremental(final boolean incremental) {
+        this.incremental = incremental;
+    }
+
+    public String getCacheDirectory() {
+        return cacheDirectory;
+    }
+
+    public void setCacheDirectory(final String cacheDirectory) {
+        this.cacheDirectory = cacheDirectory;
+    }
+
+    public Map<String, String> getProperties() {
+        return properties;
+    }
+
+    public void setProperties(final Map<String, String> properties) {
+        this.properties = properties;
+    }
+
+    public RuntimeCopyOperation getRuntime() {
+        return runtime;
+    }
+
+    public void setRuntime(final RuntimeCopyOperation runtime) {
+        this.runtime = runtime;
+    }
+
     public boolean isMainPageIncluded() {
         return mainPageIncluded;
     }
 
     public void setMainPageIncluded(final boolean mainPageIncluded) {
         this.mainPageIncluded = mainPageIncluded;
+    }
+
+    public List<String> getTransformers() {
+        return transformers;
+    }
+
+    public void setTransformers(final List<String> transformers) {
+        this.transformers = transformers;
+    }
+
+    public Map<String, String> getClassAliases() {
+        return classAliases;
+    }
+
+    public void setClassAliases(final Map<String, String> classAliases) {
+        this.classAliases = classAliases;
+    }
+
+    public List<Map<String, Object>> getMethodAliases() {
+        return methodAliases;
+    }
+
+    public void setMethodAliases(final List<Map<String, Object>> methodAliases) {
+        this.methodAliases = methodAliases;
     }
 }

--- a/tools/gradle/src/main/java/org/teavm/gradle/logging/LoggerWrapper.java
+++ b/tools/gradle/src/main/java/org/teavm/gradle/logging/LoggerWrapper.java
@@ -1,3 +1,19 @@
+/*
+ *  Copyright 2016 MJ.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package org.teavm.gradle.logging;
 
 import org.gradle.api.logging.Logger;

--- a/tools/gradle/src/main/java/org/teavm/gradle/logging/LoggerWrapper.java
+++ b/tools/gradle/src/main/java/org/teavm/gradle/logging/LoggerWrapper.java
@@ -1,0 +1,52 @@
+package org.teavm.gradle.logging;
+
+import org.gradle.api.logging.Logger;
+import org.teavm.tooling.TeaVMToolLog;
+
+public class LoggerWrapper implements TeaVMToolLog {
+    private final Logger logger;
+
+    public LoggerWrapper(final Logger logger) {
+        this.logger = logger;
+    }
+
+    @Override
+    public void info(final String text) {
+        logger.info(text);
+    }
+
+    @Override
+    public void debug(final String text) {
+        logger.debug(text);
+    }
+
+    @Override
+    public void warning(final String text) {
+        logger.warn(text);
+    }
+
+    @Override
+    public void error(final String text) {
+        logger.error(text);
+    }
+
+    @Override
+    public void info(final String text, final Throwable e) {
+        logger.info(text, e);
+    }
+
+    @Override
+    public void debug(final String text, final Throwable e) {
+        logger.debug(text, e);
+    }
+
+    @Override
+    public void warning(final String text, final Throwable e) {
+        logger.warn(text, e);
+    }
+
+    @Override
+    public void error(final String text, final Throwable e) {
+        logger.error(text, e);
+    }
+}

--- a/tools/gradle/src/main/java/org/teavm/gradle/task/CompileTask.java
+++ b/tools/gradle/src/main/java/org/teavm/gradle/task/CompileTask.java
@@ -1,3 +1,19 @@
+/*
+ *  Copyright 2016 MJ.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package org.teavm.gradle.task;
 
 import java.io.File;
@@ -6,23 +22,44 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 
 import org.gradle.api.DefaultTask;
+import org.gradle.api.GradleException;
 import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskAction;
 import org.teavm.gradle.TeaVMPlugin;
+import org.teavm.gradle.extension.MethodAliasUtils;
 import org.teavm.gradle.extension.TeaVMExtension;
 import org.teavm.gradle.logging.LoggerWrapper;
+import org.teavm.model.ClassHolderTransformer;
+import org.teavm.tooling.ClassAlias;
+import org.teavm.tooling.MethodAlias;
 import org.teavm.tooling.TeaVMTool;
 import org.teavm.tooling.TeaVMToolException;
 import org.teavm.tooling.sources.DirectorySourceFileProvider;
 import org.teavm.tooling.sources.JarSourceFileProvider;
 
+/** Compiles TeaVM application. Expects the project to has the {@code mainClassName} property. Customizable with
+ * {@link TeaVMExtension}.
+ *
+ * @author MJ */
 public class CompileTask extends DefaultTask {
     @TaskAction
-    public void compile() throws TeaVMToolException {
+    public void compile() {
+        try {
+            compileTeaVM();
+        } catch (final Exception exception) {
+            getProject().getLogger().error("Unable to compile TeaVM application.", exception);
+            throw new GradleException("Unable to compile TeaVM application.", exception);
+        }
+    }
+
+    private void compileTeaVM() throws TeaVMToolException {
         final TeaVMTool tool = new TeaVMTool();
         tool.setLog(new LoggerWrapper(getProject().getLogger()));
         copyProperties(tool);
@@ -43,15 +80,20 @@ public class CompileTask extends DefaultTask {
     private void copyProperties(final TeaVMTool tool) throws TeaVMToolException {
         final TeaVMExtension extension = getProject().getExtensions().getByType(TeaVMExtension.class);
         tool.setTargetDirectory(toFile(extension.getTargetDirectory()));
+        tool.setTargetFileName(extension.getTargetFileName());
+        tool.setMinifying(extension.isMinifying());
+        tool.setDebugInformationGenerated(extension.isDebugInformationGenerated());
+        tool.setSourceMapsFileGenerated(extension.isSourceMapsGenerated());
+        tool.setSourceFilesCopied(extension.isSourceFilesCopied());
+        tool.setIncremental(extension.isIncremental());
         tool.setCacheDirectory(toFile(extension.getCacheDirectory()));
-        tool.setTargetFileName(extension.getTargetFile());
         tool.setRuntime(extension.getRuntime());
         tool.setMainPageIncluded(extension.isMainPageIncluded());
-        tool.setMinifying(extension.isMinify());
-        tool.setDebugInformationGenerated(extension.isDebugInfo());
-        tool.setSourceFilesCopied(extension.isSourceFilesCopied());
-        tool.setSourceMapsFileGenerated(extension.isSourceMaps());
         tool.setMainClass(findMainClass());
+        fillProperties(tool, extension);
+        fillClassAliases(tool, extension);
+        fillMethodAliases(tool, extension);
+        fillTransformers(tool, extension);
     }
 
     private File toFile(final String fileName) throws TeaVMToolException {
@@ -70,6 +112,52 @@ public class CompileTask extends DefaultTask {
             }
         }
         throw new TeaVMToolException("Unable to determine main class.");
+    }
+
+    private static void fillProperties(final TeaVMTool tool, final TeaVMExtension extension) {
+        if (extension.getProperties() != null) {
+            tool.getProperties().putAll(extension.getProperties());
+        }
+    }
+
+    private static void fillClassAliases(final TeaVMTool tool, final TeaVMExtension extension) {
+        if (extension.getClassAliases() != null) {
+            final List<ClassAlias> aliases = tool.getClassAliases();
+            for (final Entry<String, String> aliasData : extension.getClassAliases().entrySet()) {
+                final ClassAlias alias = new ClassAlias();
+                alias.setClassName(aliasData.getKey());
+                alias.setAlias(aliasData.getValue());
+                aliases.add(alias);
+            }
+        }
+    }
+
+    private static void fillMethodAliases(final TeaVMTool tool, final TeaVMExtension extension)
+            throws TeaVMToolException {
+        final List<MethodAlias> aliases = tool.getMethodAliases();
+        if (extension.getMethodAliases() != null) {
+            for (final Map<String, Object> aliasData : extension.getMethodAliases()) {
+                try {
+                    aliases.add(MethodAliasUtils.convert(aliasData));
+                } catch (final Exception exception) {
+                    throw new TeaVMToolException("Unable to construct method alias from: " + aliasData, exception);
+                }
+            }
+        }
+    }
+
+    private static void fillTransformers(final TeaVMTool tool, final TeaVMExtension extension)
+            throws TeaVMToolException {
+        if (extension.getTransformers() != null) {
+            final List<ClassHolderTransformer> transformers = tool.getTransformers();
+            for (final String transformerClass : extension.getTransformers()) {
+                try {
+                    transformers.add((ClassHolderTransformer) Class.forName(transformerClass).newInstance());
+                } catch (final Exception exception) {
+                    throw new TeaVMToolException("Unable to obtain transformer class: " + transformerClass, exception);
+                }
+            }
+        }
     }
 
     private void gatherSources(final TeaVMTool tool) {

--- a/tools/gradle/src/main/java/org/teavm/gradle/task/CompileTask.java
+++ b/tools/gradle/src/main/java/org/teavm/gradle/task/CompileTask.java
@@ -1,0 +1,124 @@
+package org.teavm.gradle.task;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.plugins.JavaPluginConvention;
+import org.gradle.api.tasks.SourceSet;
+import org.gradle.api.tasks.TaskAction;
+import org.teavm.gradle.TeaVMPlugin;
+import org.teavm.gradle.extension.TeaVMExtension;
+import org.teavm.gradle.logging.LoggerWrapper;
+import org.teavm.tooling.TeaVMTool;
+import org.teavm.tooling.TeaVMToolException;
+import org.teavm.tooling.sources.DirectorySourceFileProvider;
+import org.teavm.tooling.sources.JarSourceFileProvider;
+
+public class CompileTask extends DefaultTask {
+    @TaskAction
+    public void compile() throws TeaVMToolException {
+        final TeaVMTool tool = new TeaVMTool();
+        tool.setLog(new LoggerWrapper(getProject().getLogger()));
+        copyProperties(tool);
+        gatherSources(tool);
+        final URLClassLoader loader = prepareClassLoader();
+        tool.setClassLoader(loader);
+        try {
+            tool.generate();
+        } finally {
+            try {
+                loader.close();
+            } catch (final IOException exception) {
+                getProject().getLogger().error("Unable to close class loader.", exception);
+            }
+        }
+    }
+
+    private void copyProperties(final TeaVMTool tool) throws TeaVMToolException {
+        final TeaVMExtension extension = getProject().getExtensions().getByType(TeaVMExtension.class);
+        tool.setTargetDirectory(toFile(extension.getTargetDirectory()));
+        tool.setCacheDirectory(toFile(extension.getCacheDirectory()));
+        tool.setTargetFileName(extension.getTargetFile());
+        tool.setRuntime(extension.getRuntime());
+        tool.setMainPageIncluded(extension.isMainPageIncluded());
+        tool.setMinifying(extension.isMinify());
+        tool.setDebugInformationGenerated(extension.isDebugInfo());
+        tool.setSourceFilesCopied(extension.isSourceFilesCopied());
+        tool.setSourceMapsFileGenerated(extension.isSourceMaps());
+        tool.setMainClass(findMainClass());
+    }
+
+    private File toFile(final String fileName) throws TeaVMToolException {
+        final File file = new File(getProject().getBuildDir(), fileName);
+        if (!file.exists() && !file.mkdirs()) {
+            throw new TeaVMToolException("Cannot create directory: " + fileName);
+        }
+        return file;
+    }
+
+    private String findMainClass() throws TeaVMToolException {
+        if (getProject().hasProperty("mainClassName")) {
+            final Object mainClass = getProject().property("mainClassName");
+            if (mainClass != null) {
+                return mainClass.toString();
+            }
+        }
+        throw new TeaVMToolException("Unable to determine main class.");
+    }
+
+    private void gatherSources(final TeaVMTool tool) {
+        final JavaPluginConvention javaPlugin = getProject().getConvention().getPlugin(JavaPluginConvention.class);
+        final Set<File> sources = new HashSet<File>();
+        for (final File file : javaPlugin.getSourceSets().getByName(SourceSet.MAIN_SOURCE_SET_NAME).getAllSource()) {
+            sources.add(file);
+        }
+        for (final File file : getProject().getConfigurations().getByName(TeaVMPlugin.TEAVM_CONFIGURATION)) {
+            sources.add(file);
+        }
+        for (final File file : sources) {
+            addSourceProvider(tool, file);
+        }
+    }
+
+    private static void addSourceProvider(final TeaVMTool tool, final File file) {
+        if (file.isFile() && file.getName().endsWith(".jar")) {
+            tool.addSourceFileProvider(new JarSourceFileProvider(file));
+        } else {
+            tool.addSourceFileProvider(new DirectorySourceFileProvider(file));
+        }
+    }
+
+    private URLClassLoader prepareClassLoader() throws TeaVMToolException {
+        final Set<URL> urls = new HashSet<URL>();
+        // Gathering resources:
+        final JavaPluginConvention javaPlugin = getProject().getConvention().getPlugin(JavaPluginConvention.class);
+        final SourceSet mainSourceSet = javaPlugin.getSourceSets().getByName(SourceSet.MAIN_SOURCE_SET_NAME);
+        for (final File file : mainSourceSet.getResources()) {
+            urls.add(toUrl(file));
+        }
+        // Gathering binaries:
+        for (final File file : mainSourceSet.getOutput().getFiles()) {
+            getProject().getLogger().error("Source dir:" + file);
+            urls.add(toUrl(file));
+        }
+        // Gathering runtime dependencies:
+        for (final File file : getProject().getConfigurations().getByName("runtime")) {
+            urls.add(toUrl(file));
+        }
+        return new URLClassLoader(urls.toArray(new URL[urls.size()]), getClass().getClassLoader());
+    }
+
+    private static URL toUrl(final File file) throws TeaVMToolException {
+        try {
+            return file.toURI().toURL();
+        } catch (final MalformedURLException exception) {
+            throw new TeaVMToolException("Invalid URL in classpath.", exception);
+        }
+    }
+}

--- a/tools/gradle/src/main/resources/META-INF/gradle-plugins/teavm.properties
+++ b/tools/gradle/src/main/resources/META-INF/gradle-plugins/teavm.properties
@@ -1,0 +1,1 @@
+implementation-class=org.teavm.gradle.TeaVMPlugin


### PR DESCRIPTION
Gradle plugin based on [Kotlin version](https://github.com/edibleday/teavm-gradle-plugin). Translated to Java on request for code consistency. Has more settings (including TeaVM version, which is fixed in former plugin) and fixes minor bugs (output folders are taken directly from `Project` settings rather than hardcoded to `build/classes/main` and `build/resources/main`). Includes an example project.
