### PR TITLE
Use max() instead of min() when enlarging the array.

### DIFF
--- a/classlib/src/main/java/org/teavm/classlib/java/util/TArrayList.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/util/TArrayList.java
@@ -53,7 +53,7 @@ public class TArrayList<E> extends TAbstractList<E> implements TCloneable, TSeri
 
     public void ensureCapacity(int minCapacity) {
         if (array.length < minCapacity) {
-            array = TArrays.copyOf(array, array.length + TMath.min(5, array.length / 2));
+            array = TArrays.copyOf(array, array.length + TMath.max(5, array.length / 2));
         }
     }
 


### PR DESCRIPTION
Adding n elements subsequently has now an O(n) running time while it was
O(n^2) before.