### PR TITLE
Added annotation to suppress errors like * claimed to be synchronous,…

### DIFF
--- a/interop/core/src/main/java/org/teavm/interop/SuppressSyncErrors.java
+++ b/interop/core/src/main/java/org/teavm/interop/SuppressSyncErrors.java
@@ -1,0 +1,28 @@
+/*
+ *  Copyright 2016 Alexey Andreev.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.teavm.interop;
+
+import java.lang.annotation.*;
+
+/**
+ * 
+ * @author Steve Hannah
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface SuppressSyncErrors {
+}
+


### PR DESCRIPTION
… but has invocations of synchronous methods.  This is usesful in cases where the developer knows that the APIs are synchronous but might be mistakenly marked as async for some reason.  This is a possible workaround for issues like https://github.com/konsoletyper/teavm/issues/248