### PR TITLE
Fixes issue with stack overflow upon calling Throwable.getCause().  T…

### DIFF
--- a/classlib/src/main/java/org/teavm/classlib/java/lang/TThrowable.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/lang/TThrowable.java
@@ -98,6 +98,9 @@ public class TThrowable extends RuntimeException {
         this.writableStackTrace = true;
         fillInStackTrace();
         this.cause = cause;
+        if (cause != null) {
+            this.message = cause.message;
+        }
     }
 
     @Override
@@ -117,7 +120,10 @@ public class TThrowable extends RuntimeException {
 
     @Override
     public TThrowable getCause() {
-        return cause != this ? cause : null;
+        if (cause == this) {
+            return null;
+        }
+        return cause;
     }
 
     @Remove
@@ -144,6 +150,11 @@ public class TThrowable extends RuntimeException {
 
     public void printStackTrace(TPrintStream stream) {
         stream.println(TString.wrap(getClass().getName() + ": " + getMessage()));
+        if (cause != null && cause != this) {
+            stream.print((TString.wrap("Caused by ")));
+            cause.printStackTrace(stream);
+        }
+            
     }
 
     @Rename("getStackTrace")


### PR DESCRIPTION
…here was likely another issue in the TeaVM compiler... this doesn't fix that.  It just changes the structure of the method, and TeaVM seems to be able to compile it properly now.

Ref.  https://github.com/konsoletyper/teavm/issues/249

This also changes printStackTrace to show the cause exceptions also. 
Also Throwable(Throwable cause) now sets the message to be the cause's message to bring it inline with OpenJDK's behaviour.