### PR TITLE
#252 WASM binary version was reset to 0x01 for MVP official release

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ You can use TeaVM for building applications for the browser, due to the followin
   * generation of source maps;
   * debugger;
   * interoperation with JavaScript libraries together with the set of predefined browser interfaces.
-  * supports WebAssebly output (experimental).
+  * supports WebAssembly output (experimental).
 
 
 Quick start

--- a/core/src/main/java/org/teavm/backend/wasm/WasmTarget.java
+++ b/core/src/main/java/org/teavm/backend/wasm/WasmTarget.java
@@ -131,7 +131,7 @@ public class WasmTarget implements TeaVMTarget {
     private ClassInitializerEliminator classInitializerEliminator;
     private ClassInitializerTransformer classInitializerTransformer;
     private ShadowStackTransformer shadowStackTransformer;
-    private WasmBinaryVersion version = WasmBinaryVersion.V_0xC;
+    private WasmBinaryVersion version = WasmBinaryVersion.V_0x1;
 
     @Override
     public void setController(TeaVMTargetController controller) {

--- a/core/src/main/java/org/teavm/backend/wasm/render/WasmBinaryVersion.java
+++ b/core/src/main/java/org/teavm/backend/wasm/render/WasmBinaryVersion.java
@@ -16,7 +16,5 @@
 package org.teavm.backend.wasm.render;
 
 public enum WasmBinaryVersion {
-    V_0xB,
-    V_0xC,
-    V_0xD
+    V_0x1
 }

--- a/core/src/main/java/org/teavm/backend/wasm/render/WasmBinaryWriter.java
+++ b/core/src/main/java/org/teavm/backend/wasm/render/WasmBinaryWriter.java
@@ -29,21 +29,21 @@ public class WasmBinaryWriter {
 
     public void writeType(WasmType type, WasmBinaryVersion version) {
         if (type == null) {
-            writeByte(version == WasmBinaryVersion.V_0xD ? 0x40 : 0);
+            writeByte(0x40);
             return;
         }
         switch (type) {
             case INT32:
-                writeByte(version == WasmBinaryVersion.V_0xD ? 0x7F : 1);
+                writeByte(0x7F);
                 break;
             case INT64:
-                writeByte(version == WasmBinaryVersion.V_0xD ? 0x7E : 2);
+                writeByte(0x7E);
                 break;
             case FLOAT32:
-                writeByte(version == WasmBinaryVersion.V_0xD ? 0x7D : 3);
+                writeByte(0x7D);
                 break;
             case FLOAT64:
-                writeByte(version == WasmBinaryVersion.V_0xD ? 0x7C : 4);
+                writeByte(0x7C);
                 break;
         }
     }

--- a/tools/cli/src/main/java/org/teavm/cli/TeaVMRunner.java
+++ b/tools/cli/src/main/java/org/teavm/cli/TeaVMRunner.java
@@ -15,11 +15,22 @@
  */
 package org.teavm.cli;
 
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
-import org.apache.commons.cli.*;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.OptionBuilder;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+import org.apache.commons.cli.PosixParser;
 import org.teavm.backend.wasm.render.WasmBinaryVersion;
 import org.teavm.tooling.ClassAlias;
 import org.teavm.tooling.RuntimeCopyOperation;
@@ -315,14 +326,8 @@ public final class TeaVMRunner {
             try {
                 int version = Integer.parseInt(value);
                 switch (version) {
-                    case 11:
-                        tool.setWasmVersion(WasmBinaryVersion.V_0xB);
-                        break;
-                    case 12:
-                        tool.setWasmVersion(WasmBinaryVersion.V_0xC);
-                        break;
-                    case 13:
-                        tool.setWasmVersion(WasmBinaryVersion.V_0xD);
+                    case 1:
+                        tool.setWasmVersion(WasmBinaryVersion.V_0x1);
                         break;
                     default:
                         System.err.print("Wrong version value");

--- a/tools/core/src/main/java/org/teavm/tooling/TeaVMTool.java
+++ b/tools/core/src/main/java/org/teavm/tooling/TeaVMTool.java
@@ -100,7 +100,7 @@ public class TeaVMTool implements BaseTeaVMTool {
     private DebugInformationBuilder debugEmitter;
     private JavaScriptTarget javaScriptTarget;
     private WasmTarget webAssemblyTarget;
-    private WasmBinaryVersion wasmVersion = WasmBinaryVersion.V_0xD;
+    private WasmBinaryVersion wasmVersion = WasmBinaryVersion.V_0x1;
 
     public File getTargetDirectory() {
         return targetDirectory;

--- a/tools/maven/plugin/src/main/java/org/teavm/maven/TeaVMCompileMojo.java
+++ b/tools/maven/plugin/src/main/java/org/teavm/maven/TeaVMCompileMojo.java
@@ -78,7 +78,7 @@ public class TeaVMCompileMojo extends AbstractTeaVMMojo {
     private TeaVMTool tool = new TeaVMTool();
 
     @Parameter
-    private WasmBinaryVersion wasmVersion = WasmBinaryVersion.V_0xD;
+    private WasmBinaryVersion wasmVersion = WasmBinaryVersion.V_0x1;
 
     @Override
     protected File getTargetDirectory() {


### PR DESCRIPTION
In current browsers and for the official MVP only WASM binary version 0x01 is supported.
All other binary versions are no longer required or supported, hence the generation
logic for them is no longer needed.