### PR TITLE
#253 WASM Memory should be exported to make it accessible from JS

### DIFF
--- a/core/src/main/java/org/teavm/backend/wasm/render/WasmRenderer.java
+++ b/core/src/main/java/org/teavm/backend/wasm/render/WasmRenderer.java
@@ -81,7 +81,7 @@ public class WasmRenderer {
 
     public void renderMemory(WasmModule module) {
         visitor.lf();
-        visitor.open().append("memory " + module.getMemorySize()).close().lf();
+        visitor.open().append("memory (export \"memory\") " + module.getMemorySize()).close().lf();
     }
 
     public void renderData(WasmModule module) {


### PR DESCRIPTION
Now a default export named "memory" is created to export the WASM memory.