### PR TITLE
Running Knockout for Java tests

### DIFF
--- a/html4j/src/test/java/org/teavm/html4j/test/KnockoutFXTest.java
+++ b/html4j/src/test/java/org/teavm/html4j/test/KnockoutFXTest.java
@@ -47,11 +47,16 @@ import org.testng.Assert;
 public final class KnockoutFXTest extends KnockoutTCK implements Transfer, WSTransfer<WSImpl> {
     private static Class<?> browserClass;
     private static Fn.Presenter browserContext;
+
     private KO4J ko4j = new KO4J();
     private final Map<String, Request> urlMap = new HashMap<>();
     private final Map<String, WSImpl> wsUrlMap = new HashMap<>();
 
     public KnockoutFXTest() {
+    }
+
+    static Class<?>[] allTestClasses() {
+        return testClasses();
     }
 
     static ClassLoader getClassLoader() throws InterruptedException {

--- a/html4j/src/test/java/org/teavm/html4j/test/KnockoutFXTest.java
+++ b/html4j/src/test/java/org/teavm/html4j/test/KnockoutFXTest.java
@@ -24,7 +24,6 @@ import java.util.HashMap;
 import java.util.Map;
 import net.java.html.BrwsrCtx;
 import net.java.html.js.JavaScriptBody;
-import org.netbeans.html.boot.spi.Fn;
 import org.netbeans.html.context.spi.Contexts;
 import org.netbeans.html.json.spi.JSONCall;
 import org.netbeans.html.json.spi.Technology;
@@ -38,16 +37,12 @@ import org.teavm.jso.JSObject;
 import org.teavm.jso.browser.Window;
 import org.teavm.jso.dom.html.HTMLDocument;
 import org.teavm.jso.dom.html.HTMLElement;
-import org.testng.Assert;
 
 /**
  *
  * @author Jaroslav Tulach <jtulach@netbeans.org>
  */
 public final class KnockoutFXTest extends KnockoutTCK implements Transfer, WSTransfer<WSImpl> {
-    private static Class<?> browserClass;
-    private static Fn.Presenter browserContext;
-
     private KO4J ko4j = new KO4J();
     private final Map<String, Request> urlMap = new HashMap<>();
     private final Map<String, WSImpl> wsUrlMap = new HashMap<>();
@@ -57,29 +52,6 @@ public final class KnockoutFXTest extends KnockoutTCK implements Transfer, WSTra
 
     static Class<?>[] allTestClasses() {
         return testClasses();
-    }
-
-    static ClassLoader getClassLoader() throws InterruptedException {
-        while (browserClass == null) {
-            KnockoutFXTest.class.wait();
-        }
-        return browserClass.getClassLoader();
-    }
-
-    public static void initialized(Class<?> browserCls) throws Exception {
-        browserClass = browserCls;
-        browserContext = Fn.activePresenter();
-        KnockoutFXTest.class.notifyAll();
-    }
-
-    public static void initialized() throws Exception {
-        Assert.assertSame(
-            KnockoutFXTest.class.getClassLoader(),
-            ClassLoader.getSystemClassLoader(),
-            "No special classloaders"
-        );
-        KnockoutFXTest.initialized(KnockoutFXTest.class);
-        browserContext = Fn.activePresenter();
     }
 
     @Override

--- a/html4j/src/test/java/org/teavm/html4j/test/KnockoutTCKCheckTest.java
+++ b/html4j/src/test/java/org/teavm/html4j/test/KnockoutTCKCheckTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017 Jaroslav Tulach.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.teavm.html4j.test;
+
+import java.lang.reflect.Method;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+import org.junit.Test;
+import org.netbeans.html.json.tck.KOTest;
+
+/**
+ *
+ * @author Jaroslav Tulach
+ */
+public class KnockoutTCKCheckTest {
+    @Test
+    public void allKnockoutTestMethodsOverriden() throws Exception {
+        for (Class<?> c : KnockoutFXTest.allTestClasses()) {
+            if (c.getName().contains("GC")) {
+                continue;
+            }
+            for (Method m : c.getMethods()) {
+                if (m.getAnnotation(KOTest.class) != null) {
+                    Method override = null;
+                    try {
+                        override = KnockoutTCKTest.class.getMethod(m.getName());
+                    } catch (NoSuchMethodException ex) {
+                        fail("Cannot find " + m);
+                    }
+                    assertEquals("overriden: " + override, KnockoutTCKTest.class, override.getDeclaringClass());
+                    assertNotNull("annotated: " + override, override.getAnnotation(Test.class));
+                }
+            }
+        }
+    }
+}

--- a/html4j/src/test/java/org/teavm/html4j/test/KnockoutTCKTest.java
+++ b/html4j/src/test/java/org/teavm/html4j/test/KnockoutTCKTest.java
@@ -67,7 +67,7 @@ public class KnockoutTCKTest {
 
     @Test
     public void paintTheGridOnClick() throws Throwable {
-        minesTest.paintTheGridOnClick();
+        withInterrupt(minesTest::paintTheGridOnClick);
     }
 
     @Test
@@ -126,8 +126,8 @@ public class KnockoutTCKTest {
     }
 
     @Test
-    public void modifyValueAssertAsyncChangeInModel() throws Exception {
-        knockoutTest.modifyValueAssertAsyncChangeInModel();
+    public void modifyValueAssertAsyncChangeInModel() throws Throwable {
+        withInterrupt(knockoutTest::modifyValueAssertAsyncChangeInModel);
     }
 
     @Test
@@ -161,8 +161,8 @@ public class KnockoutTCKTest {
     }
 
     @Test
-    public void displayContentOfAsyncArray() throws Exception {
-        knockoutTest.displayContentOfAsyncArray();
+    public void displayContentOfAsyncArray() throws Throwable {
+        withInterrupt(knockoutTest::displayContentOfAsyncArray);
     }
 
     @Test
@@ -396,4 +396,19 @@ public class KnockoutTCKTest {
         convertTypesTest.parseOnEmptyArray();
     }
 
+    private void withInterrupt(R r) throws Throwable {
+        for (int i = 0; i < 10; i++) {
+            try {
+                r.run();
+                break;
+            } catch (InterruptedException ex) {
+                Thread.sleep(100);
+                continue;
+            }
+        }
+    }
+
+    static interface R {
+        void run() throws Throwable;
+    }
 }

--- a/html4j/src/test/java/org/teavm/html4j/test/KnockoutTCKTest.java
+++ b/html4j/src/test/java/org/teavm/html4j/test/KnockoutTCKTest.java
@@ -1,0 +1,399 @@
+/*
+ * Copyright 2017 Jaroslav Tulach.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.teavm.html4j.test;
+
+import net.java.html.json.tests.ConvertTypesTest;
+import net.java.html.json.tests.JSONTest;
+import net.java.html.json.tests.KnockoutTest;
+import net.java.html.json.tests.MinesTest;
+import net.java.html.json.tests.OperationsTest;
+import net.java.html.json.tests.WebSocketTest;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.teavm.junit.SkipJVM;
+import org.teavm.junit.TeaVMTestRunner;
+
+/**
+ *
+ * @author Jaroslav Tulach
+ */
+@RunWith(TeaVMTestRunner.class)
+@SkipJVM
+public class KnockoutTCKTest {
+    private final ConvertTypesTest convertTypesTest = new ConvertTypesTest();
+    private final JSONTest jsonTest = new JSONTest();
+    private final KnockoutTest knockoutTest = new KnockoutTest();
+    private final MinesTest minesTest = new MinesTest();
+    private final OperationsTest operationsTest = new OperationsTest();
+    private final WebSocketTest webSocketTest = new WebSocketTest();
+
+    @Test
+    public void connectUsingWebSocket() throws Throwable {
+        webSocketTest.connectUsingWebSocket();
+    }
+
+    @Test
+    public void errorUsingWebSocket() throws Throwable {
+        webSocketTest.errorUsingWebSocket();
+    }
+
+    @Test
+    public void haveToOpenTheWebSocket() throws Throwable {
+        webSocketTest.haveToOpenTheWebSocket();
+    }
+
+    @Test
+    public void syncOperation() {
+        operationsTest.syncOperation();
+    }
+
+    @Test
+    public void asyncOperation() throws InterruptedException {
+        operationsTest.asyncOperation();
+    }
+
+    @Test
+    public void paintTheGridOnClick() throws Throwable {
+        minesTest.paintTheGridOnClick();
+    }
+
+    @Test
+    public void countAround() throws Exception {
+        minesTest.countAround();
+    }
+
+    @Test
+    public void modifyValueAssertChangeInModelOnEnum() throws Throwable {
+        knockoutTest.modifyValueAssertChangeInModelOnEnum();
+    }
+
+    @Test
+    public void modifyRadioValueOnEnum() throws Throwable {
+        knockoutTest.modifyRadioValueOnEnum();
+    }
+
+    @Test
+    public void modifyValueAssertChangeInModelOnDouble() throws Throwable {
+        knockoutTest.modifyValueAssertChangeInModelOnDouble();
+    }
+
+    @Test
+    public void rawObject() throws Exception {
+        knockoutTest.rawObject();
+    }
+
+    @Test
+    public void modifyComputedProperty() throws Throwable {
+        knockoutTest.modifyComputedProperty();
+    }
+
+    @Test
+    public void modifyValueAssertChangeInModelOnBoolean() throws Throwable {
+        knockoutTest.modifyValueAssertChangeInModelOnBoolean();
+    }
+
+    @Test
+    public void modifyValueAssertChangeInModel() throws Exception {
+        knockoutTest.modifyValueAssertChangeInModel();
+    }
+
+    @Test
+    public void selectWorksOnModels() throws Exception {
+        knockoutTest.selectWorksOnModels();
+    }
+
+    @Test
+    public void nestedObjectEqualsChange() throws Exception {
+        knockoutTest.nestedObjectEqualsChange();
+    }
+
+    @Test
+    public void nestedObjectChange() throws Exception {
+        knockoutTest.nestedObjectChange();
+    }
+
+    @Test
+    public void modifyValueAssertAsyncChangeInModel() throws Exception {
+        knockoutTest.modifyValueAssertAsyncChangeInModel();
+    }
+
+    @Test
+    public void nonMutableDouble() throws Exception {
+        knockoutTest.nonMutableDouble();
+    }
+
+    @Test
+    public void nonMutableString() throws Exception {
+        knockoutTest.nonMutableString();
+    }
+
+    @Test
+    public void nonMutableBoolean() throws Exception {
+        knockoutTest.nonMutableBoolean();
+    }
+
+    @Test
+    public void nonMutableIntArray() throws Exception {
+        knockoutTest.nonMutableIntArray();
+    }
+
+    @Test
+    public static void triggerEvent(String id, String ev) throws Exception {
+        KnockoutTest.triggerEvent(id, ev);
+    }
+
+    @Test
+    public void displayContentOfArray() throws Exception {
+        knockoutTest.displayContentOfArray();
+    }
+
+    @Test
+    public void displayContentOfAsyncArray() throws Exception {
+        knockoutTest.displayContentOfAsyncArray();
+    }
+
+    @Test
+    public void displayContentOfComputedArray() throws Exception {
+        knockoutTest.displayContentOfComputedArray();
+    }
+
+    @Test
+    public void displayContentOfComputedArrayOnASubpair() throws Exception {
+        knockoutTest.displayContentOfComputedArrayOnASubpair();
+    }
+
+    @Test
+    public void displayContentOfComputedArrayOnComputedASubpair() throws Exception {
+        knockoutTest.displayContentOfComputedArrayOnComputedASubpair();
+    }
+
+    @Test
+    public void checkBoxToBooleanBinding() throws Exception {
+        knockoutTest.checkBoxToBooleanBinding();
+    }
+
+    @Test
+    public void displayContentOfDerivedArray() throws Exception {
+        knockoutTest.displayContentOfDerivedArray();
+    }
+
+    @Test
+    public void displayContentOfArrayOfPeople() throws Exception {
+        knockoutTest.displayContentOfArrayOfPeople();
+    }
+
+    @Test
+    public void accessFirstPersonWithOnFunction() throws Exception {
+        knockoutTest.accessFirstPersonWithOnFunction();
+    }
+
+    @Test
+    public void onPersonFunction() throws Exception {
+        knockoutTest.onPersonFunction();
+    }
+
+    @Test
+    public void stringArrayModificationVisible() throws Exception {
+        knockoutTest.stringArrayModificationVisible();
+    }
+
+    @Test
+    public void intArrayModificationVisible() throws Exception {
+        knockoutTest.intArrayModificationVisible();
+    }
+
+    @Test
+    public void derivedIntArrayModificationVisible() throws Exception {
+        knockoutTest.derivedIntArrayModificationVisible();
+    }
+
+    @Test
+    public void archetypeArrayModificationVisible() throws Exception {
+        knockoutTest.archetypeArrayModificationVisible();
+    }
+
+    @Test
+    public void toJSONInABrowser() throws Throwable {
+        jsonTest.toJSONInABrowser();
+    }
+
+    @Test
+    public void toJSONWithEscapeCharactersInABrowser() throws Throwable {
+        jsonTest.toJSONWithEscapeCharactersInABrowser();
+    }
+
+    @Test
+    public void toJSONWithDoubleSlashInABrowser() throws Throwable {
+        jsonTest.toJSONWithDoubleSlashInABrowser();
+    }
+
+    @Test
+    public void toJSONWithApostrophInABrowser() throws Throwable {
+        jsonTest.toJSONWithApostrophInABrowser();
+    }
+
+    @Test
+    public void loadAndParseJSON() throws InterruptedException {
+        jsonTest.loadAndParseJSON();
+    }
+
+    @Test
+    public void loadAndParsePlainText() throws Exception {
+        jsonTest.loadAndParsePlainText();
+    }
+
+    @Test
+    public void loadAndParsePlainTextOnArray() throws Exception {
+        jsonTest.loadAndParsePlainTextOnArray();
+    }
+
+    @Test
+    public void loadAndParseJSONP() throws InterruptedException, Exception {
+        jsonTest.loadAndParseJSONP();
+    }
+
+    @Test
+    public void putPeopleUsesRightMethod() throws InterruptedException, Exception {
+        jsonTest.putPeopleUsesRightMethod();
+    }
+
+    @Test
+    public void loadAndParseJSONSentToArray() throws InterruptedException {
+        jsonTest.loadAndParseJSONSentToArray();
+    }
+
+    @Test
+    public void loadAndParseJSONArraySingle() throws InterruptedException {
+        jsonTest.loadAndParseJSONArraySingle();
+    }
+
+    @Test
+    public void loadAndParseArrayInPeople() throws InterruptedException {
+        jsonTest.loadAndParseArrayInPeople();
+    }
+
+    @Test
+    public void loadAndParseArrayInPeopleWithHeaders() throws InterruptedException {
+        jsonTest.loadAndParseArrayInPeopleWithHeaders();
+    }
+
+    @Test
+    public void loadAndParseArrayOfIntegers() throws InterruptedException {
+        jsonTest.loadAndParseArrayOfIntegers();
+    }
+
+    @Test
+    public void loadAndParseArrayOfEnums() throws InterruptedException {
+        jsonTest.loadAndParseArrayOfEnums();
+    }
+
+    @Test
+    public void loadAndParseJSONArray() throws InterruptedException {
+        jsonTest.loadAndParseJSONArray();
+    }
+
+    @Test
+    public void loadError() throws InterruptedException {
+        jsonTest.loadError();
+    }
+
+    @Test
+    public void parseNullNumber() throws Exception {
+        jsonTest.parseNullNumber();
+    }
+
+    @Test
+    public void deserializeWrongEnum() throws Exception {
+        jsonTest.deserializeWrongEnum();
+    }
+
+    @Test
+    public void testConvertToPeople() throws Exception {
+        convertTypesTest.testConvertToPeople();
+    }
+
+    @Test
+    public void parseConvertToPeople() throws Exception {
+        convertTypesTest.parseConvertToPeople();
+    }
+
+    @Test
+    public void parseConvertToPeopleWithAddress() throws Exception {
+        convertTypesTest.parseConvertToPeopleWithAddress();
+    }
+
+    @Test
+    public void parseConvertToPeopleWithAddressIntoAnArray() throws Exception {
+        convertTypesTest.parseConvertToPeopleWithAddressIntoAnArray();
+    }
+
+    @Test
+    public void parseNullValue() throws Exception {
+        convertTypesTest.parseNullValue();
+    }
+
+    @Test
+    public void parseNullArrayValue() throws Exception {
+        convertTypesTest.parseNullArrayValue();
+    }
+
+    @Test
+    public void testConvertToPeopleWithoutSex() throws Exception {
+        convertTypesTest.testConvertToPeopleWithoutSex();
+    }
+
+    @Test
+    public void parseConvertToPeopleWithoutSex() throws Exception {
+        convertTypesTest.parseConvertToPeopleWithoutSex();
+    }
+
+    @Test
+    public void parseConvertToPeopleWithAddressOnArray() throws Exception {
+        convertTypesTest.parseConvertToPeopleWithAddressOnArray();
+    }
+
+    @Test
+    public void parseConvertToPeopleWithoutSexOnArray() throws Exception {
+        convertTypesTest.parseConvertToPeopleWithoutSexOnArray();
+    }
+
+    @Test
+    public void parseFirstElementFromAbiggerArray() throws Exception {
+        convertTypesTest.parseFirstElementFromAbiggerArray();
+    }
+
+    @Test
+    public void parseAllElementFromAbiggerArray() throws Exception {
+        convertTypesTest.parseAllElementFromAbiggerArray();
+    }
+
+    @Test
+    public void parseFiveElementsAsAnArray() throws Exception {
+        convertTypesTest.parseFiveElementsAsAnArray();
+    }
+
+    @Test
+    public void parseInnerElementAsAnArray() throws Exception {
+        convertTypesTest.parseInnerElementAsAnArray();
+    }
+
+
+    @Test
+    public void parseOnEmptyArray() throws Exception {
+        convertTypesTest.parseOnEmptyArray();
+    }
+
+}

--- a/html4j/src/test/java/org/teavm/html4j/test/KnockoutTCKTest.java
+++ b/html4j/src/test/java/org/teavm/html4j/test/KnockoutTCKTest.java
@@ -151,11 +151,6 @@ public class KnockoutTCKTest {
     }
 
     @Test
-    public static void triggerEvent(String id, String ev) throws Exception {
-        KnockoutTest.triggerEvent(id, ev);
-    }
-
-    @Test
     public void displayContentOfArray() throws Exception {
         knockoutTest.displayContentOfArray();
     }


### PR DESCRIPTION
I am converting the ko4j tests to JUnit's `@RunWith`. Right now I am getting an error, but the generated `test-js` files seem to be running OK. What shall I do to avoid the error?

```
  KnockoutTCKTest.loadAndParseJSONArray Class java.util.WeakHashMap was not found
    at org.teavm.junit.TeaVMTestRunner.<clinit>(TeaVMTestRunner.java:81)
    at java.lang.Class.forName(TClass.java:149)
    at java.lang.Class.forName(TClass.java:159)
    at org.netbeans.html.json.impl.JSON.initClass(JSON.java:453)
    at org.netbeans.html.json.impl.JSON.findType(JSON.java:387)
    at org.netbeans.html.json.impl.JSON.bindTo(JSON.java:396)
    at net.java.html.json.Models.bind(Models.java:83)
    at net.java.html.json.tests.JSONTest.loadAndParseJSONArray(JSONTest.java:549)
    at org.teavm.html4j.test.KnockoutTCKTest.loadAndParseJSONArray(KnockoutTCKTest.java:305)
    at org.teavm.junit.TestEntryPoint.launchTest
    at org.teavm.junit.TestEntryPoint.lambda$run$0(TestEntryPoint.java:27)
    at $$LAMBDA0$$.launch
    at org.teavm.testing.SimpleTestRunner.run(SimpleTestRunner.java:25)
    at org.teavm.junit.TestEntryPoint.run(TestEntryPoint.java:27)
```

It looks to me that the compilation believes that the `Class.forName` in `JSON.initClass` can load `TeaVMTestRunner`, but that is certainly not something that happens in the actual test...