### PR TITLE
Added methods to expose the scrollY value and body offset

### DIFF
--- a/jso/apis/src/main/java/org/teavm/jso/browser/Window.java
+++ b/jso/apis/src/main/java/org/teavm/jso/browser/Window.java
@@ -67,7 +67,7 @@ public abstract class Window implements JSObject, WindowEventTarget, StorageProv
     public abstract int getOuterHeight();
 
     @JSProperty
-    public abstract int scrollY();
+    public abstract int getScrollY();
 
     @JSProperty
     public abstract String getName();

--- a/jso/apis/src/main/java/org/teavm/jso/browser/Window.java
+++ b/jso/apis/src/main/java/org/teavm/jso/browser/Window.java
@@ -67,6 +67,9 @@ public abstract class Window implements JSObject, WindowEventTarget, StorageProv
     public abstract int getOuterHeight();
 
     @JSProperty
+    public abstract int scrollY();
+
+    @JSProperty
     public abstract String getName();
 
     @JSProperty

--- a/jso/apis/src/main/java/org/teavm/jso/dom/html/HTMLElement.java
+++ b/jso/apis/src/main/java/org/teavm/jso/dom/html/HTMLElement.java
@@ -115,6 +115,9 @@ public interface HTMLElement extends Element, ElementCSSInlineStyle, EventTarget
     int getScrollHeight();
 
     @JSProperty
+    int getOffsetHeight();
+
+    @JSProperty
     @Override
     HTMLDocument getOwnerDocument();
 


### PR DESCRIPTION
As discussed by e-mail. I think this should be the appropriate place to put the methods. But I think I am missing something, since I cannot use them in my TeaVM client project. My IDE allows me to use these methods, but the maven build fails when I try to build my project.

This is the output from my build:

nl/scuro/fridge/client/collections/CollectionsView.java:[68,70] cannot find symbol
  symbol:   method scrollY()
  location: class org.teavm.jso.browser.Window
nl/scuro/fridge/client/collections/CollectionsView.java:[68,125] cannot find symbol
  symbol:   method getOffsetHeight()
  location: interface org.teavm.jso.dom.html.HTMLBodyElement
