### PR TITLE
Fix TSetFromMap#add return value

### DIFF
--- a/classlib/src/main/java/org/teavm/classlib/java/util/TSetFromMap.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/util/TSetFromMap.java
@@ -46,7 +46,7 @@ public class TSetFromMap<E> extends TAbstractSet<E> {
 
     @Override
     public boolean add(E e) {
-        return map.put(e, TBoolean.TRUE) != null;
+        return map.put(e, TBoolean.TRUE) == null;
     }
 
     @Override


### PR DESCRIPTION
Noticed while trying to use `TCollections.newSetFromMap`. The fix makes it fit the `Collections#add` documentation stating: `@return <tt>true</tt> if this collection changed as a result of the call`