### PR TITLE
Fix IllegalStateException in TDeflater

### DIFF
--- a/classlib/src/main/java/org/teavm/classlib/java/util/zip/TDeflater.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/util/zip/TDeflater.java
@@ -57,7 +57,7 @@ public class TDeflater {
         }
         compressLevel = level;
         try {
-            impl = new Deflater(compressLevel, strategy, noHeader);
+            impl = new Deflater(compressLevel, noHeader);
         } catch (GZIPException e) {
             // do nothing
         }


### PR DESCRIPTION
TDeflater passes in strategy as the second parameter in jzlib's Deflater class.

https://github.com/ymnk/jzlib/blob/master/src/main/java/com/jcraft/jzlib/Deflater.java#L78

The second parameter is actually for window bits and a value of 0 causes the compressor initialization to fail. Simply removing this parameter fixes the issue.