### PR TITLE
Fix runtime exception when using forEach with collections

### DIFF
--- a/classlib/src/main/java/org/teavm/classlib/java/lang/TIterable.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/lang/TIterable.java
@@ -22,6 +22,12 @@ import org.teavm.classlib.java.util.TSpliterator;
 public interface TIterable<T> {
     TIterator<T> iterator();
 
+    default void forEach(Consumer<? super T> action) {
+        for (TIterator<T> itr = iterator(); itr.hasNext();) {
+            action.accept(itr.next());
+        }
+    }
+    
     default TSpliterator<T> spliterator() {
         TIterator<T> iterator = iterator();
         return new TSpliterator<T>() {


### PR DESCRIPTION
```
Arrays.asList("hello", "world").forEach(System.out::println);
```
produces a JavaScript exception similar to `Uncaught (in promise) TypeError: $list1.$forEach is not a function` due to forEach not being implemented in TIterable.