### PR TITLE
sanitize unicode in java identifiers

### DIFF
--- a/core/src/main/java/org/teavm/backend/lowlevel/generate/LowLevelNameProvider.java
+++ b/core/src/main/java/org/teavm/backend/lowlevel/generate/LowLevelNameProvider.java
@@ -191,10 +191,14 @@ public abstract class LowLevelNameProvider {
                 case '>':
                 case '<':
                 case '$':
+                case '_':
                     sb.append('_');
                     break;
                 default:
-                    sb.append(c);
+                    if ('a' <= c && c <= 'z' || 'A' <= c && c <= 'Z' || '0' <= c && c <= '9' && i != 0)
+                        sb.append(c);
+                    else
+                        sb.append(String.format("U%04X", (int)c));
                     break;
             }
         }

--- a/core/src/main/java/org/teavm/backend/lowlevel/generate/LowLevelNameProvider.java
+++ b/core/src/main/java/org/teavm/backend/lowlevel/generate/LowLevelNameProvider.java
@@ -195,10 +195,11 @@ public abstract class LowLevelNameProvider {
                     sb.append('_');
                     break;
                 default:
-                    if ('a' <= c && c <= 'z' || 'A' <= c && c <= 'Z' || '0' <= c && c <= '9' && i != 0)
+                    if ('a' <= c && c <= 'z' || 'A' <= c && c <= 'Z' || '0' <= c && c <= '9' && i != 0) {
                         sb.append(c);
-                    else
-                        sb.append(String.format("U%04X", (int)c));
+                    } else {
+                        sb.append(String.format("U%04X", (int) c));
+                    }
                     break;
             }
         }


### PR DESCRIPTION
greek letters and math symbols (`λ`, etc) are ok as Java identifiers C compilers do not accept them.