### PR TITLE
Mark certain features of Thread and Date unsupported in WASM

### DIFF
--- a/classlib/src/main/java/org/teavm/classlib/java/util/TDate.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/util/TDate.java
@@ -22,7 +22,9 @@ import org.teavm.classlib.java.lang.TComparable;
 import org.teavm.classlib.java.lang.TSystem;
 import org.teavm.interop.Import;
 import org.teavm.interop.NoSideEffects;
+import org.teavm.interop.Platforms;
 import org.teavm.interop.Unmanaged;
+import org.teavm.interop.UnsupportedOn;
 import org.teavm.jso.core.JSDate;
 
 public class TDate implements TComparable<TDate> {
@@ -36,6 +38,7 @@ public class TDate implements TComparable<TDate> {
 
     @Import(name = "teavm_date_init")
     @RuntimeInclude("date.h")
+    @UnsupportedOn(Platforms.WEBASSEMBLY)
     @NoSideEffects
     @Unmanaged
     private static native void initLowLevel();
@@ -72,6 +75,7 @@ public class TDate implements TComparable<TDate> {
     @NoSideEffects
     @Unmanaged
     @RuntimeInclude("date.h")
+    @UnsupportedOn(Platforms.WEBASSEMBLY)
     private static native long initDateLowLevel(int year, int month, int date, int hrs, int min, int sec);
 
     public TDate(String s) {
@@ -96,6 +100,7 @@ public class TDate implements TComparable<TDate> {
     @NoSideEffects
     @Unmanaged
     @RuntimeInclude("date.h")
+    @UnsupportedOn(Platforms.WEBASSEMBLY)
     private static native long initUtcDateLowLevel(int year, int month, int date, int hrs, int min, int sec);
 
     @Deprecated
@@ -115,6 +120,7 @@ public class TDate implements TComparable<TDate> {
     @NoSideEffects
     @Unmanaged
     @RuntimeInclude("date.h")
+    @UnsupportedOn(Platforms.WEBASSEMBLY)
     private static native long parseLowLevel(String s);
 
     @Deprecated
@@ -129,6 +135,7 @@ public class TDate implements TComparable<TDate> {
     @NoSideEffects
     @Unmanaged
     @RuntimeInclude("date.h")
+    @UnsupportedOn(Platforms.WEBASSEMBLY)
     private static native int getYearLowLevel(long date);
 
     @Deprecated
@@ -146,6 +153,7 @@ public class TDate implements TComparable<TDate> {
     @NoSideEffects
     @Unmanaged
     @RuntimeInclude("date.h")
+    @UnsupportedOn(Platforms.WEBASSEMBLY)
     private static native long setYearLowLevel(long date, int year);
 
     @Deprecated
@@ -160,6 +168,7 @@ public class TDate implements TComparable<TDate> {
     @NoSideEffects
     @Unmanaged
     @RuntimeInclude("date.h")
+    @UnsupportedOn(Platforms.WEBASSEMBLY)
     private static native int getMonthLowLevel(long date);
 
     @Deprecated
@@ -177,6 +186,7 @@ public class TDate implements TComparable<TDate> {
     @NoSideEffects
     @Unmanaged
     @RuntimeInclude("date.h")
+    @UnsupportedOn(Platforms.WEBASSEMBLY)
     private static native long setMonthLowLevel(long date, int month);
 
     @Deprecated
@@ -191,6 +201,7 @@ public class TDate implements TComparable<TDate> {
     @NoSideEffects
     @Unmanaged
     @RuntimeInclude("date.h")
+    @UnsupportedOn(Platforms.WEBASSEMBLY)
     private static native int getDateLowLevel(long date);
 
     @Deprecated
@@ -208,6 +219,7 @@ public class TDate implements TComparable<TDate> {
     @NoSideEffects
     @Unmanaged
     @RuntimeInclude("date.h")
+    @UnsupportedOn(Platforms.WEBASSEMBLY)
     private static native int setDateLowLevel(long target, int date);
 
     @Deprecated
@@ -219,6 +231,7 @@ public class TDate implements TComparable<TDate> {
     }
 
     @Import(name = "teavm_date_getDay")
+    @UnsupportedOn(Platforms.WEBASSEMBLY)
     @Unmanaged
     public static native int getDayLowLevel(long date);
 
@@ -234,6 +247,7 @@ public class TDate implements TComparable<TDate> {
     @NoSideEffects
     @Unmanaged
     @RuntimeInclude("date.h")
+    @UnsupportedOn(Platforms.WEBASSEMBLY)
     private static native int getHoursLowLevel(long date);
 
     @Deprecated
@@ -251,6 +265,7 @@ public class TDate implements TComparable<TDate> {
     @NoSideEffects
     @Unmanaged
     @RuntimeInclude("date.h")
+    @UnsupportedOn(Platforms.WEBASSEMBLY)
     private static native int setHoursLowLevel(long date, int hours);
 
     @Deprecated
@@ -265,6 +280,7 @@ public class TDate implements TComparable<TDate> {
     @NoSideEffects
     @Unmanaged
     @RuntimeInclude("date.h")
+    @UnsupportedOn(Platforms.WEBASSEMBLY)
     private static native int getMinutesLowLevel(long date);
 
     @Deprecated
@@ -282,6 +298,7 @@ public class TDate implements TComparable<TDate> {
     @NoSideEffects
     @Unmanaged
     @RuntimeInclude("date.h")
+    @UnsupportedOn(Platforms.WEBASSEMBLY)
     private static native int setMinutesLowLevel(long date, int minutes);
 
     @Deprecated
@@ -296,6 +313,7 @@ public class TDate implements TComparable<TDate> {
     @NoSideEffects
     @Unmanaged
     @RuntimeInclude("date.h")
+    @UnsupportedOn(Platforms.WEBASSEMBLY)
     private static native int getSecondsLowLevel(long date);
 
     @Deprecated
@@ -313,6 +331,7 @@ public class TDate implements TComparable<TDate> {
     @NoSideEffects
     @Unmanaged
     @RuntimeInclude("date.h")
+    @UnsupportedOn(Platforms.WEBASSEMBLY)
     private static native int setSecondsLowLevel(long date, int seconds);
 
     public long getTime() {
@@ -362,6 +381,7 @@ public class TDate implements TComparable<TDate> {
     @Import(name = "teavm_date_format")
     @NoSideEffects
     @RuntimeInclude("date.h")
+    @UnsupportedOn(Platforms.WEBASSEMBLY)
     private static native String toStringLowLevel(long date);
 
     @Deprecated

--- a/core/src/main/java/org/teavm/runtime/EventQueue.java
+++ b/core/src/main/java/org/teavm/runtime/EventQueue.java
@@ -18,7 +18,9 @@ package org.teavm.runtime;
 import java.util.Arrays;
 import org.teavm.backend.c.intrinsic.RuntimeInclude;
 import org.teavm.interop.Import;
+import org.teavm.interop.Platforms;
 import org.teavm.interop.StaticInit;
+import org.teavm.interop.UnsupportedOn;
 
 @StaticInit
 public final class EventQueue {
@@ -127,10 +129,12 @@ public final class EventQueue {
 
     @Import(name = "teavm_waitFor")
     @RuntimeInclude("fiber.h")
+    @UnsupportedOn(Platforms.WEBASSEMBLY)
     private static native void waitFor(long time);
 
     @Import(name = "teavm_interrupt")
     @RuntimeInclude("fiber.h")
+    @UnsupportedOn(Platforms.WEBASSEMBLY)
     private static native void interrupt();
 
     private static void ensureCapacity(int capacity) {


### PR DESCRIPTION
This gives much clearer feedback, at build time rather than WASM load time, when attempting to use TeaVM with code that uses these operations. (cf #427)

There are surely more of these scattered around the code.  These are just the ones I encountered when trying to get a bit of my company's code to run as a proof of concept.