### PR TITLE
Fill in some gaps in the class library

### DIFF
--- a/classlib/src/main/java/org/teavm/classlib/java/awt/TColor.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/awt/TColor.java
@@ -1,0 +1,70 @@
+/*
+ *  Copyright 2015 Alexey Andreev.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.teavm.classlib.java.awt;
+
+public class TColor {
+
+    private int r;
+    private int g;
+    private int b;
+    private int a;
+
+    public static final TColor BLACK = new TColor(0, 0, 0);
+    public static final TColor WHITE = new TColor(255, 255, 255);
+
+    public TColor(int r, int g, int b) {
+        this(r, g, b, 255);
+    }
+
+    public TColor(int r, int g, int b, int a) {
+        this.r = r;
+        this.g = g;
+        this.b = b;
+        this.a = a;
+    }
+
+    public TColor(float r, float g, float b) {
+        this(r, g, b, 1f);
+    }
+
+    public TColor(float r, float g, float b, float a) {
+        this(Math.round(r * 255f), Math.round(g * 255f), 
+            Math.round(b * 255f), Math.round(a * 255f));
+    }
+
+    public TColor(int value) {
+        this.r = (value >> 16) & 0xFF;
+        this.g = (value >> 8) & 0xFF;
+        this.b = (value) & 0xFF;
+        this.a = (value >> 24) & 0xFF;
+    }
+
+    public int getRed() {
+        return r;
+    }
+
+    public int getGreen() {
+        return g;
+    }
+
+    public int getBlue() {
+        return b;
+    }
+
+    public int getAlpha() {
+        return a;
+    }
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/awt/TColor.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/awt/TColor.java
@@ -48,7 +48,7 @@ public class TColor {
     public TColor(int value) {
         this.r = (value >> 16) & 0xFF;
         this.g = (value >> 8) & 0xFF;
-        this.b = (value) & 0xFF;
+        this.b = value & 0xFF;
         this.a = (value >> 24) & 0xFF;
     }
 

--- a/classlib/src/main/java/org/teavm/classlib/java/awt/TDimension.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/awt/TDimension.java
@@ -1,0 +1,27 @@
+/*
+ *  Copyright 2015 Alexey Andreev.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.teavm.classlib.java.awt;
+
+public class TDimension {
+
+    public int width;
+    public int height;
+
+    public TDimension(int width, int height) {
+        this.width = width;
+        this.height = height;
+    }
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/awt/TPoint.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/awt/TPoint.java
@@ -1,0 +1,27 @@
+/*
+ *  Copyright 2015 Alexey Andreev.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.teavm.classlib.java.awt;
+
+public class TPoint {
+
+    public int x;
+    public int y;
+
+    public TPoint(int x, int y) {
+        this.x = x;
+        this.y = y;
+    }
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/util/TSpliterator.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/util/TSpliterator.java
@@ -57,7 +57,7 @@ public interface TSpliterator<T> {
         throw new IllegalStateException();
     }
 
-    interface OfPrimitive<T, C, S extends OfPrimitive<T, C, S>> {
+    public interface OfPrimitive<T, C, S extends OfPrimitive<T, C, S>> {
         S trySplit();
 
         boolean tryAdvance(C action);
@@ -69,7 +69,7 @@ public interface TSpliterator<T> {
         }
     }
 
-    interface OfInt extends OfPrimitive<Integer, IntConsumer, OfInt> {
+    public interface OfInt extends OfPrimitive<Integer, IntConsumer, OfInt> {
         default boolean tryAdvance(Consumer<? super Integer> action) {
             return tryAdvance((IntConsumer) action::accept);
         }
@@ -81,7 +81,7 @@ public interface TSpliterator<T> {
         }
     }
 
-    interface OfLong extends OfPrimitive<Long, LongConsumer, OfLong> {
+    public interface OfLong extends OfPrimitive<Long, LongConsumer, OfLong> {
         default boolean tryAdvance(Consumer<? super Long> action) {
             return tryAdvance((LongConsumer) action::accept);
         }
@@ -93,7 +93,7 @@ public interface TSpliterator<T> {
         }
     }
 
-    interface OfDouble extends OfPrimitive<Double, DoubleConsumer, OfDouble> {
+    public interface OfDouble extends OfPrimitive<Double, DoubleConsumer, OfDouble> {
         default boolean tryAdvance(Consumer<? super Double> action) {
             return tryAdvance((DoubleConsumer) action::accept);
         }

--- a/classlib/src/main/java/org/teavm/classlib/java/util/TUUID.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/util/TUUID.java
@@ -1,0 +1,58 @@
+/*
+ *  Copyright 2015 Alexey Andreev.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.teavm.classlib.java.util;
+
+public class TUUID {
+
+    private String value;
+
+    private TUUID(String value) {
+        this.value = value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o instanceof TUUID) {
+            TUUID other = (TUUID) o;
+            return value.equals(other.value);
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+
+    public static TUUID randomUUID() {
+        String value = s4() + s4() + "-" + s4() + "-" + s4() + "-" + s4() + "-" + s4() + s4() + s4();
+        return new TUUID(value);
+    }
+
+    private static String s4() {
+        return Integer.toString((int) Math.floor((1 + Math.random()) * 65536), 16).substring(1);
+    }
+
+    public static TUUID fromString(String value) {
+        return new TUUID(value);
+    }
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/util/logging/TFormatter.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/util/logging/TFormatter.java
@@ -1,0 +1,23 @@
+/*
+ *  Copyright 2015 Alexey Andreev.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.teavm.classlib.java.util.logging;
+
+import java.util.logging.LogRecord;
+
+public abstract class TFormatter {
+
+    public abstract String format(LogRecord record);
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/util/logging/TLogManager.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/util/logging/TLogManager.java
@@ -1,0 +1,30 @@
+/*
+ *  Copyright 2015 Alexey Andreev.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.teavm.classlib.java.util.logging;
+
+import java.io.InputStream;
+
+public class TLogManager {
+
+    public void readConfiguration(InputStream stream) {
+        // Ignore the configuration, keep using the default logging
+        // configuration instead.
+    }
+
+    public static TLogManager getLogManager() {
+        return new TLogManager();
+    }
+}


### PR DESCRIPTION
- the inner classes are marked as public in the JDK, but not in TeaVM's version
- added Color/Dimension/Point, these are defined in AWT, but also accessed from elsewhere in the JDK
- added UUID emulation
- added more logging classes so that applications don't immediately crash when trying to initialize logging