### PR TITLE
Remove unnecessary dependencies

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -51,11 +51,12 @@
     <dependency>
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm-commons</artifactId>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
-      <groupId>org.ow2.asm</groupId>
-      <artifactId>asm-util</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.ow2.asm</groupId>
+          <artifactId>asm-analysis</artifactId>
+        </exclusion>
+      </exclusions>
       <optional>true</optional>
     </dependency>
     <dependency>


### PR DESCRIPTION
Hello, I noticed that dependencies  `asm-util` and `asm-commons` were added (https://github.com/konsoletyper/teavm/commit/d7b57ae9380ddd03b9f96f1ce57f9bf15e6f89b5) to support Java 10 bytecode. However,  the first one is not used by teavm at all, thus dependency `asm-analysis` can be excluded. Removing these unused dependencies makes the core of teavm slimmer and the dependency tree easier to maintain.