### PR TITLE
Support for System.getenv()

### DIFF
--- a/classlib/src/main/java/org/teavm/classlib/java/lang/TSystem.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/lang/TSystem.java
@@ -284,4 +284,8 @@ public final class TSystem extends TObject {
     public static String lineSeparator() {
         return "\n";
     }
+    
+    public static String getenv(String name) {
+        return null;
+    }
 }


### PR DESCRIPTION
This will always return that the environment variables does not exist, it is purely intended for compatibility with applications that check for optional environment variables (in those cases the TeaVM transpiler currently fails because the method does not exist).