### PR TITLE
Add support for URL encode/decode methods added in Java 10

### DIFF
--- a/classlib/src/main/java/org/teavm/classlib/java/net/TURLDecoder.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/net/TURLDecoder.java
@@ -33,6 +33,15 @@ public final class TURLDecoder {
     public static String decode(String s) {
         return decode(s, StandardCharsets.UTF_8);
     }
+    
+    public static String decode(String s, Charset enc) {
+        try {
+            return decode(s, enc.displayName());
+        } catch (UnsupportedEncodingException e) {
+            // Cannot happen as the provided character encoding is known to be available.
+            throw new AssertionError(e);
+        }
+    }
 
     public static String decode(String s, String enc) throws UnsupportedEncodingException {
         Objects.requireNonNull(enc);

--- a/classlib/src/main/java/org/teavm/classlib/java/net/TURLDecoder.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/net/TURLDecoder.java
@@ -33,15 +33,6 @@ public final class TURLDecoder {
     public static String decode(String s) {
         return decode(s, StandardCharsets.UTF_8);
     }
-    
-    public static String decode(String s, Charset enc) {
-        try {
-            return decode(s, enc.displayName());
-        } catch (UnsupportedEncodingException e) {
-            // Cannot happen as the provided character encoding is known to be available.
-            throw new AssertionError(e);
-        }
-    }
 
     public static String decode(String s, String enc) throws UnsupportedEncodingException {
         Objects.requireNonNull(enc);

--- a/classlib/src/main/java/org/teavm/classlib/java/net/TURLEncoder.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/net/TURLEncoder.java
@@ -53,24 +53,8 @@ public final class TURLEncoder {
     }
     
     public static String encode(String s, Charset enc) {
-        try {
-            return encode(s, enc.displayName());
-        } catch (UnsupportedEncodingException e) {
-            // Cannot happen as the provided character encoding is known to be available.
-            throw new AssertionError(e);
-        }
-    }
-
-    public static String encode(String s, String enc) throws UnsupportedEncodingException {
         Objects.requireNonNull(s);
         Objects.requireNonNull(enc);
-
-        // check for UnsupportedEncodingException
-        try {
-            Charset.forName(enc);
-        } catch (UnsupportedCharsetException e) {
-            throw new UnsupportedEncodingException(enc);
-        }
 
         // Guess a bit bigger for encoded form
         StringBuffer buf = new StringBuffer(s.length() + 16);
@@ -100,7 +84,19 @@ public final class TURLEncoder {
         return buf.toString();
     }
 
-    private static void convert(String s, StringBuffer buf, String enc) throws UnsupportedEncodingException {
+    public static String encode(String s, String enc) throws UnsupportedEncodingException {
+        Objects.requireNonNull(s);
+        Objects.requireNonNull(enc);
+
+        // check for UnsupportedEncodingException
+        try {
+            return encode(s, Charset.forName(enc));
+        } catch (UnsupportedCharsetException e) {
+            throw new UnsupportedEncodingException(enc);
+        }
+    }
+
+    private static void convert(String s, StringBuffer buf, Charset enc) {
         byte[] bytes = s.getBytes(enc);
         for (int j = 0; j < bytes.length; j++) {
             buf.append('%');

--- a/classlib/src/main/java/org/teavm/classlib/java/net/TURLEncoder.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/net/TURLEncoder.java
@@ -51,6 +51,15 @@ public final class TURLEncoder {
         }
         return buf.toString();
     }
+    
+    public static String encode(String s, Charset enc) {
+        try {
+            return encode(s, enc.displayName());
+        } catch (UnsupportedEncodingException e) {
+            // Cannot happen as the provided character encoding is known to be available.
+            throw new AssertionError(e);
+        }
+    }
 
     public static String encode(String s, String enc) throws UnsupportedEncodingException {
         Objects.requireNonNull(s);

--- a/classlib/src/main/java/org/teavm/classlib/java/util/TCollection.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/util/TCollection.java
@@ -16,6 +16,7 @@
 package org.teavm.classlib.java.util;
 
 import java.util.Spliterator;
+import java.util.function.Predicate;
 import org.teavm.classlib.java.lang.TIterable;
 import org.teavm.classlib.java.util.stream.TStream;
 import org.teavm.classlib.java.util.stream.impl.TSpliteratorOverCollection;
@@ -54,5 +55,22 @@ public interface TCollection<E> extends TIterable<E> {
     @SuppressWarnings("unchecked")
     default TStream<E> stream() {
         return new TStreamOverSpliterator<>((Spliterator<E>) spliterator());
+    }
+
+    default boolean removeIf(Predicate<? super E> filter) {
+        TIterator<E> iterator = iterator();
+        boolean removed = false;
+
+        while (iterator.hasNext()) {
+            E element = iterator.next();
+            boolean match = filter.test(element);
+
+            if (match) {
+                iterator.remove();
+                removed = true;
+            }
+        }
+
+        return removed;
     }
 }

--- a/tests/src/test/java/org/teavm/classlib/java/util/ArrayListTest.java
+++ b/tests/src/test/java/org/teavm/classlib/java/util/ArrayListTest.java
@@ -159,4 +159,19 @@ public class ArrayListTest {
             // OK
         }
     }
+
+    @Test
+    public void removeIf() {
+        List<String> list = new ArrayList<>();
+        list.add("A1");
+        list.add("A2");
+        list.add("B1");
+        list.add("B2");
+
+        list.removeIf(e -> e.endsWith("2"));
+
+        assertEquals(2, list.size());
+        assertEquals("A1", list.get(0));
+        assertEquals("B1", list.get(1));
+    }
 }


### PR DESCRIPTION
Java 10 added versions of URL encode/decode that take the Charset instance as an argument rather than the charset name. This means the user of these methods no longer has to handle the UnsupportedEncodingException (since the presence of a Charset instance indicates the character encoding is known to exist).

This method was already present in the URLDecoder, but not yet in the URLEncoder.