### PR TITLE
added placeholder property

### DIFF
--- a/jso/apis/src/main/java/org/teavm/jso/dom/html/HTMLInputElement.java
+++ b/jso/apis/src/main/java/org/teavm/jso/dom/html/HTMLInputElement.java
@@ -67,4 +67,10 @@ public interface HTMLInputElement extends HTMLElement {
     void setValue(String value);
 
     void select();
+
+    @JSProperty
+    String getPlaceholder();
+
+    @JSProperty
+    void setPlaceholder(String value);
 }


### PR DESCRIPTION
The property `placeholder` was already present in `HTMLTextAreaElement` but missing in `HTMLInputElement`.
Therefore I added this property:
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-placeholder