### PR TITLE
#457: also add check/reportValidity

### DIFF
--- a/jso/apis/src/main/java/org/teavm/jso/dom/html/HTMLInputElement.java
+++ b/jso/apis/src/main/java/org/teavm/jso/dom/html/HTMLInputElement.java
@@ -67,6 +67,10 @@ public interface HTMLInputElement extends HTMLElement {
     void setValue(String value);
     
     void setCustomValidity(String validationFailure);
+    
+    boolean checkValidity();
+    
+    boolean reportValidity();
 
     void select();
 

--- a/jso/apis/src/main/java/org/teavm/jso/dom/html/HTMLSelectElement.java
+++ b/jso/apis/src/main/java/org/teavm/jso/dom/html/HTMLSelectElement.java
@@ -58,4 +58,6 @@ public interface HTMLSelectElement extends HTMLElement {
     void setValue(String value);
 
     void setCustomValidity(String validationFailure);
+    
+    boolean reportValidity();
 }

--- a/jso/apis/src/main/java/org/teavm/jso/dom/html/HTMLTextAreaElement.java
+++ b/jso/apis/src/main/java/org/teavm/jso/dom/html/HTMLTextAreaElement.java
@@ -112,6 +112,10 @@ public interface HTMLTextAreaElement extends HTMLElement {
     int getTextLength();
 
     void setCustomValidity(String validationFailure);
+    
+    boolean checkValidity();
+    
+    boolean reportValidity();
 
     void select();
 


### PR DESCRIPTION
To make #457 / #458 complete, I also added checkValidity() and reportValidity() method:
* https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement#Methods
* https://developer.mozilla.org/en-US/docs/Web/API/HTMLTextAreaElement#Methods
* For HTMLSelectElement I only added `reportValidity()` as the addition of `checkValidity()` ist still in draft mode: https://developer.mozilla.org/en-US/docs/Web/API/HTMLSelectElement#Specifications (For the record: The web is a disnosaur build by amateurs)

Here is a demo to see the value of `reportValidity()`: https://googlechrome.github.io/samples/report-validity/