### PR TITLE
#451: added java.time support

### DIFF
--- a/classlib/src/main/java/org/teavm/classlib/java/time/TClock.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/time/TClock.java
@@ -1,0 +1,360 @@
+package org.teavm.classlib.java.time;
+
+import static org.teavm.classlib.java.time.TLocalTime.NANOS_PER_MILLI;
+import static org.teavm.classlib.java.time.TLocalTime.NANOS_PER_MINUTE;
+import static org.teavm.classlib.java.time.TLocalTime.NANOS_PER_SECOND;
+
+import org.teavm.classlib.java.io.TSerializable;
+import org.teavm.classlib.java.lang.TIllegalArgumentException;
+import org.teavm.classlib.java.lang.TSystem;
+import org.teavm.classlib.java.util.TObjects;
+
+public abstract class TClock {
+
+  public static TClock systemUTC() {
+
+    return TSystemClock.UTC;
+  }
+
+  public static TClock systemDefaultZone() {
+
+    return new TSystemClock(TZoneId.systemDefault());
+  }
+
+  public static TClock system(TZoneId zone) {
+
+    TObjects.requireNonNull(zone, "zone");
+    if (zone == TZoneOffset.UTC) {
+      return TSystemClock.UTC;
+    }
+    return new TSystemClock(zone);
+  }
+
+  public static TClock tickMillis(TZoneId zone) {
+
+    return new TTickClock(system(zone), NANOS_PER_MILLI);
+  }
+
+  public static TClock tickSeconds(TZoneId zone) {
+
+    return new TTickClock(system(zone), NANOS_PER_SECOND);
+  }
+
+  public static TClock tickMinutes(TZoneId zone) {
+
+    return new TTickClock(system(zone), NANOS_PER_MINUTE);
+  }
+
+  public static TClock tick(TClock baseClock, TDuration tickDuration) {
+
+    TObjects.requireNonNull(baseClock, "baseClock");
+    TObjects.requireNonNull(tickDuration, "tickDuration");
+    if (tickDuration.isNegative()) {
+      throw new TIllegalArgumentException("Tick duration must not be negative");
+    }
+    long tickNanos = tickDuration.toNanos();
+    if (tickNanos % 1000_000 == 0) {
+    } else if (1000_000_000 % tickNanos == 0) {
+    } else {
+      throw new TIllegalArgumentException("Invalid tick duration");
+    }
+    if (tickNanos <= 1) {
+      return baseClock;
+    }
+    return new TTickClock(baseClock, tickNanos);
+  }
+
+  public static TClock fixed(TInstant fixedInstant, TZoneId zone) {
+
+    TObjects.requireNonNull(fixedInstant, "fixedInstant");
+    TObjects.requireNonNull(zone, "zone");
+    return new TFixedClock(fixedInstant, zone);
+  }
+
+  public static TClock offset(TClock baseClock, TDuration offsetDuration) {
+
+    TObjects.requireNonNull(baseClock, "baseClock");
+    TObjects.requireNonNull(offsetDuration, "offsetDuration");
+    if (offsetDuration.equals(TDuration.ZERO)) {
+      return baseClock;
+    }
+    return new TOffsetClock(baseClock, offsetDuration);
+  }
+
+  protected TClock() {
+
+  }
+
+  public abstract TZoneId getZone();
+
+  public abstract TClock withZone(TZoneId zone);
+
+  public long millis() {
+
+    return instant().toEpochMilli();
+  }
+
+  public abstract TInstant instant();
+
+  static final class TSystemClock extends TClock implements TSerializable {
+
+    static final TSystemClock UTC = new TSystemClock(TZoneOffset.UTC);
+
+    private final TZoneId zone;
+
+    TSystemClock(TZoneId zone) {
+
+      this.zone = zone;
+    }
+
+    @Override
+    public TZoneId getZone() {
+
+      return this.zone;
+    }
+
+    @Override
+    public TClock withZone(TZoneId zone) {
+
+      if (zone.equals(this.zone)) {
+        return this;
+      }
+      return new TSystemClock(zone);
+    }
+
+    @Override
+    public long millis() {
+
+      return TSystem.currentTimeMillis();
+    }
+
+    @Override
+    public TInstant instant() {
+
+      long localOffset = TSystem.currentTimeMillis();
+      // long TSystem.nanoTime() % 1000000000;
+      // long adjustment = TSystem.nanoTime() & 0x1FFFFFF;
+      // who needs nano precision in the browser after all?
+      long adjustment = 0;
+
+      return TInstant.ofEpochSecond(localOffset, adjustment);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+
+      if (obj instanceof TSystemClock) {
+        return this.zone.equals(((TSystemClock) obj).zone);
+      }
+      return false;
+    }
+
+    @Override
+    public int hashCode() {
+
+      return this.zone.hashCode() + 1;
+    }
+
+    @Override
+    public String toString() {
+
+      return "SystemClock[" + this.zone + "]";
+    }
+
+  }
+
+  static final class TFixedClock extends TClock implements TSerializable {
+
+    private final TInstant instant;
+
+    private final TZoneId zone;
+
+    TFixedClock(TInstant fixedInstant, TZoneId zone) {
+
+      this.instant = fixedInstant;
+      this.zone = zone;
+    }
+
+    @Override
+    public TZoneId getZone() {
+
+      return this.zone;
+    }
+
+    @Override
+    public TClock withZone(TZoneId zone) {
+
+      if (zone.equals(this.zone)) {
+        return this;
+      }
+      return new TFixedClock(this.instant, zone);
+    }
+
+    @Override
+    public long millis() {
+
+      return this.instant.toEpochMilli();
+    }
+
+    @Override
+    public TInstant instant() {
+
+      return this.instant;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+
+      if (obj instanceof TFixedClock) {
+        TFixedClock other = (TFixedClock) obj;
+        return this.instant.equals(other.instant) && this.zone.equals(other.zone);
+      }
+      return false;
+    }
+
+    @Override
+    public int hashCode() {
+
+      return this.instant.hashCode() ^ this.zone.hashCode();
+    }
+
+    @Override
+    public String toString() {
+
+      return "FixedClock[" + this.instant + "," + this.zone + "]";
+    }
+  }
+
+  static final class TOffsetClock extends TClock implements TSerializable {
+
+    private final TClock baseClock;
+
+    private final TDuration offset;
+
+    TOffsetClock(TClock baseClock, TDuration offset) {
+
+      this.baseClock = baseClock;
+      this.offset = offset;
+    }
+
+    @Override
+    public TZoneId getZone() {
+
+      return this.baseClock.getZone();
+    }
+
+    @Override
+    public TClock withZone(TZoneId zone) {
+
+      if (zone.equals(this.baseClock.getZone())) {
+        return this;
+      }
+      return new TOffsetClock(this.baseClock.withZone(zone), this.offset);
+    }
+
+    @Override
+    public long millis() {
+
+      return Math.addExact(this.baseClock.millis(), this.offset.toMillis());
+    }
+
+    @Override
+    public TInstant instant() {
+
+      return this.baseClock.instant().plus(this.offset);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+
+      if (obj instanceof TOffsetClock) {
+        TOffsetClock other = (TOffsetClock) obj;
+        return this.baseClock.equals(other.baseClock) && this.offset.equals(other.offset);
+      }
+      return false;
+    }
+
+    @Override
+    public int hashCode() {
+
+      return this.baseClock.hashCode() ^ this.offset.hashCode();
+    }
+
+    @Override
+    public String toString() {
+
+      return "OffsetClock[" + this.baseClock + "," + this.offset + "]";
+    }
+  }
+
+  static final class TTickClock extends TClock implements TSerializable {
+
+    private final TClock baseClock;
+
+    private final long tickNanos;
+
+    TTickClock(TClock baseClock, long tickNanos) {
+
+      this.baseClock = baseClock;
+      this.tickNanos = tickNanos;
+    }
+
+    @Override
+    public TZoneId getZone() {
+
+      return this.baseClock.getZone();
+    }
+
+    @Override
+    public TClock withZone(TZoneId zone) {
+
+      if (zone.equals(this.baseClock.getZone())) {
+        return this;
+      }
+      return new TTickClock(this.baseClock.withZone(zone), this.tickNanos);
+    }
+
+    @Override
+    public long millis() {
+
+      long millis = this.baseClock.millis();
+      return millis - Math.floorMod(millis, this.tickNanos / 1000_000L);
+    }
+
+    @Override
+    public TInstant instant() {
+
+      if ((this.tickNanos % 1000_000) == 0) {
+        long millis = this.baseClock.millis();
+        return TInstant.ofEpochMilli(millis - Math.floorMod(millis, this.tickNanos / 1000_000L));
+      }
+      TInstant instant = this.baseClock.instant();
+      long nanos = instant.getNano();
+      long adjust = Math.floorMod(nanos, this.tickNanos);
+      return instant.minusNanos(adjust);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+
+      if (obj instanceof TTickClock) {
+        TTickClock other = (TTickClock) obj;
+        return this.baseClock.equals(other.baseClock) && this.tickNanos == other.tickNanos;
+      }
+      return false;
+    }
+
+    @Override
+    public int hashCode() {
+
+      return this.baseClock.hashCode() ^ ((int) (this.tickNanos ^ (this.tickNanos >>> 32)));
+    }
+
+    @Override
+    public String toString() {
+
+      return "TickClock[" + this.baseClock + "," + TDuration.ofNanos(this.tickNanos) + "]";
+    }
+  }
+
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/time/TDateTimeException.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/time/TDateTimeException.java
@@ -1,0 +1,14 @@
+package org.teavm.classlib.java.time;
+
+public class TDateTimeException extends RuntimeException {
+
+  public TDateTimeException(String message) {
+
+    super(message);
+  }
+
+  public TDateTimeException(String message, Throwable cause) {
+
+    super(message, cause);
+  }
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/time/TDayOfWeek.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/time/TDayOfWeek.java
@@ -1,0 +1,118 @@
+package org.teavm.classlib.java.time;
+
+import static org.teavm.classlib.java.time.temporal.TChronoField.DAY_OF_WEEK;
+import static org.teavm.classlib.java.time.temporal.TChronoUnit.DAYS;
+
+import org.teavm.classlib.java.time.temporal.TChronoField;
+import org.teavm.classlib.java.time.temporal.TTemporal;
+import org.teavm.classlib.java.time.temporal.TTemporalAccessor;
+import org.teavm.classlib.java.time.temporal.TTemporalAdjuster;
+import org.teavm.classlib.java.time.temporal.TTemporalField;
+import org.teavm.classlib.java.time.temporal.TTemporalQueries;
+import org.teavm.classlib.java.time.temporal.TTemporalQuery;
+import org.teavm.classlib.java.time.temporal.TUnsupportedTemporalTypeException;
+import org.teavm.classlib.java.time.temporal.TValueRange;
+
+public enum TDayOfWeek implements TTemporalAccessor, TTemporalAdjuster {
+  MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY;
+
+  private static final TDayOfWeek[] ENUMS = TDayOfWeek.values();
+
+  public int getValue() {
+
+    return ordinal() + 1;
+  }
+
+  // public String getDisplayName(TTextStyle style, TLocale locale) {
+  //
+  // return new TDateTimeFormatterBuilder().appendText(DAY_OF_WEEK, style).toFormatter(locale).format(this);
+  // }
+
+  @Override
+  public boolean isSupported(TTemporalField field) {
+
+    if (field instanceof TChronoField) {
+      return field == DAY_OF_WEEK;
+    }
+    return field != null && field.isSupportedBy(this);
+  }
+
+  @Override
+  public TValueRange range(TTemporalField field) {
+
+    if (field == DAY_OF_WEEK) {
+      return field.range();
+    }
+    return TTemporalAccessor.super.range(field);
+  }
+
+  @Override
+  public int get(TTemporalField field) {
+
+    if (field == DAY_OF_WEEK) {
+      return getValue();
+    }
+    return TTemporalAccessor.super.get(field);
+  }
+
+  @Override
+  public long getLong(TTemporalField field) {
+
+    if (field == DAY_OF_WEEK) {
+      return getValue();
+    } else if (field instanceof TChronoField) {
+      throw new TUnsupportedTemporalTypeException("Unsupported field: " + field);
+    }
+    return field.getFrom(this);
+  }
+
+  public TDayOfWeek plus(long days) {
+
+    int amount = (int) (days % 7);
+    return ENUMS[(ordinal() + (amount + 7)) % 7];
+  }
+
+  public TDayOfWeek minus(long days) {
+
+    return plus(-(days % 7));
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public <R> R query(TTemporalQuery<R> query) {
+
+    if (query == TTemporalQueries.precision()) {
+      return (R) DAYS;
+    }
+    return TTemporalAccessor.super.query(query);
+  }
+
+  @Override
+  public TTemporal adjustInto(TTemporal temporal) {
+
+    return temporal.with(DAY_OF_WEEK, getValue());
+  }
+
+  public static TDayOfWeek of(int dayOfWeek) {
+
+    if (dayOfWeek < 1 || dayOfWeek > 7) {
+      throw new TDateTimeException("Invalid value for DayOfWeek: " + dayOfWeek);
+    }
+    return ENUMS[dayOfWeek - 1];
+  }
+
+  public static TDayOfWeek from(TTemporalAccessor temporal) {
+
+    if (temporal instanceof TDayOfWeek) {
+      return (TDayOfWeek) temporal;
+    }
+    try {
+      return of(temporal.get(DAY_OF_WEEK));
+    } catch (TDateTimeException ex) {
+      throw new TDateTimeException(
+          "Unable to obtain DayOfWeek from TemporalAccessor: " + temporal + " of type " + temporal.getClass().getName(),
+          ex);
+    }
+  }
+
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/time/TDuration.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/time/TDuration.java
@@ -1,0 +1,671 @@
+/* Copyright (c) The m-m-m Team, Licensed under the Apache License, Version 2.0
+ * http://www.apache.org/licenses/LICENSE-2.0 */
+package org.teavm.classlib.java.time;
+
+import static org.teavm.classlib.java.time.TLocalTime.MINUTES_PER_HOUR;
+import static org.teavm.classlib.java.time.TLocalTime.NANOS_PER_MILLI;
+import static org.teavm.classlib.java.time.TLocalTime.NANOS_PER_SECOND;
+import static org.teavm.classlib.java.time.TLocalTime.SECONDS_PER_DAY;
+import static org.teavm.classlib.java.time.TLocalTime.SECONDS_PER_HOUR;
+import static org.teavm.classlib.java.time.TLocalTime.SECONDS_PER_MINUTE;
+import static org.teavm.classlib.java.time.temporal.TChronoField.NANO_OF_SECOND;
+import static org.teavm.classlib.java.time.temporal.TChronoUnit.DAYS;
+import static org.teavm.classlib.java.time.temporal.TChronoUnit.NANOS;
+import static org.teavm.classlib.java.time.temporal.TChronoUnit.SECONDS;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+import org.teavm.classlib.java.io.TSerializable;
+import org.teavm.classlib.java.lang.TArithmeticException;
+import org.teavm.classlib.java.lang.TComparable;
+import org.teavm.classlib.java.lang.TNumberFormatException;
+import org.teavm.classlib.java.lang.TStringBuilder;
+import org.teavm.classlib.java.math.TBigDecimal;
+import org.teavm.classlib.java.math.TBigInteger;
+import org.teavm.classlib.java.math.TRoundingMode;
+import org.teavm.classlib.java.time.format.TDateTimeParseException;
+import org.teavm.classlib.java.time.temporal.TChronoUnit;
+import org.teavm.classlib.java.time.temporal.TTemporal;
+import org.teavm.classlib.java.time.temporal.TTemporalAmount;
+import org.teavm.classlib.java.time.temporal.TTemporalUnit;
+import org.teavm.classlib.java.time.temporal.TUnsupportedTemporalTypeException;
+import org.teavm.classlib.java.util.regex.TMatcher;
+import org.teavm.classlib.java.util.regex.TPattern;
+
+public final class TDuration implements TTemporalAmount, TComparable<TDuration>, TSerializable {
+
+  public static final TDuration ZERO = new TDuration(0, 0);
+
+  private static final TBigInteger BI_NANOS_PER_SECOND = TBigInteger.valueOf(NANOS_PER_SECOND);
+
+  private final long seconds;
+
+  private final int nanos;
+
+  private TDuration(long seconds, int nanos) {
+
+    super();
+    this.seconds = seconds;
+    this.nanos = nanos;
+  }
+
+  @Override
+  public long get(TTemporalUnit unit) {
+
+    if (unit == SECONDS) {
+      return this.seconds;
+    } else if (unit == NANOS) {
+      return this.nanos;
+    } else {
+      throw new TUnsupportedTemporalTypeException("Unsupported unit: " + unit);
+    }
+  }
+
+  @Override
+  public List<TTemporalUnit> getUnits() {
+
+    return TDurationUnits.UNITS;
+  }
+
+  public boolean isZero() {
+
+    return (this.seconds | this.nanos) == 0;
+  }
+
+  public boolean isNegative() {
+
+    return this.seconds < 0;
+  }
+
+  public long getSeconds() {
+
+    return this.seconds;
+  }
+
+  public int getNano() {
+
+    return this.nanos;
+  }
+
+  public TDuration withSeconds(long seconds) {
+
+    return create(seconds, this.nanos);
+  }
+
+  public TDuration withNanos(int nanoOfSecond) {
+
+    NANO_OF_SECOND.checkValidIntValue(nanoOfSecond);
+    return create(this.seconds, nanoOfSecond);
+  }
+
+  public TDuration plus(TDuration duration) {
+
+    return plus(duration.getSeconds(), duration.getNano());
+  }
+
+  public TDuration plus(long amountToAdd, TTemporalUnit unit) {
+
+    Objects.requireNonNull(unit, "unit");
+    if (unit == DAYS) {
+      return plus(Math.multiplyExact(amountToAdd, SECONDS_PER_DAY), 0);
+    }
+    if (unit.isDurationEstimated()) {
+      throw new TUnsupportedTemporalTypeException("Unit must not have an estimated duration");
+    }
+    if (amountToAdd == 0) {
+      return this;
+    }
+    if (unit instanceof TChronoUnit) {
+      switch ((TChronoUnit) unit) {
+        case NANOS:
+          return plusNanos(amountToAdd);
+        case MICROS:
+          return plusSeconds((amountToAdd / (1000_000L * 1000)) * 1000)
+              .plusNanos((amountToAdd % (1000_000L * 1000)) * 1000);
+        case MILLIS:
+          return plusMillis(amountToAdd);
+        case SECONDS:
+          return plusSeconds(amountToAdd);
+      }
+      return plusSeconds(Math.multiplyExact(unit.getDuration().seconds, amountToAdd));
+    }
+    TDuration duration = unit.getDuration().multipliedBy(amountToAdd);
+    return plusSeconds(duration.getSeconds()).plusNanos(duration.getNano());
+  }
+
+  // -----------------------------------------------------------------------
+  public TDuration plusDays(long daysToAdd) {
+
+    return plus(Math.multiplyExact(daysToAdd, SECONDS_PER_DAY), 0);
+  }
+
+  public TDuration plusHours(long hoursToAdd) {
+
+    return plus(Math.multiplyExact(hoursToAdd, SECONDS_PER_HOUR), 0);
+  }
+
+  public TDuration plusMinutes(long minutesToAdd) {
+
+    return plus(Math.multiplyExact(minutesToAdd, SECONDS_PER_MINUTE), 0);
+  }
+
+  public TDuration plusSeconds(long secondsToAdd) {
+
+    return plus(secondsToAdd, 0);
+  }
+
+  public TDuration plusMillis(long millisToAdd) {
+
+    return plus(millisToAdd / 1000, (millisToAdd % 1000) * 1000_000);
+  }
+
+  public TDuration plusNanos(long nanosToAdd) {
+
+    return plus(0, nanosToAdd);
+  }
+
+  private TDuration plus(long secondsToAdd, long nanosToAdd) {
+
+    if ((secondsToAdd | nanosToAdd) == 0) {
+      return this;
+    }
+    long epochSec = Math.addExact(this.seconds, secondsToAdd);
+    epochSec = Math.addExact(epochSec, nanosToAdd / NANOS_PER_SECOND);
+    nanosToAdd = nanosToAdd % NANOS_PER_SECOND;
+    long nanoAdjustment = this.nanos + nanosToAdd; // safe int+NANOS_PER_SECOND
+    return ofSeconds(epochSec, nanoAdjustment);
+  }
+
+  public TDuration minus(TDuration duration) {
+
+    long secsToSubtract = duration.getSeconds();
+    int nanosToSubtract = duration.getNano();
+    if (secsToSubtract == Long.MIN_VALUE) {
+      return plus(Long.MAX_VALUE, -nanosToSubtract).plus(1, 0);
+    }
+    return plus(-secsToSubtract, -nanosToSubtract);
+  }
+
+  public TDuration minus(long amountToSubtract, TTemporalUnit unit) {
+
+    return (amountToSubtract == Long.MIN_VALUE ? plus(Long.MAX_VALUE, unit).plus(1, unit)
+        : plus(-amountToSubtract, unit));
+  }
+
+  public TDuration minusDays(long daysToSubtract) {
+
+    return (daysToSubtract == Long.MIN_VALUE ? plusDays(Long.MAX_VALUE).plusDays(1) : plusDays(-daysToSubtract));
+  }
+
+  public TDuration minusHours(long hoursToSubtract) {
+
+    return (hoursToSubtract == Long.MIN_VALUE ? plusHours(Long.MAX_VALUE).plusHours(1) : plusHours(-hoursToSubtract));
+  }
+
+  public TDuration minusMinutes(long minutesToSubtract) {
+
+    return (minutesToSubtract == Long.MIN_VALUE ? plusMinutes(Long.MAX_VALUE).plusMinutes(1)
+        : plusMinutes(-minutesToSubtract));
+  }
+
+  public TDuration minusSeconds(long secondsToSubtract) {
+
+    return (secondsToSubtract == Long.MIN_VALUE ? plusSeconds(Long.MAX_VALUE).plusSeconds(1)
+        : plusSeconds(-secondsToSubtract));
+  }
+
+  public TDuration minusMillis(long millisToSubtract) {
+
+    return (millisToSubtract == Long.MIN_VALUE ? plusMillis(Long.MAX_VALUE).plusMillis(1)
+        : plusMillis(-millisToSubtract));
+  }
+
+  public TDuration minusNanos(long nanosToSubtract) {
+
+    return (nanosToSubtract == Long.MIN_VALUE ? plusNanos(Long.MAX_VALUE).plusNanos(1) : plusNanos(-nanosToSubtract));
+  }
+
+  public TDuration multipliedBy(long multiplicand) {
+
+    if (multiplicand == 0) {
+      return ZERO;
+    }
+    if (multiplicand == 1) {
+      return this;
+    }
+    return create(toBigDecimalSeconds().multiply(TBigDecimal.valueOf(multiplicand)));
+  }
+
+  public TDuration dividedBy(long divisor) {
+
+    if (divisor == 0) {
+      throw new ArithmeticException("Cannot divide by zero");
+    }
+    if (divisor == 1) {
+      return this;
+    }
+    return create(toBigDecimalSeconds().divide(TBigDecimal.valueOf(divisor), TRoundingMode.DOWN));
+  }
+
+  public long dividedBy(TDuration divisor) {
+
+    Objects.requireNonNull(divisor, "divisor");
+    TBigDecimal dividendBigD = toBigDecimalSeconds();
+    TBigDecimal divisorBigD = divisor.toBigDecimalSeconds();
+    return dividendBigD.divideToIntegralValue(divisorBigD).longValueExact();
+  }
+
+  private TBigDecimal toBigDecimalSeconds() {
+
+    return TBigDecimal.valueOf(this.seconds).add(TBigDecimal.valueOf(this.nanos, 9));
+  }
+
+  private static TDuration create(TBigDecimal seconds) {
+
+    TBigInteger nanos = seconds.movePointRight(9).toBigIntegerExact();
+    TBigInteger[] divRem = nanos.divideAndRemainder(BI_NANOS_PER_SECOND);
+    if (divRem[0].bitLength() > 63) {
+      throw new TArithmeticException("Exceeds capacity of Duration: " + nanos);
+    }
+    return ofSeconds(divRem[0].longValue(), divRem[1].intValue());
+  }
+
+  public TDuration negated() {
+
+    return multipliedBy(-1);
+  }
+
+  public TDuration abs() {
+
+    return isNegative() ? negated() : this;
+  }
+
+  @Override
+  public TTemporal addTo(TTemporal temporal) {
+
+    if (this.seconds != 0) {
+      temporal = temporal.plus(this.seconds, SECONDS);
+    }
+    if (this.nanos != 0) {
+      temporal = temporal.plus(this.nanos, NANOS);
+    }
+    return temporal;
+  }
+
+  @Override
+  public TTemporal subtractFrom(TTemporal temporal) {
+
+    if (this.seconds != 0) {
+      temporal = temporal.minus(this.seconds, SECONDS);
+    }
+    if (this.nanos != 0) {
+      temporal = temporal.minus(this.nanos, NANOS);
+    }
+    return temporal;
+  }
+
+  public long toDays() {
+
+    return this.seconds / SECONDS_PER_DAY;
+  }
+
+  public long toHours() {
+
+    return this.seconds / SECONDS_PER_HOUR;
+  }
+
+  public long toMinutes() {
+
+    return this.seconds / SECONDS_PER_MINUTE;
+  }
+
+  public long toSeconds() {
+
+    return this.seconds;
+  }
+
+  public long toMillis() {
+
+    long tempSeconds = this.seconds;
+    long tempNanos = this.nanos;
+    if (tempSeconds < 0) {
+      tempSeconds = tempSeconds + 1;
+      tempNanos = tempNanos - NANOS_PER_SECOND;
+    }
+    long millis = Math.multiplyExact(tempSeconds, 1000);
+    millis = Math.addExact(millis, tempNanos / NANOS_PER_MILLI);
+    return millis;
+  }
+
+  public long toNanos() {
+
+    long tempSeconds = this.seconds;
+    long tempNanos = this.nanos;
+    if (tempSeconds < 0) {
+      tempSeconds = tempSeconds + 1;
+      tempNanos = tempNanos - NANOS_PER_SECOND;
+    }
+    long totalNanos = Math.multiplyExact(tempSeconds, NANOS_PER_SECOND);
+    totalNanos = Math.addExact(totalNanos, tempNanos);
+    return totalNanos;
+  }
+
+  public long toDaysPart() {
+
+    return this.seconds / SECONDS_PER_DAY;
+  }
+
+  public int toHoursPart() {
+
+    return (int) (toHours() % 24);
+  }
+
+  public int toMinutesPart() {
+
+    return (int) (toMinutes() % MINUTES_PER_HOUR);
+  }
+
+  public int toSecondsPart() {
+
+    return (int) (this.seconds % SECONDS_PER_MINUTE);
+  }
+
+  public int toMillisPart() {
+
+    return this.nanos / 1000_000;
+  }
+
+  public int toNanosPart() {
+
+    return this.nanos;
+  }
+
+  public TDuration truncatedTo(TTemporalUnit unit) {
+
+    Objects.requireNonNull(unit, "unit");
+    if (unit == TChronoUnit.SECONDS && (this.seconds >= 0 || this.nanos == 0)) {
+      return new TDuration(this.seconds, 0);
+    } else if (unit == TChronoUnit.NANOS) {
+      return this;
+    }
+    TDuration unitDur = unit.getDuration();
+    if (unitDur.getSeconds() > TLocalTime.SECONDS_PER_DAY) {
+      throw new TUnsupportedTemporalTypeException("Unit is too large to be used for truncation");
+    }
+    long dur = unitDur.toNanos();
+    if ((TLocalTime.NANOS_PER_DAY % dur) != 0) {
+      throw new TUnsupportedTemporalTypeException("Unit must divide into a standard day without remainder");
+    }
+    long nod = (this.seconds % TLocalTime.SECONDS_PER_DAY) * TLocalTime.NANOS_PER_SECOND + this.nanos;
+    long result = (nod / dur) * dur;
+    return plusNanos(result - nod);
+  }
+
+  @Override
+  public int compareTo(TDuration otherDuration) {
+
+    int cmp = Long.compare(this.seconds, otherDuration.seconds);
+    if (cmp != 0) {
+      return cmp;
+    }
+    return this.nanos - otherDuration.nanos;
+  }
+
+  @Override
+  public boolean equals(Object otherDuration) {
+
+    if (this == otherDuration) {
+      return true;
+    }
+    if (otherDuration instanceof TDuration) {
+      TDuration other = (TDuration) otherDuration;
+      return this.seconds == other.seconds && this.nanos == other.nanos;
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+
+    return ((int) (this.seconds ^ (this.seconds >>> 32))) + (51 * this.nanos);
+  }
+
+  @Override
+  public String toString() {
+
+    if (this == ZERO) {
+      return "PT0S";
+    }
+    long effectiveTotalSecs = this.seconds;
+    if (this.seconds < 0 && this.nanos > 0) {
+      effectiveTotalSecs++;
+    }
+    long hours = effectiveTotalSecs / SECONDS_PER_HOUR;
+    int minutes = (int) ((effectiveTotalSecs % SECONDS_PER_HOUR) / SECONDS_PER_MINUTE);
+    int secs = (int) (effectiveTotalSecs % SECONDS_PER_MINUTE);
+    TStringBuilder buf = new TStringBuilder(24);
+    buf.append("PT");
+    if (hours != 0) {
+      buf.append(hours).append('H');
+    }
+    if (minutes != 0) {
+      buf.append(minutes).append('M');
+    }
+    if (secs == 0 && this.nanos == 0 && buf.length() > 2) {
+      return buf.toString();
+    }
+    if (this.seconds < 0 && this.nanos > 0) {
+      if (secs == 0) {
+        buf.append("-0");
+      } else {
+        buf.append(secs);
+      }
+    } else {
+      buf.append(secs);
+    }
+    if (this.nanos > 0) {
+      int pos = buf.length();
+      if (this.seconds < 0) {
+        buf.append(2 * NANOS_PER_SECOND - this.nanos);
+      } else {
+        buf.append(this.nanos + NANOS_PER_SECOND);
+      }
+      while (buf.charAt(buf.length() - 1) == '0') {
+        buf.setLength(buf.length() - 1);
+      }
+      buf.setCharAt(pos, '.');
+    }
+    buf.append('S');
+    return buf.toString();
+  }
+
+  public static TDuration ofDays(long days) {
+
+    return create(Math.multiplyExact(days, SECONDS_PER_DAY), 0);
+  }
+
+  public static TDuration ofHours(long hours) {
+
+    return create(Math.multiplyExact(hours, SECONDS_PER_HOUR), 0);
+  }
+
+  public static TDuration ofMinutes(long minutes) {
+
+    return create(Math.multiplyExact(minutes, SECONDS_PER_MINUTE), 0);
+  }
+
+  public static TDuration ofSeconds(long seconds) {
+
+    return create(seconds, 0);
+  }
+
+  public static TDuration ofSeconds(long seconds, long nanoAdjustment) {
+
+    long secs = Math.addExact(seconds, Math.floorDiv(nanoAdjustment, NANOS_PER_SECOND));
+    int nos = (int) Math.floorMod(nanoAdjustment, NANOS_PER_SECOND);
+    return create(secs, nos);
+  }
+
+  public static TDuration ofMillis(long millis) {
+
+    long secs = millis / 1000;
+    int mos = (int) (millis % 1000);
+    if (mos < 0) {
+      mos += 1000;
+      secs--;
+    }
+    return create(secs, mos * 1000_000);
+  }
+
+  public static TDuration ofNanos(long nanos) {
+
+    long secs = nanos / NANOS_PER_SECOND;
+    int nos = (int) (nanos % NANOS_PER_SECOND);
+    if (nos < 0) {
+      nos += NANOS_PER_SECOND;
+      secs--;
+    }
+    return create(secs, nos);
+  }
+
+  public static TDuration of(long amount, TTemporalUnit unit) {
+
+    return ZERO.plus(amount, unit);
+  }
+
+  public static TDuration from(TTemporalAmount amount) {
+
+    Objects.requireNonNull(amount, "amount");
+    TDuration duration = ZERO;
+    for (TTemporalUnit unit : amount.getUnits()) {
+      duration = duration.plus(amount.get(unit), unit);
+    }
+    return duration;
+  }
+
+  public static TDuration parse(CharSequence text) {
+
+    Objects.requireNonNull(text, "text");
+    TMatcher matcher = TLazy.PATTERN.matcher(text);
+    if (matcher.matches()) {
+      // check for letter T but no time sections
+      if (!charMatch(text, matcher.start(3), matcher.end(3), 'T')) {
+        boolean negate = charMatch(text, matcher.start(1), matcher.end(1), '-');
+
+        int dayStart = matcher.start(2), dayEnd = matcher.end(2);
+        int hourStart = matcher.start(4), hourEnd = matcher.end(4);
+        int minuteStart = matcher.start(5), minuteEnd = matcher.end(5);
+        int secondStart = matcher.start(6), secondEnd = matcher.end(6);
+        int fractionStart = matcher.start(7), fractionEnd = matcher.end(7);
+
+        if (dayStart >= 0 || hourStart >= 0 || minuteStart >= 0 || secondStart >= 0) {
+          long daysAsSecs = parseNumber(text, dayStart, dayEnd, SECONDS_PER_DAY, "days");
+          long hoursAsSecs = parseNumber(text, hourStart, hourEnd, SECONDS_PER_HOUR, "hours");
+          long minsAsSecs = parseNumber(text, minuteStart, minuteEnd, SECONDS_PER_MINUTE, "minutes");
+          long seconds = parseNumber(text, secondStart, secondEnd, 1, "seconds");
+          boolean negativeSecs = secondStart >= 0 && text.charAt(secondStart) == '-';
+          int nanos = parseFraction(text, fractionStart, fractionEnd, negativeSecs ? -1 : 1);
+          try {
+            return create(negate, daysAsSecs, hoursAsSecs, minsAsSecs, seconds, nanos);
+          } catch (TArithmeticException ex) {
+            throw new TDateTimeParseException("Text cannot be parsed to a Duration: overflow", text, 0, ex);
+          }
+        }
+      }
+    }
+    throw new TDateTimeParseException("Text cannot be parsed to a Duration", text, 0);
+  }
+
+  private static boolean charMatch(CharSequence text, int start, int end, char c) {
+
+    return (start >= 0 && end == start + 1 && text.charAt(start) == c);
+  }
+
+  private static long parseNumber(CharSequence text, int start, int end, int multiplier, String errorText) {
+
+    // regex limits to [-+]?[0-9]+
+    if (start < 0 || end < 0) {
+      return 0;
+    }
+    try {
+      long val = Long.parseLong(text, start, end, 10);
+      return Math.multiplyExact(val, multiplier);
+    } catch (TNumberFormatException | TArithmeticException ex) {
+      throw new TDateTimeParseException("Text cannot be parsed to a Duration: " + errorText, text, 0, ex);
+    }
+  }
+
+  private static int parseFraction(CharSequence text, int start, int end, int negate) {
+
+    // regex limits to [0-9]{0,9}
+    if (start < 0 || end < 0 || end - start == 0) {
+      return 0;
+    }
+    try {
+      int fraction = Integer.parseInt(text, start, end, 10);
+
+      // for number strings smaller than 9 digits, interpret as if there
+      // were trailing zeros
+      for (int i = end - start; i < 9; i++) {
+        fraction *= 10;
+      }
+      return fraction * negate;
+    } catch (TNumberFormatException | TArithmeticException ex) {
+      throw new TDateTimeParseException("Text cannot be parsed to a Duration: fraction", text, 0, ex);
+    }
+  }
+
+  private static TDuration create(boolean negate, long daysAsSecs, long hoursAsSecs, long minsAsSecs, long secs,
+      int nanos) {
+
+    long seconds = Math.addExact(daysAsSecs, Math.addExact(hoursAsSecs, Math.addExact(minsAsSecs, secs)));
+    if (negate) {
+      return ofSeconds(seconds, nanos).negated();
+    }
+    return ofSeconds(seconds, nanos);
+  }
+
+  public static TDuration between(TTemporal startInclusive, TTemporal endExclusive) {
+
+    try {
+      return ofNanos(startInclusive.until(endExclusive, NANOS));
+    } catch (TDateTimeException | TArithmeticException ex) {
+      long secs = startInclusive.until(endExclusive, SECONDS);
+      long nanos;
+      try {
+        nanos = endExclusive.getLong(NANO_OF_SECOND) - startInclusive.getLong(NANO_OF_SECOND);
+        if (secs > 0 && nanos < 0) {
+          secs++;
+        } else if (secs < 0 && nanos > 0) {
+          secs--;
+        }
+      } catch (TDateTimeException ex2) {
+        nanos = 0;
+      }
+      return ofSeconds(secs, nanos);
+    }
+  }
+
+  private static TDuration create(long seconds, int nanoAdjustment) {
+
+    if ((seconds | nanoAdjustment) == 0) {
+      return ZERO;
+    }
+    return new TDuration(seconds, nanoAdjustment);
+  }
+
+  private static class TDurationUnits {
+    static final List<TTemporalUnit> UNITS = Collections.unmodifiableList(Arrays.asList(SECONDS, NANOS));
+  }
+
+  private static class TLazy {
+    static final TPattern PATTERN = TPattern.compile(
+        "([-+]?)P(?:([-+]?[0-9]+)D)?"
+            + "(T(?:([-+]?[0-9]+)H)?(?:([-+]?[0-9]+)M)?(?:([-+]?[0-9]+)(?:[.,]([0-9]{0,9}))?S)?)?",
+        TPattern.CASE_INSENSITIVE);
+  }
+
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/time/TInstant.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/time/TInstant.java
@@ -1,0 +1,470 @@
+package org.teavm.classlib.java.time;
+
+import static org.teavm.classlib.java.time.TLocalTime.NANOS_PER_SECOND;
+import static org.teavm.classlib.java.time.TLocalTime.SECONDS_PER_DAY;
+import static org.teavm.classlib.java.time.TLocalTime.SECONDS_PER_HOUR;
+import static org.teavm.classlib.java.time.TLocalTime.SECONDS_PER_MINUTE;
+import static org.teavm.classlib.java.time.temporal.TChronoField.INSTANT_SECONDS;
+import static org.teavm.classlib.java.time.temporal.TChronoField.MICRO_OF_SECOND;
+import static org.teavm.classlib.java.time.temporal.TChronoField.MILLI_OF_SECOND;
+import static org.teavm.classlib.java.time.temporal.TChronoField.NANO_OF_SECOND;
+import static org.teavm.classlib.java.time.temporal.TChronoUnit.DAYS;
+import static org.teavm.classlib.java.time.temporal.TChronoUnit.NANOS;
+
+import org.teavm.classlib.java.io.TSerializable;
+import org.teavm.classlib.java.lang.TComparable;
+import org.teavm.classlib.java.time.format.TDateTimeFormatter;
+import org.teavm.classlib.java.time.temporal.TChronoField;
+import org.teavm.classlib.java.time.temporal.TChronoUnit;
+import org.teavm.classlib.java.time.temporal.TTemporal;
+import org.teavm.classlib.java.time.temporal.TTemporalAccessor;
+import org.teavm.classlib.java.time.temporal.TTemporalAdjuster;
+import org.teavm.classlib.java.time.temporal.TTemporalAmount;
+import org.teavm.classlib.java.time.temporal.TTemporalField;
+import org.teavm.classlib.java.time.temporal.TTemporalQueries;
+import org.teavm.classlib.java.time.temporal.TTemporalQuery;
+import org.teavm.classlib.java.time.temporal.TTemporalUnit;
+import org.teavm.classlib.java.time.temporal.TUnsupportedTemporalTypeException;
+import org.teavm.classlib.java.time.temporal.TValueRange;
+import org.teavm.classlib.java.util.TObjects;
+
+public final class TInstant implements TTemporal, TTemporalAdjuster, TComparable<TInstant>, TSerializable {
+
+  public static final TInstant EPOCH = new TInstant(0, 0);
+
+  private static final long MIN_SECOND = -31557014167219200L;
+
+  private static final long MAX_SECOND = 31556889864403199L;
+
+  public static final TInstant MIN = TInstant.ofEpochSecond(MIN_SECOND, 0);
+
+  public static final TInstant MAX = TInstant.ofEpochSecond(MAX_SECOND, 999_999_999);
+
+  private final long seconds;
+
+  private final int nanos;
+
+  private TInstant(long epochSecond, int nanos) {
+
+    super();
+    this.seconds = epochSecond;
+    this.nanos = nanos;
+  }
+
+  public long getEpochSecond() {
+
+    return this.seconds;
+  }
+
+  public int getNano() {
+
+    return this.nanos;
+  }
+
+  @Override
+  public boolean isSupported(TTemporalField field) {
+
+    if (field instanceof TChronoField) {
+      return field == INSTANT_SECONDS || field == NANO_OF_SECOND || field == MICRO_OF_SECOND
+          || field == MILLI_OF_SECOND;
+    }
+    return field != null && field.isSupportedBy(this);
+  }
+
+  @Override
+  public boolean isSupported(TTemporalUnit unit) {
+
+    if (unit instanceof TChronoUnit) {
+      return unit.isTimeBased() || unit == DAYS;
+    }
+    return unit != null && unit.isSupportedBy(this);
+  }
+
+  @Override
+  public TValueRange range(TTemporalField field) {
+
+    return TTemporal.super.range(field);
+  }
+
+  @Override
+  public int get(TTemporalField field) {
+
+    if (field instanceof TChronoField) {
+      switch ((TChronoField) field) {
+        case NANO_OF_SECOND:
+          return this.nanos;
+        case MICRO_OF_SECOND:
+          return this.nanos / 1000;
+        case MILLI_OF_SECOND:
+          return this.nanos / 1000_000;
+      }
+      throw new TUnsupportedTemporalTypeException("Unsupported field: " + field);
+    }
+    return range(field).checkValidIntValue(field.getFrom(this), field);
+  }
+
+  @Override
+  public long getLong(TTemporalField field) {
+
+    if (field instanceof TChronoField) {
+      switch ((TChronoField) field) {
+        case NANO_OF_SECOND:
+          return this.nanos;
+        case MICRO_OF_SECOND:
+          return this.nanos / 1000;
+        case MILLI_OF_SECOND:
+          return this.nanos / 1000_000;
+        case INSTANT_SECONDS:
+          return this.seconds;
+      }
+      throw new TUnsupportedTemporalTypeException("Unsupported field: " + field);
+    }
+    return field.getFrom(this);
+  }
+
+  @Override
+  public TInstant with(TTemporalAdjuster adjuster) {
+
+    return (TInstant) adjuster.adjustInto(this);
+  }
+
+  @Override
+  public TInstant with(TTemporalField field, long newValue) {
+
+    if (field instanceof TChronoField) {
+      TChronoField f = (TChronoField) field;
+      f.checkValidValue(newValue);
+      switch (f) {
+        case MILLI_OF_SECOND: {
+          int nval = (int) newValue * 1000_000;
+          return (nval != this.nanos ? create(this.seconds, nval) : this);
+        }
+        case MICRO_OF_SECOND: {
+          int nval = (int) newValue * 1000;
+          return (nval != this.nanos ? create(this.seconds, nval) : this);
+        }
+        case NANO_OF_SECOND:
+          return (newValue != this.nanos ? create(this.seconds, (int) newValue) : this);
+        case INSTANT_SECONDS:
+          return (newValue != this.seconds ? create(newValue, this.nanos) : this);
+      }
+      throw new TUnsupportedTemporalTypeException("Unsupported field: " + field);
+    }
+    return field.adjustInto(this, newValue);
+  }
+
+  public TInstant truncatedTo(TTemporalUnit unit) {
+
+    if (unit == TChronoUnit.NANOS) {
+      return this;
+    }
+    TDuration unitDur = unit.getDuration();
+    if (unitDur.getSeconds() > TLocalTime.SECONDS_PER_DAY) {
+      throw new TUnsupportedTemporalTypeException("Unit is too large to be used for truncation");
+    }
+    long dur = unitDur.toNanos();
+    if ((TLocalTime.NANOS_PER_DAY % dur) != 0) {
+      throw new TUnsupportedTemporalTypeException("Unit must divide into a standard day without remainder");
+    }
+    long nod = (this.seconds % TLocalTime.SECONDS_PER_DAY) * TLocalTime.NANOS_PER_SECOND + this.nanos;
+    long result = Math.floorDiv(nod, dur) * dur;
+    return plusNanos(result - nod);
+  }
+
+  @Override
+  public TInstant plus(TTemporalAmount amountToAdd) {
+
+    return (TInstant) amountToAdd.addTo(this);
+  }
+
+  @Override
+  public TInstant plus(long amountToAdd, TTemporalUnit unit) {
+
+    if (unit instanceof TChronoUnit) {
+      switch ((TChronoUnit) unit) {
+        case NANOS:
+          return plusNanos(amountToAdd);
+        case MICROS:
+          return plus(amountToAdd / 1000_000, (amountToAdd % 1000_000) * 1000);
+        case MILLIS:
+          return plusMillis(amountToAdd);
+        case SECONDS:
+          return plusSeconds(amountToAdd);
+        case MINUTES:
+          return plusSeconds(Math.multiplyExact(amountToAdd, SECONDS_PER_MINUTE));
+        case HOURS:
+          return plusSeconds(Math.multiplyExact(amountToAdd, SECONDS_PER_HOUR));
+        case HALF_DAYS:
+          return plusSeconds(Math.multiplyExact(amountToAdd, SECONDS_PER_DAY / 2));
+        case DAYS:
+          return plusSeconds(Math.multiplyExact(amountToAdd, SECONDS_PER_DAY));
+      }
+      throw new TUnsupportedTemporalTypeException("Unsupported unit: " + unit);
+    }
+    return unit.addTo(this, amountToAdd);
+  }
+
+  public TInstant plusSeconds(long secondsToAdd) {
+
+    return plus(secondsToAdd, 0);
+  }
+
+  public TInstant plusMillis(long millisToAdd) {
+
+    return plus(millisToAdd / 1000, (millisToAdd % 1000) * 1000_000);
+  }
+
+  public TInstant plusNanos(long nanosToAdd) {
+
+    return plus(0, nanosToAdd);
+  }
+
+  private TInstant plus(long secondsToAdd, long nanosToAdd) {
+
+    if ((secondsToAdd | nanosToAdd) == 0) {
+      return this;
+    }
+    long epochSec = Math.addExact(this.seconds, secondsToAdd);
+    epochSec = Math.addExact(epochSec, nanosToAdd / NANOS_PER_SECOND);
+    nanosToAdd = nanosToAdd % NANOS_PER_SECOND;
+    long nanoAdjustment = this.nanos + nanosToAdd; // safe int+NANOS_PER_SECOND
+    return ofEpochSecond(epochSec, nanoAdjustment);
+  }
+
+  @Override
+  public TInstant minus(TTemporalAmount amountToSubtract) {
+
+    return (TInstant) amountToSubtract.subtractFrom(this);
+  }
+
+  @Override
+  public TInstant minus(long amountToSubtract, TTemporalUnit unit) {
+
+    return (amountToSubtract == Long.MIN_VALUE ? plus(Long.MAX_VALUE, unit).plus(1, unit)
+        : plus(-amountToSubtract, unit));
+  }
+
+  public TInstant minusSeconds(long secondsToSubtract) {
+
+    if (secondsToSubtract == Long.MIN_VALUE) {
+      return plusSeconds(Long.MAX_VALUE).plusSeconds(1);
+    }
+    return plusSeconds(-secondsToSubtract);
+  }
+
+  public TInstant minusMillis(long millisToSubtract) {
+
+    if (millisToSubtract == Long.MIN_VALUE) {
+      return plusMillis(Long.MAX_VALUE).plusMillis(1);
+    }
+    return plusMillis(-millisToSubtract);
+  }
+
+  public TInstant minusNanos(long nanosToSubtract) {
+
+    if (nanosToSubtract == Long.MIN_VALUE) {
+      return plusNanos(Long.MAX_VALUE).plusNanos(1);
+    }
+    return plusNanos(-nanosToSubtract);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public <R> R query(TTemporalQuery<R> query) {
+
+    if (query == TTemporalQueries.precision()) {
+      return (R) NANOS;
+    }
+    if (query == TTemporalQueries.chronology() || query == TTemporalQueries.zoneId() || query == TTemporalQueries.zone()
+        || query == TTemporalQueries.offset() || query == TTemporalQueries.localDate()
+        || query == TTemporalQueries.localTime()) {
+      return null;
+    }
+    return query.queryFrom(this);
+  }
+
+  @Override
+  public TTemporal adjustInto(TTemporal temporal) {
+
+    return temporal.with(INSTANT_SECONDS, this.seconds).with(NANO_OF_SECOND, this.nanos);
+  }
+
+  @Override
+  public long until(TTemporal endExclusive, TTemporalUnit unit) {
+
+    TInstant end = TInstant.from(endExclusive);
+    if (unit instanceof TChronoUnit) {
+      TChronoUnit f = (TChronoUnit) unit;
+      switch (f) {
+        case NANOS:
+          return nanosUntil(end);
+        case MICROS:
+          return nanosUntil(end) / 1000;
+        case MILLIS:
+          return Math.subtractExact(end.toEpochMilli(), toEpochMilli());
+        case SECONDS:
+          return secondsUntil(end);
+        case MINUTES:
+          return secondsUntil(end) / SECONDS_PER_MINUTE;
+        case HOURS:
+          return secondsUntil(end) / SECONDS_PER_HOUR;
+        case HALF_DAYS:
+          return secondsUntil(end) / (12 * SECONDS_PER_HOUR);
+        case DAYS:
+          return secondsUntil(end) / (SECONDS_PER_DAY);
+      }
+      throw new TUnsupportedTemporalTypeException("Unsupported unit: " + unit);
+    }
+    return unit.between(this, end);
+  }
+
+  private long nanosUntil(TInstant end) {
+
+    long secsDiff = Math.subtractExact(end.seconds, this.seconds);
+    long totalNanos = Math.multiplyExact(secsDiff, NANOS_PER_SECOND);
+    return Math.addExact(totalNanos, end.nanos - this.nanos);
+  }
+
+  private long secondsUntil(TInstant end) {
+
+    long secsDiff = Math.subtractExact(end.seconds, this.seconds);
+    long nanosDiff = end.nanos - this.nanos;
+    if (secsDiff > 0 && nanosDiff < 0) {
+      secsDiff--;
+    } else if (secsDiff < 0 && nanosDiff > 0) {
+      secsDiff++;
+    }
+    return secsDiff;
+  }
+
+  public TOffsetDateTime atOffset(TZoneOffset offset) {
+
+    return TOffsetDateTime.ofInstant(this, offset);
+  }
+
+  public TZonedDateTime atZone(TZoneId zone) {
+
+    return TZonedDateTime.ofInstant(this, zone);
+  }
+
+  public long toEpochMilli() {
+
+    if (this.seconds < 0 && this.nanos > 0) {
+      long millis = Math.multiplyExact(this.seconds + 1, 1000);
+      long adjustment = this.nanos / 1000_000 - 1000;
+      return Math.addExact(millis, adjustment);
+    } else {
+      long millis = Math.multiplyExact(this.seconds, 1000);
+      return Math.addExact(millis, this.nanos / 1000_000);
+    }
+  }
+
+  @Override
+  public int compareTo(TInstant otherInstant) {
+
+    int cmp = Long.compare(this.seconds, otherInstant.seconds);
+    if (cmp != 0) {
+      return cmp;
+    }
+    return this.nanos - otherInstant.nanos;
+  }
+
+  public boolean isAfter(TInstant otherInstant) {
+
+    return compareTo(otherInstant) > 0;
+  }
+
+  public boolean isBefore(TInstant otherInstant) {
+
+    return compareTo(otherInstant) < 0;
+  }
+
+  @Override
+  public boolean equals(Object otherInstant) {
+
+    if (this == otherInstant) {
+      return true;
+    }
+    if (otherInstant instanceof TInstant) {
+      TInstant other = (TInstant) otherInstant;
+      return this.seconds == other.seconds && this.nanos == other.nanos;
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+
+    return ((int) (this.seconds ^ (this.seconds >>> 32))) + 51 * this.nanos;
+  }
+
+  @Override
+  public String toString() {
+
+    return TDateTimeFormatter.ISO_INSTANT.format(this);
+  }
+
+  public static TInstant now() {
+
+    return TClock.systemUTC().instant();
+  }
+
+  public static TInstant now(TClock clock) {
+
+    TObjects.requireNonNull(clock, "clock");
+    return clock.instant();
+  }
+
+  public static TInstant ofEpochSecond(long epochSecond) {
+
+    return create(epochSecond, 0);
+  }
+
+  public static TInstant ofEpochSecond(long epochSecond, long nanoAdjustment) {
+
+    long secs = Math.addExact(epochSecond, Math.floorDiv(nanoAdjustment, NANOS_PER_SECOND));
+    int nos = (int) Math.floorMod(nanoAdjustment, NANOS_PER_SECOND);
+    return create(secs, nos);
+  }
+
+  public static TInstant ofEpochMilli(long epochMilli) {
+
+    long secs = Math.floorDiv(epochMilli, 1000);
+    int mos = Math.floorMod(epochMilli, 1000);
+    return create(secs, mos * 1000_000);
+  }
+
+  public static TInstant from(TTemporalAccessor temporal) {
+
+    if (temporal instanceof TInstant) {
+      return (TInstant) temporal;
+    }
+    TObjects.requireNonNull(temporal, "temporal");
+    try {
+      long instantSecs = temporal.getLong(INSTANT_SECONDS);
+      int nanoOfSecond = temporal.get(NANO_OF_SECOND);
+      return TInstant.ofEpochSecond(instantSecs, nanoOfSecond);
+    } catch (TDateTimeException ex) {
+      throw new TDateTimeException(
+          "Unable to obtain Instant from TemporalAccessor: " + temporal + " of type " + temporal.getClass().getName(),
+          ex);
+    }
+  }
+
+  public static TInstant parse(final CharSequence text) {
+
+    return TDateTimeFormatter.ISO_INSTANT.parse(text, TInstant::from);
+  }
+
+  private static TInstant create(long seconds, int nanoOfSecond) {
+
+    if ((seconds | nanoOfSecond) == 0) {
+      return EPOCH;
+    }
+    if (seconds < MIN_SECOND || seconds > MAX_SECOND) {
+      throw new TDateTimeException("Instant exceeds minimum or maximum instant");
+    }
+    return new TInstant(seconds, nanoOfSecond);
+  }
+
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/time/TLocalDate.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/time/TLocalDate.java
@@ -1,0 +1,903 @@
+package org.teavm.classlib.java.time;
+
+import static org.teavm.classlib.java.time.TLocalTime.SECONDS_PER_DAY;
+import static org.teavm.classlib.java.time.temporal.TChronoField.ALIGNED_DAY_OF_WEEK_IN_MONTH;
+import static org.teavm.classlib.java.time.temporal.TChronoField.ALIGNED_DAY_OF_WEEK_IN_YEAR;
+import static org.teavm.classlib.java.time.temporal.TChronoField.ALIGNED_WEEK_OF_MONTH;
+import static org.teavm.classlib.java.time.temporal.TChronoField.ALIGNED_WEEK_OF_YEAR;
+import static org.teavm.classlib.java.time.temporal.TChronoField.DAY_OF_MONTH;
+import static org.teavm.classlib.java.time.temporal.TChronoField.DAY_OF_YEAR;
+import static org.teavm.classlib.java.time.temporal.TChronoField.EPOCH_DAY;
+import static org.teavm.classlib.java.time.temporal.TChronoField.ERA;
+import static org.teavm.classlib.java.time.temporal.TChronoField.MONTH_OF_YEAR;
+import static org.teavm.classlib.java.time.temporal.TChronoField.PROLEPTIC_MONTH;
+import static org.teavm.classlib.java.time.temporal.TChronoField.YEAR;
+
+import org.teavm.classlib.java.io.TSerializable;
+import org.teavm.classlib.java.lang.TIllegalArgumentException;
+import org.teavm.classlib.java.lang.TMath;
+import org.teavm.classlib.java.lang.TStringBuilder;
+import org.teavm.classlib.java.time.chrono.TChronoLocalDate;
+import org.teavm.classlib.java.time.chrono.TIsoChronology;
+import org.teavm.classlib.java.time.chrono.TIsoEra;
+import org.teavm.classlib.java.time.format.TDateTimeFormatter;
+import org.teavm.classlib.java.time.temporal.TChronoField;
+import org.teavm.classlib.java.time.temporal.TChronoUnit;
+import org.teavm.classlib.java.time.temporal.TTemporal;
+import org.teavm.classlib.java.time.temporal.TTemporalAccessor;
+import org.teavm.classlib.java.time.temporal.TTemporalAdjuster;
+import org.teavm.classlib.java.time.temporal.TTemporalAmount;
+import org.teavm.classlib.java.time.temporal.TTemporalField;
+import org.teavm.classlib.java.time.temporal.TTemporalQueries;
+import org.teavm.classlib.java.time.temporal.TTemporalQuery;
+import org.teavm.classlib.java.time.temporal.TTemporalUnit;
+import org.teavm.classlib.java.time.temporal.TUnsupportedTemporalTypeException;
+import org.teavm.classlib.java.time.temporal.TValueRange;
+import org.teavm.classlib.java.util.TObjects;
+import org.teavm.classlib.java.util.stream.TLongStream;
+import org.teavm.classlib.java.util.stream.TStream;
+
+public final class TLocalDate implements TTemporal, TTemporalAdjuster, TChronoLocalDate, TSerializable {
+
+  public static final TLocalDate MIN = TLocalDate.of(TYear.MIN_VALUE, 1, 1);
+
+  public static final TLocalDate MAX = TLocalDate.of(TYear.MAX_VALUE, 12, 31);
+
+  public static final TLocalDate EPOCH = TLocalDate.of(1970, 1, 1);
+
+  private static final int DAYS_PER_CYCLE = 146097;
+
+  static final long DAYS_0000_TO_1970 = (DAYS_PER_CYCLE * 5L) - (30L * 365L + 7L);
+
+  private final int year;
+
+  private final short month;
+
+  private final short day;
+
+  private TLocalDate(int year, int month, int dayOfMonth) {
+
+    this.year = year;
+    this.month = (short) month;
+    this.day = (short) dayOfMonth;
+  }
+
+  @Override
+  public boolean isSupported(TTemporalField field) {
+
+    return TChronoLocalDate.super.isSupported(field);
+  }
+
+  @Override
+  public boolean isSupported(TTemporalUnit unit) {
+
+    return TChronoLocalDate.super.isSupported(unit);
+  }
+
+  @Override
+  public TValueRange range(TTemporalField field) {
+
+    if (field instanceof TChronoField) {
+      TChronoField f = (TChronoField) field;
+      if (f.isDateBased()) {
+        switch (f) {
+          case DAY_OF_MONTH:
+            return TValueRange.of(1, lengthOfMonth());
+          case DAY_OF_YEAR:
+            return TValueRange.of(1, lengthOfYear());
+          case ALIGNED_WEEK_OF_MONTH:
+            return TValueRange.of(1, getMonth() == TMonth.FEBRUARY && isLeapYear() == false ? 4 : 5);
+          case YEAR_OF_ERA:
+            return (getYear() <= 0 ? TValueRange.of(1, TYear.MAX_VALUE + 1) : TValueRange.of(1, TYear.MAX_VALUE));
+        }
+        return field.range();
+      }
+      throw new TUnsupportedTemporalTypeException("Unsupported field: " + field);
+    }
+    return field.rangeRefinedBy(this);
+  }
+
+  @Override
+  public int get(TTemporalField field) {
+
+    if (field instanceof TChronoField) {
+      return get0(field);
+    }
+    return TChronoLocalDate.super.get(field);
+  }
+
+  @Override
+  public long getLong(TTemporalField field) {
+
+    if (field instanceof TChronoField) {
+      if (field == EPOCH_DAY) {
+        return toEpochDay();
+      }
+      if (field == PROLEPTIC_MONTH) {
+        return getProlepticMonth();
+      }
+      return get0(field);
+    }
+    return field.getFrom(this);
+  }
+
+  private int get0(TTemporalField field) {
+
+    switch ((TChronoField) field) {
+      case DAY_OF_WEEK:
+        return getDayOfWeek().getValue();
+      case ALIGNED_DAY_OF_WEEK_IN_MONTH:
+        return ((this.day - 1) % 7) + 1;
+      case ALIGNED_DAY_OF_WEEK_IN_YEAR:
+        return ((getDayOfYear() - 1) % 7) + 1;
+      case DAY_OF_MONTH:
+        return this.day;
+      case DAY_OF_YEAR:
+        return getDayOfYear();
+      case EPOCH_DAY:
+        throw new TUnsupportedTemporalTypeException("Invalid field 'EpochDay' for get() method, use getLong() instead");
+      case ALIGNED_WEEK_OF_MONTH:
+        return ((this.day - 1) / 7) + 1;
+      case ALIGNED_WEEK_OF_YEAR:
+        return ((getDayOfYear() - 1) / 7) + 1;
+      case MONTH_OF_YEAR:
+        return this.month;
+      case PROLEPTIC_MONTH:
+        throw new TUnsupportedTemporalTypeException(
+            "Invalid field 'ProlepticMonth' for get() method, use getLong() instead");
+      case YEAR_OF_ERA:
+        return (this.year >= 1 ? this.year : 1 - this.year);
+      case YEAR:
+        return this.year;
+      case ERA:
+        return (this.year >= 1 ? 1 : 0);
+    }
+    throw new TUnsupportedTemporalTypeException("Unsupported field: " + field);
+  }
+
+  private long getProlepticMonth() {
+
+    return (this.year * 12L + this.month - 1);
+  }
+
+  @Override
+  public TIsoChronology getChronology() {
+
+    return TIsoChronology.INSTANCE;
+  }
+
+  @Override
+  public TIsoEra getEra() {
+
+    return (getYear() >= 1 ? TIsoEra.CE : TIsoEra.BCE);
+  }
+
+  public int getYear() {
+
+    return this.year;
+  }
+
+  public int getMonthValue() {
+
+    return this.month;
+  }
+
+  public TMonth getMonth() {
+
+    return TMonth.of(this.month);
+  }
+
+  public int getDayOfMonth() {
+
+    return this.day;
+  }
+
+  public int getDayOfYear() {
+
+    return getMonth().firstDayOfYear(isLeapYear()) + this.day - 1;
+  }
+
+  public TDayOfWeek getDayOfWeek() {
+
+    int dow0 = Math.floorMod(toEpochDay() + 3, 7);
+    return TDayOfWeek.of(dow0 + 1);
+  }
+
+  @Override
+  public boolean isLeapYear() {
+
+    return TYear.isLeap(this.year);
+  }
+
+  @Override
+  public int lengthOfMonth() {
+
+    switch (this.month) {
+      case 2:
+        return (isLeapYear() ? 29 : 28);
+      case 4:
+      case 6:
+      case 9:
+      case 11:
+        return 30;
+      default:
+        return 31;
+    }
+  }
+
+  @Override
+  public int lengthOfYear() {
+
+    return (isLeapYear() ? 366 : 365);
+  }
+
+  @Override
+  public TLocalDate with(TTemporalAdjuster adjuster) {
+
+    if (adjuster instanceof TLocalDate) {
+      return (TLocalDate) adjuster;
+    }
+    return (TLocalDate) adjuster.adjustInto(this);
+  }
+
+  @Override
+  public TLocalDate with(TTemporalField field, long newValue) {
+
+    if (field instanceof TChronoField) {
+      TChronoField f = (TChronoField) field;
+      f.checkValidValue(newValue);
+      switch (f) {
+        case DAY_OF_WEEK:
+          return plusDays(newValue - getDayOfWeek().getValue());
+        case ALIGNED_DAY_OF_WEEK_IN_MONTH:
+          return plusDays(newValue - getLong(ALIGNED_DAY_OF_WEEK_IN_MONTH));
+        case ALIGNED_DAY_OF_WEEK_IN_YEAR:
+          return plusDays(newValue - getLong(ALIGNED_DAY_OF_WEEK_IN_YEAR));
+        case DAY_OF_MONTH:
+          return withDayOfMonth((int) newValue);
+        case DAY_OF_YEAR:
+          return withDayOfYear((int) newValue);
+        case EPOCH_DAY:
+          return TLocalDate.ofEpochDay(newValue);
+        case ALIGNED_WEEK_OF_MONTH:
+          return plusWeeks(newValue - getLong(ALIGNED_WEEK_OF_MONTH));
+        case ALIGNED_WEEK_OF_YEAR:
+          return plusWeeks(newValue - getLong(ALIGNED_WEEK_OF_YEAR));
+        case MONTH_OF_YEAR:
+          return withMonth((int) newValue);
+        case PROLEPTIC_MONTH:
+          return plusMonths(newValue - getProlepticMonth());
+        case YEAR_OF_ERA:
+          return withYear((int) (this.year >= 1 ? newValue : 1 - newValue));
+        case YEAR:
+          return withYear((int) newValue);
+        case ERA:
+          return (getLong(ERA) == newValue ? this : withYear(1 - this.year));
+      }
+      throw new TUnsupportedTemporalTypeException("Unsupported field: " + field);
+    }
+    return field.adjustInto(this, newValue);
+  }
+
+  public TLocalDate withYear(int year) {
+
+    if (this.year == year) {
+      return this;
+    }
+    YEAR.checkValidValue(year);
+    return resolvePreviousValid(year, this.month, this.day);
+  }
+
+  public TLocalDate withMonth(int month) {
+
+    if (this.month == month) {
+      return this;
+    }
+    MONTH_OF_YEAR.checkValidValue(month);
+    return resolvePreviousValid(this.year, month, this.day);
+  }
+
+  public TLocalDate withDayOfMonth(int dayOfMonth) {
+
+    if (this.day == dayOfMonth) {
+      return this;
+    }
+    return of(this.year, this.month, dayOfMonth);
+  }
+
+  public TLocalDate withDayOfYear(int dayOfYear) {
+
+    if (getDayOfYear() == dayOfYear) {
+      return this;
+    }
+    return ofYearDay(this.year, dayOfYear);
+  }
+
+  @Override
+  public TLocalDate plus(TTemporalAmount amountToAdd) {
+
+    if (amountToAdd instanceof TPeriod) {
+      TPeriod periodToAdd = (TPeriod) amountToAdd;
+      return plusMonths(periodToAdd.toTotalMonths()).plusDays(periodToAdd.getDays());
+    }
+    TObjects.requireNonNull(amountToAdd, "amountToAdd");
+    return (TLocalDate) amountToAdd.addTo(this);
+  }
+
+  @Override
+  public TLocalDate plus(long amountToAdd, TTemporalUnit unit) {
+
+    if (unit instanceof TChronoUnit) {
+      TChronoUnit f = (TChronoUnit) unit;
+      switch (f) {
+        case DAYS:
+          return plusDays(amountToAdd);
+        case WEEKS:
+          return plusWeeks(amountToAdd);
+        case MONTHS:
+          return plusMonths(amountToAdd);
+        case YEARS:
+          return plusYears(amountToAdd);
+        case DECADES:
+          return plusYears(Math.multiplyExact(amountToAdd, 10));
+        case CENTURIES:
+          return plusYears(Math.multiplyExact(amountToAdd, 100));
+        case MILLENNIA:
+          return plusYears(Math.multiplyExact(amountToAdd, 1000));
+        case ERAS:
+          return with(ERA, Math.addExact(getLong(ERA), amountToAdd));
+      }
+      throw new TUnsupportedTemporalTypeException("Unsupported unit: " + unit);
+    }
+    return unit.addTo(this, amountToAdd);
+  }
+
+  public TLocalDate plusYears(long yearsToAdd) {
+
+    if (yearsToAdd == 0) {
+      return this;
+    }
+    int newYear = YEAR.checkValidIntValue(this.year + yearsToAdd);
+    return resolvePreviousValid(newYear, this.month, this.day);
+  }
+
+  public TLocalDate plusMonths(long monthsToAdd) {
+
+    if (monthsToAdd == 0) {
+      return this;
+    }
+    long monthCount = this.year * 12L + (this.month - 1);
+    long calcMonths = monthCount + monthsToAdd;
+    int newYear = YEAR.checkValidIntValue(Math.floorDiv(calcMonths, 12));
+    int newMonth = Math.floorMod(calcMonths, 12) + 1;
+    return resolvePreviousValid(newYear, newMonth, this.day);
+  }
+
+  public TLocalDate plusWeeks(long weeksToAdd) {
+
+    return plusDays(Math.multiplyExact(weeksToAdd, 7));
+  }
+
+  public TLocalDate plusDays(long daysToAdd) {
+
+    if (daysToAdd == 0) {
+      return this;
+    }
+    long dom = this.day + daysToAdd;
+    if (dom > 0) {
+      if (dom <= 28) {
+        return new TLocalDate(this.year, this.month, (int) dom);
+      } else if (dom <= 59) {
+        long monthLen = lengthOfMonth();
+        if (dom <= monthLen) {
+          return new TLocalDate(this.year, this.month, (int) dom);
+        } else if (this.month < 12) {
+          return new TLocalDate(this.year, this.month + 1, (int) (dom - monthLen));
+        } else {
+          YEAR.checkValidValue(this.year + 1);
+          return new TLocalDate(this.year + 1, 1, (int) (dom - monthLen));
+        }
+      }
+    }
+
+    long mjDay = Math.addExact(toEpochDay(), daysToAdd);
+    return TLocalDate.ofEpochDay(mjDay);
+  }
+
+  @Override
+  public TLocalDate minus(TTemporalAmount amountToSubtract) {
+
+    if (amountToSubtract instanceof TPeriod) {
+      TPeriod periodToSubtract = (TPeriod) amountToSubtract;
+      return minusMonths(periodToSubtract.toTotalMonths()).minusDays(periodToSubtract.getDays());
+    }
+    TObjects.requireNonNull(amountToSubtract, "amountToSubtract");
+    return (TLocalDate) amountToSubtract.subtractFrom(this);
+  }
+
+  @Override
+  public TLocalDate minus(long amountToSubtract, TTemporalUnit unit) {
+
+    return (amountToSubtract == Long.MIN_VALUE ? plus(Long.MAX_VALUE, unit).plus(1, unit)
+        : plus(-amountToSubtract, unit));
+  }
+
+  public TLocalDate minusYears(long yearsToSubtract) {
+
+    return (yearsToSubtract == Long.MIN_VALUE ? plusYears(Long.MAX_VALUE).plusYears(1) : plusYears(-yearsToSubtract));
+  }
+
+  public TLocalDate minusMonths(long monthsToSubtract) {
+
+    return (monthsToSubtract == Long.MIN_VALUE ? plusMonths(Long.MAX_VALUE).plusMonths(1)
+        : plusMonths(-monthsToSubtract));
+  }
+
+  public TLocalDate minusWeeks(long weeksToSubtract) {
+
+    return (weeksToSubtract == Long.MIN_VALUE ? plusWeeks(Long.MAX_VALUE).plusWeeks(1) : plusWeeks(-weeksToSubtract));
+  }
+
+  public TLocalDate minusDays(long daysToSubtract) {
+
+    return (daysToSubtract == Long.MIN_VALUE ? plusDays(Long.MAX_VALUE).plusDays(1) : plusDays(-daysToSubtract));
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public <R> R query(TTemporalQuery<R> query) {
+
+    if (query == TTemporalQueries.localDate()) {
+      return (R) this;
+    }
+    return TChronoLocalDate.super.query(query);
+  }
+
+  @Override
+  public TTemporal adjustInto(TTemporal temporal) {
+
+    return TChronoLocalDate.super.adjustInto(temporal);
+  }
+
+  @Override
+  public long until(TTemporal endExclusive, TTemporalUnit unit) {
+
+    TLocalDate end = TLocalDate.from(endExclusive);
+    if (unit instanceof TChronoUnit) {
+      switch ((TChronoUnit) unit) {
+        case DAYS:
+          return daysUntil(end);
+        case WEEKS:
+          return daysUntil(end) / 7;
+        case MONTHS:
+          return monthsUntil(end);
+        case YEARS:
+          return monthsUntil(end) / 12;
+        case DECADES:
+          return monthsUntil(end) / 120;
+        case CENTURIES:
+          return monthsUntil(end) / 1200;
+        case MILLENNIA:
+          return monthsUntil(end) / 12000;
+        case ERAS:
+          return end.getLong(ERA) - getLong(ERA);
+      }
+      throw new TUnsupportedTemporalTypeException("Unsupported unit: " + unit);
+    }
+    return unit.between(this, end);
+  }
+
+  long daysUntil(TLocalDate end) {
+
+    return end.toEpochDay() - toEpochDay();
+  }
+
+  private long monthsUntil(TLocalDate end) {
+
+    long packed1 = getProlepticMonth() * 32L + getDayOfMonth();
+    long packed2 = end.getProlepticMonth() * 32L + end.getDayOfMonth();
+    return (packed2 - packed1) / 32;
+  }
+
+  @Override
+  public TPeriod until(TChronoLocalDate endDateExclusive) {
+
+    TLocalDate end = TLocalDate.from(endDateExclusive);
+    long totalMonths = end.getProlepticMonth() - getProlepticMonth();
+    int days = end.day - this.day;
+    if (totalMonths > 0 && days < 0) {
+      totalMonths--;
+      TLocalDate calcDate = plusMonths(totalMonths);
+      days = (int) (end.toEpochDay() - calcDate.toEpochDay());
+    } else if (totalMonths < 0 && days > 0) {
+      totalMonths++;
+      days -= end.lengthOfMonth();
+    }
+    long years = totalMonths / 12;
+    int months = (int) (totalMonths % 12);
+    return TPeriod.of(Math.toIntExact(years), months, days);
+  }
+
+  public TStream<TLocalDate> datesUntil(TLocalDate endExclusive) {
+
+    long end = endExclusive.toEpochDay();
+    long start = toEpochDay();
+    if (end < start) {
+      throw new IllegalArgumentException(endExclusive + " < " + this);
+    }
+    return TLongStream.range(start, end).mapToObj(TLocalDate::ofEpochDay);
+  }
+
+  public TStream<TLocalDate> datesUntil(TLocalDate endExclusive, TPeriod step) {
+
+    if (step.isZero()) {
+      throw new IllegalArgumentException("step is zero");
+    }
+    long end = endExclusive.toEpochDay();
+    long start = toEpochDay();
+    long until = end - start;
+    long months = step.toTotalMonths();
+    long days = step.getDays();
+    if ((months < 0 && days > 0) || (months > 0 && days < 0)) {
+      throw new IllegalArgumentException("period months and days are of opposite sign");
+    }
+    if (until == 0) {
+      return TStream.empty();
+    }
+    int sign = months > 0 || days > 0 ? 1 : -1;
+    if (sign < 0 ^ until < 0) {
+      throw new TIllegalArgumentException(endExclusive + (sign < 0 ? " > " : " < ") + this);
+    }
+    if (months == 0) {
+      long steps = (until - sign) / days;
+      return TLongStream.rangeClosed(0, steps).mapToObj(n -> TLocalDate.ofEpochDay(start + n * days));
+    }
+    long steps = until * 1600 / (months * 48699 + days * 1600) + 1;
+    long addMonths = months * steps;
+    long addDays = days * steps;
+    long maxAddMonths = months > 0 ? MAX.getProlepticMonth() - getProlepticMonth()
+        : getProlepticMonth() - MIN.getProlepticMonth();
+    if (addMonths * sign > maxAddMonths || (plusMonths(addMonths).toEpochDay() + addDays) * sign >= end * sign) {
+      steps--;
+      addMonths -= months;
+      addDays -= days;
+      if (addMonths * sign > maxAddMonths || (plusMonths(addMonths).toEpochDay() + addDays) * sign >= end * sign) {
+        steps--;
+      }
+    }
+    return TLongStream.rangeClosed(0, steps).mapToObj(n -> plusMonths(months * n).plusDays(days * n));
+  }
+
+  @Override
+  public String format(TDateTimeFormatter formatter) {
+
+    TObjects.requireNonNull(formatter, "formatter");
+    return formatter.format(this);
+  }
+
+  @Override
+  public TLocalDateTime atTime(TLocalTime time) {
+
+    return TLocalDateTime.of(this, time);
+  }
+
+  public TLocalDateTime atTime(int hour, int minute) {
+
+    return atTime(TLocalTime.of(hour, minute));
+  }
+
+  public TLocalDateTime atTime(int hour, int minute, int second) {
+
+    return atTime(TLocalTime.of(hour, minute, second));
+  }
+
+  public TLocalDateTime atTime(int hour, int minute, int second, int nanoOfSecond) {
+
+    return atTime(TLocalTime.of(hour, minute, second, nanoOfSecond));
+  }
+
+  public TOffsetDateTime atTime(TOffsetTime time) {
+
+    return TOffsetDateTime.of(TLocalDateTime.of(this, time.toLocalTime()), time.getOffset());
+  }
+
+  public TLocalDateTime atStartOfDay() {
+
+    return TLocalDateTime.of(this, TLocalTime.MIDNIGHT);
+  }
+
+  public TZonedDateTime atStartOfDay(TZoneId zone) {
+
+    TObjects.requireNonNull(zone, "zone");
+    // need to handle case where there is a gap from 11:30 to 00:30
+    // standard ZDT factory would result in 01:00 rather than 00:30
+    TLocalDateTime ldt = atTime(TLocalTime.MIDNIGHT);
+    if (zone instanceof TZoneOffset == false) {
+      // TZoneRules rules = zone.getRules();
+      // TZoneOffsetTransition trans = rules.getTransition(ldt);
+      // if (trans != null && trans.isGap()) {
+      // ldt = trans.getDateTimeAfter();
+      // }
+    }
+    return TZonedDateTime.of(ldt, zone);
+  }
+
+  @Override
+  public long toEpochDay() {
+
+    long y = this.year;
+    long m = this.month;
+    long total = 0;
+    total += 365 * y;
+    if (y >= 0) {
+      total += (y + 3) / 4 - (y + 99) / 100 + (y + 399) / 400;
+    } else {
+      total -= y / -4 - y / -100 + y / -400;
+    }
+    total += ((367 * m - 362) / 12);
+    total += this.day - 1;
+    if (m > 2) {
+      total--;
+      if (isLeapYear() == false) {
+        total--;
+      }
+    }
+    return total - DAYS_0000_TO_1970;
+  }
+
+  public long toEpochSecond(TLocalTime time, TZoneOffset offset) {
+
+    TObjects.requireNonNull(time, "time");
+    TObjects.requireNonNull(offset, "offset");
+    long secs = toEpochDay() * SECONDS_PER_DAY + time.toSecondOfDay();
+    secs -= offset.getTotalSeconds();
+    return secs;
+  }
+
+  @Override
+  public int compareTo(TChronoLocalDate other) {
+
+    if (other instanceof TLocalDate) {
+      return compareTo0((TLocalDate) other);
+    }
+    return TChronoLocalDate.super.compareTo(other);
+  }
+
+  int compareTo0(TLocalDate otherDate) {
+
+    int cmp = (this.year - otherDate.year);
+    if (cmp == 0) {
+      cmp = (this.month - otherDate.month);
+      if (cmp == 0) {
+        cmp = (this.day - otherDate.day);
+      }
+    }
+    return cmp;
+  }
+
+  @Override
+  public boolean isAfter(TChronoLocalDate other) {
+
+    if (other instanceof TLocalDate) {
+      return compareTo0((TLocalDate) other) > 0;
+    }
+    return TChronoLocalDate.super.isAfter(other);
+  }
+
+  @Override
+  public boolean isBefore(TChronoLocalDate other) {
+
+    if (other instanceof TLocalDate) {
+      return compareTo0((TLocalDate) other) < 0;
+    }
+    return TChronoLocalDate.super.isBefore(other);
+  }
+
+  @Override
+  public boolean isEqual(TChronoLocalDate other) {
+
+    if (other instanceof TLocalDate) {
+      return compareTo0((TLocalDate) other) == 0;
+    }
+    return TChronoLocalDate.super.isEqual(other);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+
+    if (this == obj) {
+      return true;
+    }
+    if (obj instanceof TLocalDate) {
+      return compareTo0((TLocalDate) obj) == 0;
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+
+    int yearValue = this.year;
+    int monthValue = this.month;
+    int dayValue = this.day;
+    return (yearValue & 0xFFFFF800) ^ ((yearValue << 11) + (monthValue << 6) + (dayValue));
+  }
+
+  @Override
+  public String toString() {
+
+    int yearValue = this.year;
+    int monthValue = this.month;
+    int dayValue = this.day;
+    int absYear = Math.abs(yearValue);
+    TStringBuilder buf = new TStringBuilder(10);
+    if (absYear < 1000) {
+      if (yearValue < 0) {
+        buf.append(yearValue - 10000).deleteCharAt(1);
+      } else {
+        buf.append(yearValue + 10000).deleteCharAt(0);
+      }
+    } else {
+      if (yearValue > 9999) {
+        buf.append('+');
+      }
+      buf.append(yearValue);
+    }
+    return buf.append(monthValue < 10 ? "-0" : "-").append(monthValue).append(dayValue < 10 ? "-0" : "-")
+        .append(dayValue).toString();
+  }
+
+  public static TLocalDate now() {
+
+    return now(TClock.systemDefaultZone());
+  }
+
+  public static TLocalDate now(TZoneId zone) {
+
+    return now(TClock.system(zone));
+  }
+
+  public static TLocalDate now(TClock clock) {
+
+    TObjects.requireNonNull(clock, "clock");
+    final TInstant now = clock.instant();
+    return ofInstant(now, clock.getZone());
+  }
+
+  public static TLocalDate of(int year, TMonth month, int dayOfMonth) {
+
+    YEAR.checkValidValue(year);
+    TObjects.requireNonNull(month, "month");
+    DAY_OF_MONTH.checkValidValue(dayOfMonth);
+    return create(year, month.getValue(), dayOfMonth);
+  }
+
+  public static TLocalDate of(int year, int month, int dayOfMonth) {
+
+    YEAR.checkValidValue(year);
+    MONTH_OF_YEAR.checkValidValue(month);
+    DAY_OF_MONTH.checkValidValue(dayOfMonth);
+    return create(year, month, dayOfMonth);
+  }
+
+  public static TLocalDate ofYearDay(int year, int dayOfYear) {
+
+    YEAR.checkValidValue(year);
+    DAY_OF_YEAR.checkValidValue(dayOfYear);
+    boolean leap = TYear.isLeap(year);
+    if (dayOfYear == 366 && leap == false) {
+      throw new TDateTimeException("Invalid date 'DayOfYear 366' as '" + year + "' is not a leap year");
+    }
+    TMonth moy = TMonth.of((dayOfYear - 1) / 31 + 1);
+    int monthEnd = moy.firstDayOfYear(leap) + moy.length(leap) - 1;
+    if (dayOfYear > monthEnd) {
+      moy = moy.plus(1);
+    }
+    int dom = dayOfYear - moy.firstDayOfYear(leap) + 1;
+    return new TLocalDate(year, moy.getValue(), dom);
+  }
+
+  public static TLocalDate ofInstant(TInstant instant, TZoneId zone) {
+
+    TObjects.requireNonNull(instant, "instant");
+    TObjects.requireNonNull(zone, "zone");
+    // TZoneRules rules = zone.getRules();
+    TZoneOffset offset = null; // rules.getOffset(instant);
+    long localSecond = instant.getEpochSecond() + offset.getTotalSeconds();
+    long localEpochDay = Math.floorDiv(localSecond, SECONDS_PER_DAY);
+    return ofEpochDay(localEpochDay);
+  }
+
+  public static TLocalDate ofEpochDay(long epochDay) {
+
+    EPOCH_DAY.checkValidValue(epochDay);
+    long zeroDay = epochDay + DAYS_0000_TO_1970;
+    zeroDay -= 60;
+    long adjust = 0;
+    if (zeroDay < 0) {
+      long adjustCycles = (zeroDay + 1) / DAYS_PER_CYCLE - 1;
+      adjust = adjustCycles * 400;
+      zeroDay += -adjustCycles * DAYS_PER_CYCLE;
+    }
+    long yearEst = (400 * zeroDay + 591) / DAYS_PER_CYCLE;
+    long doyEst = zeroDay - (365 * yearEst + yearEst / 4 - yearEst / 100 + yearEst / 400);
+    if (doyEst < 0) {
+      yearEst--;
+      doyEst = zeroDay - (365 * yearEst + yearEst / 4 - yearEst / 100 + yearEst / 400);
+    }
+    yearEst += adjust;
+    int marchDoy0 = (int) doyEst;
+
+    int marchMonth0 = (marchDoy0 * 5 + 2) / 153;
+    int month = (marchMonth0 + 2) % 12 + 1;
+    int dom = marchDoy0 - (marchMonth0 * 306 + 5) / 10 + 1;
+    yearEst += marchMonth0 / 10;
+
+    int year = YEAR.checkValidIntValue(yearEst);
+    return new TLocalDate(year, month, dom);
+  }
+
+  public static TLocalDate from(TTemporalAccessor temporal) {
+
+    TObjects.requireNonNull(temporal, "temporal");
+    TLocalDate date = temporal.query(TTemporalQueries.localDate());
+    if (date == null) {
+      throw new TDateTimeException("Unable to obtain LocalDate from TemporalAccessor: " + temporal + " of type "
+          + temporal.getClass().getName());
+    }
+    return date;
+  }
+
+  public static TLocalDate parse(CharSequence text) {
+
+    return parse(text, TDateTimeFormatter.ISO_LOCAL_DATE);
+  }
+
+  public static TLocalDate parse(CharSequence text, TDateTimeFormatter formatter) {
+
+    TObjects.requireNonNull(formatter, "formatter");
+    return formatter.parse(text, TLocalDate::from);
+  }
+
+  private static TLocalDate create(int year, int month, int dayOfMonth) {
+
+    if (dayOfMonth > 28) {
+      int dom = 31;
+      switch (month) {
+        case 2:
+          dom = (TYear.isLeap(year) ? 29 : 28);
+          break;
+        case 4:
+        case 6:
+        case 9:
+        case 11:
+          dom = 30;
+          break;
+      }
+      if (dayOfMonth > dom) {
+        if (dayOfMonth == 29) {
+          throw new TDateTimeException("Invalid date 'February 29' as '" + year + "' is not a leap year");
+        } else {
+          throw new TDateTimeException("Invalid date '" + TMonth.of(month).name() + " " + dayOfMonth + "'");
+        }
+      }
+    }
+    return new TLocalDate(year, month, dayOfMonth);
+  }
+
+  private static TLocalDate resolvePreviousValid(int year, int month, int day) {
+
+    switch (month) {
+      case 2:
+        day = TMath.min(day, TYear.isLeap(year) ? 29 : 28);
+        break;
+      case 4:
+      case 6:
+      case 9:
+      case 11:
+        day = TMath.min(day, 30);
+        break;
+    }
+    return new TLocalDate(year, month, day);
+  }
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/time/TLocalDateTime.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/time/TLocalDateTime.java
@@ -1,0 +1,681 @@
+package org.teavm.classlib.java.time;
+
+import static org.teavm.classlib.java.time.TLocalTime.HOURS_PER_DAY;
+import static org.teavm.classlib.java.time.TLocalTime.MICROS_PER_DAY;
+import static org.teavm.classlib.java.time.TLocalTime.MILLIS_PER_DAY;
+import static org.teavm.classlib.java.time.TLocalTime.MINUTES_PER_DAY;
+import static org.teavm.classlib.java.time.TLocalTime.NANOS_PER_DAY;
+import static org.teavm.classlib.java.time.TLocalTime.NANOS_PER_HOUR;
+import static org.teavm.classlib.java.time.TLocalTime.NANOS_PER_MINUTE;
+import static org.teavm.classlib.java.time.TLocalTime.NANOS_PER_SECOND;
+import static org.teavm.classlib.java.time.TLocalTime.SECONDS_PER_DAY;
+import static org.teavm.classlib.java.time.temporal.TChronoField.NANO_OF_SECOND;
+
+import org.teavm.classlib.java.io.TSerializable;
+import org.teavm.classlib.java.time.chrono.TChronoLocalDateTime;
+import org.teavm.classlib.java.time.format.TDateTimeFormatter;
+import org.teavm.classlib.java.time.temporal.TChronoField;
+import org.teavm.classlib.java.time.temporal.TChronoUnit;
+import org.teavm.classlib.java.time.temporal.TTemporal;
+import org.teavm.classlib.java.time.temporal.TTemporalAccessor;
+import org.teavm.classlib.java.time.temporal.TTemporalAdjuster;
+import org.teavm.classlib.java.time.temporal.TTemporalAmount;
+import org.teavm.classlib.java.time.temporal.TTemporalField;
+import org.teavm.classlib.java.time.temporal.TTemporalQueries;
+import org.teavm.classlib.java.time.temporal.TTemporalQuery;
+import org.teavm.classlib.java.time.temporal.TTemporalUnit;
+import org.teavm.classlib.java.time.temporal.TValueRange;
+import org.teavm.classlib.java.time.zone.TZoneRules;
+import org.teavm.classlib.java.util.TObjects;
+
+public final class TLocalDateTime
+    implements TTemporal, TTemporalAdjuster, TChronoLocalDateTime<TLocalDate>, TSerializable {
+
+  public static final TLocalDateTime MIN = TLocalDateTime.of(TLocalDate.MIN, TLocalTime.MIN);
+
+  public static final TLocalDateTime MAX = TLocalDateTime.of(TLocalDate.MAX, TLocalTime.MAX);
+
+  private final TLocalDate date;
+
+  private final TLocalTime time;
+
+  private TLocalDateTime(TLocalDate date, TLocalTime time) {
+
+    this.date = date;
+    this.time = time;
+  }
+
+  private TLocalDateTime with(TLocalDate newDate, TLocalTime newTime) {
+
+    if (this.date == newDate && this.time == newTime) {
+      return this;
+    }
+    return new TLocalDateTime(newDate, newTime);
+  }
+
+  @Override
+  public boolean isSupported(TTemporalField field) {
+
+    if (field instanceof TChronoField) {
+      TChronoField f = (TChronoField) field;
+      return f.isDateBased() || f.isTimeBased();
+    }
+    return field != null && field.isSupportedBy(this);
+  }
+
+  @Override
+  public boolean isSupported(TTemporalUnit unit) {
+
+    return TChronoLocalDateTime.super.isSupported(unit);
+  }
+
+  @Override
+  public TValueRange range(TTemporalField field) {
+
+    if (field instanceof TChronoField) {
+      TChronoField f = (TChronoField) field;
+      return (f.isTimeBased() ? this.time.range(field) : this.date.range(field));
+    }
+    return field.rangeRefinedBy(this);
+  }
+
+  @Override
+  public int get(TTemporalField field) {
+
+    if (field instanceof TChronoField) {
+      TChronoField f = (TChronoField) field;
+      return (f.isTimeBased() ? this.time.get(field) : this.date.get(field));
+    }
+    return TChronoLocalDateTime.super.get(field);
+  }
+
+  @Override
+  public long getLong(TTemporalField field) {
+
+    if (field instanceof TChronoField) {
+      TChronoField f = (TChronoField) field;
+      return (f.isTimeBased() ? this.time.getLong(field) : this.date.getLong(field));
+    }
+    return field.getFrom(this);
+  }
+
+  @Override
+  public TLocalDate toLocalDate() {
+
+    return this.date;
+  }
+
+  public int getYear() {
+
+    return this.date.getYear();
+  }
+
+  public int getMonthValue() {
+
+    return this.date.getMonthValue();
+  }
+
+  public TMonth getMonth() {
+
+    return this.date.getMonth();
+  }
+
+  public int getDayOfMonth() {
+
+    return this.date.getDayOfMonth();
+  }
+
+  public int getDayOfYear() {
+
+    return this.date.getDayOfYear();
+  }
+
+  public TDayOfWeek getDayOfWeek() {
+
+    return this.date.getDayOfWeek();
+  }
+
+  @Override
+  public TLocalTime toLocalTime() {
+
+    return this.time;
+  }
+
+  public int getHour() {
+
+    return this.time.getHour();
+  }
+
+  public int getMinute() {
+
+    return this.time.getMinute();
+  }
+
+  public int getSecond() {
+
+    return this.time.getSecond();
+  }
+
+  public int getNano() {
+
+    return this.time.getNano();
+  }
+
+  @Override
+  public TLocalDateTime with(TTemporalAdjuster adjuster) {
+
+    if (adjuster instanceof TLocalDate) {
+      return with((TLocalDate) adjuster, this.time);
+    } else if (adjuster instanceof TLocalTime) {
+      return with(this.date, (TLocalTime) adjuster);
+    } else if (adjuster instanceof TLocalDateTime) {
+      return (TLocalDateTime) adjuster;
+    }
+    return (TLocalDateTime) adjuster.adjustInto(this);
+  }
+
+  @Override
+  public TLocalDateTime with(TTemporalField field, long newValue) {
+
+    if (field instanceof TChronoField) {
+      TChronoField f = (TChronoField) field;
+      if (f.isTimeBased()) {
+        return with(this.date, this.time.with(field, newValue));
+      } else {
+        return with(this.date.with(field, newValue), this.time);
+      }
+    }
+    return field.adjustInto(this, newValue);
+  }
+
+  public TLocalDateTime withYear(int year) {
+
+    return with(this.date.withYear(year), this.time);
+  }
+
+  public TLocalDateTime withMonth(int month) {
+
+    return with(this.date.withMonth(month), this.time);
+  }
+
+  public TLocalDateTime withDayOfMonth(int dayOfMonth) {
+
+    return with(this.date.withDayOfMonth(dayOfMonth), this.time);
+  }
+
+  public TLocalDateTime withDayOfYear(int dayOfYear) {
+
+    return with(this.date.withDayOfYear(dayOfYear), this.time);
+  }
+
+  public TLocalDateTime withHour(int hour) {
+
+    TLocalTime newTime = this.time.withHour(hour);
+    return with(this.date, newTime);
+  }
+
+  public TLocalDateTime withMinute(int minute) {
+
+    TLocalTime newTime = this.time.withMinute(minute);
+    return with(this.date, newTime);
+  }
+
+  public TLocalDateTime withSecond(int second) {
+
+    TLocalTime newTime = this.time.withSecond(second);
+    return with(this.date, newTime);
+  }
+
+  public TLocalDateTime withNano(int nanoOfSecond) {
+
+    TLocalTime newTime = this.time.withNano(nanoOfSecond);
+    return with(this.date, newTime);
+  }
+
+  public TLocalDateTime truncatedTo(TTemporalUnit unit) {
+
+    return with(this.date, this.time.truncatedTo(unit));
+  }
+
+  @Override
+  public TLocalDateTime plus(TTemporalAmount amountToAdd) {
+
+    if (amountToAdd instanceof TPeriod) {
+      TPeriod periodToAdd = (TPeriod) amountToAdd;
+      return with(this.date.plus(periodToAdd), this.time);
+    }
+    TObjects.requireNonNull(amountToAdd, "amountToAdd");
+    return (TLocalDateTime) amountToAdd.addTo(this);
+  }
+
+  @Override
+  public TLocalDateTime plus(long amountToAdd, TTemporalUnit unit) {
+
+    if (unit instanceof TChronoUnit) {
+      TChronoUnit f = (TChronoUnit) unit;
+      switch (f) {
+        case NANOS:
+          return plusNanos(amountToAdd);
+        case MICROS:
+          return plusDays(amountToAdd / MICROS_PER_DAY).plusNanos((amountToAdd % MICROS_PER_DAY) * 1000);
+        case MILLIS:
+          return plusDays(amountToAdd / MILLIS_PER_DAY).plusNanos((amountToAdd % MILLIS_PER_DAY) * 1000_000);
+        case SECONDS:
+          return plusSeconds(amountToAdd);
+        case MINUTES:
+          return plusMinutes(amountToAdd);
+        case HOURS:
+          return plusHours(amountToAdd);
+        case HALF_DAYS:
+          return plusDays(amountToAdd / 256).plusHours((amountToAdd % 256) * 12); // no overflow (256 is multiple of 2)
+      }
+      return with(this.date.plus(amountToAdd, unit), this.time);
+    }
+    return unit.addTo(this, amountToAdd);
+  }
+
+  public TLocalDateTime plusYears(long years) {
+
+    TLocalDate newDate = this.date.plusYears(years);
+    return with(newDate, this.time);
+  }
+
+  public TLocalDateTime plusMonths(long months) {
+
+    TLocalDate newDate = this.date.plusMonths(months);
+    return with(newDate, this.time);
+  }
+
+  public TLocalDateTime plusWeeks(long weeks) {
+
+    TLocalDate newDate = this.date.plusWeeks(weeks);
+    return with(newDate, this.time);
+  }
+
+  public TLocalDateTime plusDays(long days) {
+
+    TLocalDate newDate = this.date.plusDays(days);
+    return with(newDate, this.time);
+  }
+
+  public TLocalDateTime plusHours(long hours) {
+
+    return plusWithOverflow(this.date, hours, 0, 0, 0, 1);
+  }
+
+  public TLocalDateTime plusMinutes(long minutes) {
+
+    return plusWithOverflow(this.date, 0, minutes, 0, 0, 1);
+  }
+
+  public TLocalDateTime plusSeconds(long seconds) {
+
+    return plusWithOverflow(this.date, 0, 0, seconds, 0, 1);
+  }
+
+  public TLocalDateTime plusNanos(long nanos) {
+
+    return plusWithOverflow(this.date, 0, 0, 0, nanos, 1);
+  }
+
+  @Override
+  public TLocalDateTime minus(TTemporalAmount amountToSubtract) {
+
+    if (amountToSubtract instanceof TPeriod) {
+      TPeriod periodToSubtract = (TPeriod) amountToSubtract;
+      return with(this.date.minus(periodToSubtract), this.time);
+    }
+    TObjects.requireNonNull(amountToSubtract, "amountToSubtract");
+    return (TLocalDateTime) amountToSubtract.subtractFrom(this);
+  }
+
+  @Override
+  public TLocalDateTime minus(long amountToSubtract, TTemporalUnit unit) {
+
+    return (amountToSubtract == Long.MIN_VALUE ? plus(Long.MAX_VALUE, unit).plus(1, unit)
+        : plus(-amountToSubtract, unit));
+  }
+
+  public TLocalDateTime minusYears(long years) {
+
+    return (years == Long.MIN_VALUE ? plusYears(Long.MAX_VALUE).plusYears(1) : plusYears(-years));
+  }
+
+  public TLocalDateTime minusMonths(long months) {
+
+    return (months == Long.MIN_VALUE ? plusMonths(Long.MAX_VALUE).plusMonths(1) : plusMonths(-months));
+  }
+
+  public TLocalDateTime minusWeeks(long weeks) {
+
+    return (weeks == Long.MIN_VALUE ? plusWeeks(Long.MAX_VALUE).plusWeeks(1) : plusWeeks(-weeks));
+  }
+
+  public TLocalDateTime minusDays(long days) {
+
+    return (days == Long.MIN_VALUE ? plusDays(Long.MAX_VALUE).plusDays(1) : plusDays(-days));
+  }
+
+  public TLocalDateTime minusHours(long hours) {
+
+    return plusWithOverflow(this.date, hours, 0, 0, 0, -1);
+  }
+
+  public TLocalDateTime minusMinutes(long minutes) {
+
+    return plusWithOverflow(this.date, 0, minutes, 0, 0, -1);
+  }
+
+  public TLocalDateTime minusSeconds(long seconds) {
+
+    return plusWithOverflow(this.date, 0, 0, seconds, 0, -1);
+  }
+
+  public TLocalDateTime minusNanos(long nanos) {
+
+    return plusWithOverflow(this.date, 0, 0, 0, nanos, -1);
+  }
+
+  private TLocalDateTime plusWithOverflow(TLocalDate newDate, long hours, long minutes, long seconds, long nanos,
+      int sign) {
+
+    if ((hours | minutes | seconds | nanos) == 0) {
+      return with(newDate, this.time);
+    }
+    long totDays = nanos / NANOS_PER_DAY + seconds / SECONDS_PER_DAY + minutes / MINUTES_PER_DAY
+        + hours / HOURS_PER_DAY;
+    totDays *= sign;
+    long totNanos = nanos % NANOS_PER_DAY + (seconds % SECONDS_PER_DAY) * NANOS_PER_SECOND
+        + (minutes % MINUTES_PER_DAY) * NANOS_PER_MINUTE + (hours % HOURS_PER_DAY) * NANOS_PER_HOUR;
+    long curNoD = this.time.toNanoOfDay();
+    totNanos = totNanos * sign + curNoD;
+    totDays += Math.floorDiv(totNanos, NANOS_PER_DAY);
+    long newNoD = Math.floorMod(totNanos, NANOS_PER_DAY);
+    TLocalTime newTime = (newNoD == curNoD ? this.time : TLocalTime.ofNanoOfDay(newNoD));
+    return with(newDate.plusDays(totDays), newTime);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public <R> R query(TTemporalQuery<R> query) {
+
+    if (query == TTemporalQueries.localDate()) {
+      return (R) this.date;
+    }
+    return TChronoLocalDateTime.super.query(query);
+  }
+
+  @Override
+  public TTemporal adjustInto(TTemporal temporal) {
+
+    return TChronoLocalDateTime.super.adjustInto(temporal);
+  }
+
+  @Override
+  public long until(TTemporal endExclusive, TTemporalUnit unit) {
+
+    TLocalDateTime end = TLocalDateTime.from(endExclusive);
+    if (unit instanceof TChronoUnit) {
+      if (unit.isTimeBased()) {
+        long amount = this.date.daysUntil(end.date);
+        if (amount == 0) {
+          return this.time.until(end.time, unit);
+        }
+        long timePart = end.time.toNanoOfDay() - this.time.toNanoOfDay();
+        if (amount > 0) {
+          amount--; // safe
+          timePart += NANOS_PER_DAY; // safe
+        } else {
+          amount++; // safe
+          timePart -= NANOS_PER_DAY; // safe
+        }
+        switch ((TChronoUnit) unit) {
+          case NANOS:
+            amount = Math.multiplyExact(amount, NANOS_PER_DAY);
+            break;
+          case MICROS:
+            amount = Math.multiplyExact(amount, MICROS_PER_DAY);
+            timePart = timePart / 1000;
+            break;
+          case MILLIS:
+            amount = Math.multiplyExact(amount, MILLIS_PER_DAY);
+            timePart = timePart / 1_000_000;
+            break;
+          case SECONDS:
+            amount = Math.multiplyExact(amount, SECONDS_PER_DAY);
+            timePart = timePart / NANOS_PER_SECOND;
+            break;
+          case MINUTES:
+            amount = Math.multiplyExact(amount, MINUTES_PER_DAY);
+            timePart = timePart / NANOS_PER_MINUTE;
+            break;
+          case HOURS:
+            amount = Math.multiplyExact(amount, HOURS_PER_DAY);
+            timePart = timePart / NANOS_PER_HOUR;
+            break;
+          case HALF_DAYS:
+            amount = Math.multiplyExact(amount, 2);
+            timePart = timePart / (NANOS_PER_HOUR * 12);
+            break;
+        }
+        return Math.addExact(amount, timePart);
+      }
+      TLocalDate endDate = end.date;
+      if (endDate.isAfter(this.date) && end.time.isBefore(this.time)) {
+        endDate = endDate.minusDays(1);
+      } else if (endDate.isBefore(this.date) && end.time.isAfter(this.time)) {
+        endDate = endDate.plusDays(1);
+      }
+      return this.date.until(endDate, unit);
+    }
+    return unit.between(this, end);
+  }
+
+  @Override
+  public String format(TDateTimeFormatter formatter) {
+
+    TObjects.requireNonNull(formatter, "formatter");
+    return formatter.format(this);
+  }
+
+  public TOffsetDateTime atOffset(TZoneOffset offset) {
+
+    return TOffsetDateTime.of(this, offset);
+  }
+
+  @Override
+  public TZonedDateTime atZone(TZoneId zone) {
+
+    return TZonedDateTime.of(this, zone);
+  }
+
+  @Override
+  public int compareTo(TChronoLocalDateTime<?> other) {
+
+    if (other instanceof TLocalDateTime) {
+      return compareTo0((TLocalDateTime) other);
+    }
+    return TChronoLocalDateTime.super.compareTo(other);
+  }
+
+  private int compareTo0(TLocalDateTime other) {
+
+    int cmp = this.date.compareTo0(other.toLocalDate());
+    if (cmp == 0) {
+      cmp = this.time.compareTo(other.toLocalTime());
+    }
+    return cmp;
+  }
+
+  @Override
+  public boolean isAfter(TChronoLocalDateTime<?> other) {
+
+    if (other instanceof TLocalDateTime) {
+      return compareTo0((TLocalDateTime) other) > 0;
+    }
+    return TChronoLocalDateTime.super.isAfter(other);
+  }
+
+  @Override
+  public boolean isBefore(TChronoLocalDateTime<?> other) {
+
+    if (other instanceof TLocalDateTime) {
+      return compareTo0((TLocalDateTime) other) < 0;
+    }
+    return TChronoLocalDateTime.super.isBefore(other);
+  }
+
+  @Override
+  public boolean isEqual(TChronoLocalDateTime<?> other) {
+
+    if (other instanceof TLocalDateTime) {
+      return compareTo0((TLocalDateTime) other) == 0;
+    }
+    return TChronoLocalDateTime.super.isEqual(other);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+
+    if (this == obj) {
+      return true;
+    }
+    if (obj instanceof TLocalDateTime) {
+      TLocalDateTime other = (TLocalDateTime) obj;
+      return this.date.equals(other.date) && this.time.equals(other.time);
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+
+    return this.date.hashCode() ^ this.time.hashCode();
+  }
+
+  @Override
+  public String toString() {
+
+    return this.date.toString() + 'T' + this.time.toString();
+  }
+
+  public static TLocalDateTime now() {
+
+    return now(TClock.systemDefaultZone());
+  }
+
+  public static TLocalDateTime now(TZoneId zone) {
+
+    return now(TClock.system(zone));
+  }
+
+  public static TLocalDateTime now(TClock clock) {
+
+    TObjects.requireNonNull(clock, "clock");
+    final TInstant now = clock.instant();
+    TZoneOffset offset = clock.getZone().getRules().getOffset(now);
+    return ofEpochSecond(now.getEpochSecond(), now.getNano(), offset);
+  }
+
+  public static TLocalDateTime of(int year, TMonth month, int dayOfMonth, int hour, int minute) {
+
+    TLocalDate date = TLocalDate.of(year, month, dayOfMonth);
+    TLocalTime time = TLocalTime.of(hour, minute);
+    return new TLocalDateTime(date, time);
+  }
+
+  public static TLocalDateTime of(int year, TMonth month, int dayOfMonth, int hour, int minute, int second) {
+
+    TLocalDate date = TLocalDate.of(year, month, dayOfMonth);
+    TLocalTime time = TLocalTime.of(hour, minute, second);
+    return new TLocalDateTime(date, time);
+  }
+
+  public static TLocalDateTime of(int year, TMonth month, int dayOfMonth, int hour, int minute, int second,
+      int nanoOfSecond) {
+
+    TLocalDate date = TLocalDate.of(year, month, dayOfMonth);
+    TLocalTime time = TLocalTime.of(hour, minute, second, nanoOfSecond);
+    return new TLocalDateTime(date, time);
+  }
+
+  public static TLocalDateTime of(int year, int month, int dayOfMonth, int hour, int minute) {
+
+    TLocalDate date = TLocalDate.of(year, month, dayOfMonth);
+    TLocalTime time = TLocalTime.of(hour, minute);
+    return new TLocalDateTime(date, time);
+  }
+
+  public static TLocalDateTime of(int year, int month, int dayOfMonth, int hour, int minute, int second) {
+
+    TLocalDate date = TLocalDate.of(year, month, dayOfMonth);
+    TLocalTime time = TLocalTime.of(hour, minute, second);
+    return new TLocalDateTime(date, time);
+  }
+
+  public static TLocalDateTime of(int year, int month, int dayOfMonth, int hour, int minute, int second,
+      int nanoOfSecond) {
+
+    TLocalDate date = TLocalDate.of(year, month, dayOfMonth);
+    TLocalTime time = TLocalTime.of(hour, minute, second, nanoOfSecond);
+    return new TLocalDateTime(date, time);
+  }
+
+  public static TLocalDateTime of(TLocalDate date, TLocalTime time) {
+
+    TObjects.requireNonNull(date, "date");
+    TObjects.requireNonNull(time, "time");
+    return new TLocalDateTime(date, time);
+  }
+
+  public static TLocalDateTime ofInstant(TInstant instant, TZoneId zone) {
+
+    TObjects.requireNonNull(instant, "instant");
+    TObjects.requireNonNull(zone, "zone");
+    TZoneRules rules = zone.getRules();
+    TZoneOffset offset = rules.getOffset(instant);
+    return ofEpochSecond(instant.getEpochSecond(), instant.getNano(), offset);
+  }
+
+  public static TLocalDateTime ofEpochSecond(long epochSecond, int nanoOfSecond, TZoneOffset offset) {
+
+    TObjects.requireNonNull(offset, "offset");
+    NANO_OF_SECOND.checkValidValue(nanoOfSecond);
+    long localSecond = epochSecond + offset.getTotalSeconds(); // overflow caught later
+    long localEpochDay = Math.floorDiv(localSecond, SECONDS_PER_DAY);
+    int secsOfDay = Math.floorMod(localSecond, SECONDS_PER_DAY);
+    TLocalDate date = TLocalDate.ofEpochDay(localEpochDay);
+    TLocalTime time = TLocalTime.ofNanoOfDay(secsOfDay * NANOS_PER_SECOND + nanoOfSecond);
+    return new TLocalDateTime(date, time);
+  }
+
+  public static TLocalDateTime from(TTemporalAccessor temporal) {
+
+    if (temporal instanceof TLocalDateTime) {
+      return (TLocalDateTime) temporal;
+    } else if (temporal instanceof TZonedDateTime) {
+      return ((TZonedDateTime) temporal).toLocalDateTime();
+    } else if (temporal instanceof TOffsetDateTime) {
+      return ((TOffsetDateTime) temporal).toLocalDateTime();
+    }
+    try {
+      TLocalDate date = TLocalDate.from(temporal);
+      TLocalTime time = TLocalTime.from(temporal);
+      return new TLocalDateTime(date, time);
+    } catch (TDateTimeException ex) {
+      throw new TDateTimeException("Unable to obtain LocalDateTime from TemporalAccessor: " + temporal + " of type "
+          + temporal.getClass().getName(), ex);
+    }
+  }
+
+  public static TLocalDateTime parse(CharSequence text) {
+
+    return parse(text, TDateTimeFormatter.ISO_LOCAL_DATE_TIME);
+  }
+
+  public static TLocalDateTime parse(CharSequence text, TDateTimeFormatter formatter) {
+
+    TObjects.requireNonNull(formatter, "formatter");
+    return formatter.parse(text, TLocalDateTime::from);
+  }
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/time/TLocalTime.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/time/TLocalTime.java
@@ -1,0 +1,700 @@
+package org.teavm.classlib.java.time;
+
+import static org.teavm.classlib.java.time.temporal.TChronoField.HOUR_OF_DAY;
+import static org.teavm.classlib.java.time.temporal.TChronoField.MICRO_OF_DAY;
+import static org.teavm.classlib.java.time.temporal.TChronoField.MINUTE_OF_HOUR;
+import static org.teavm.classlib.java.time.temporal.TChronoField.NANO_OF_DAY;
+import static org.teavm.classlib.java.time.temporal.TChronoField.NANO_OF_SECOND;
+import static org.teavm.classlib.java.time.temporal.TChronoField.SECOND_OF_DAY;
+import static org.teavm.classlib.java.time.temporal.TChronoField.SECOND_OF_MINUTE;
+import static org.teavm.classlib.java.time.temporal.TChronoUnit.NANOS;
+
+import org.teavm.classlib.java.io.TSerializable;
+import org.teavm.classlib.java.lang.TComparable;
+import org.teavm.classlib.java.time.format.TDateTimeFormatter;
+import org.teavm.classlib.java.time.temporal.TChronoField;
+import org.teavm.classlib.java.time.temporal.TChronoUnit;
+import org.teavm.classlib.java.time.temporal.TTemporal;
+import org.teavm.classlib.java.time.temporal.TTemporalAccessor;
+import org.teavm.classlib.java.time.temporal.TTemporalAdjuster;
+import org.teavm.classlib.java.time.temporal.TTemporalAmount;
+import org.teavm.classlib.java.time.temporal.TTemporalField;
+import org.teavm.classlib.java.time.temporal.TTemporalQueries;
+import org.teavm.classlib.java.time.temporal.TTemporalQuery;
+import org.teavm.classlib.java.time.temporal.TTemporalUnit;
+import org.teavm.classlib.java.time.temporal.TUnsupportedTemporalTypeException;
+import org.teavm.classlib.java.time.temporal.TValueRange;
+import org.teavm.classlib.java.util.TObjects;
+
+public final class TLocalTime implements TTemporal, TTemporalAdjuster, TComparable<TLocalTime>, TSerializable {
+
+  public static final TLocalTime MIN;
+
+  public static final TLocalTime MAX;
+
+  public static final TLocalTime MIDNIGHT;
+
+  public static final TLocalTime NOON;
+
+  private static final TLocalTime[] HOURS = new TLocalTime[24];
+  static {
+    for (int i = 0; i < HOURS.length; i++) {
+      HOURS[i] = new TLocalTime(i, 0, 0, 0);
+    }
+    MIDNIGHT = HOURS[0];
+    NOON = HOURS[12];
+    MIN = HOURS[0];
+    MAX = new TLocalTime(23, 59, 59, 999_999_999);
+  }
+
+  static final int HOURS_PER_DAY = 24;
+
+  static final int MINUTES_PER_HOUR = 60;
+
+  static final int MINUTES_PER_DAY = MINUTES_PER_HOUR * HOURS_PER_DAY;
+
+  static final int SECONDS_PER_MINUTE = 60;
+
+  static final int SECONDS_PER_HOUR = SECONDS_PER_MINUTE * MINUTES_PER_HOUR;
+
+  static final int SECONDS_PER_DAY = SECONDS_PER_HOUR * HOURS_PER_DAY;
+
+  static final long MILLIS_PER_DAY = SECONDS_PER_DAY * 1000L;
+
+  static final long MICROS_PER_DAY = SECONDS_PER_DAY * 1000_000L;
+
+  static final long NANOS_PER_MILLI = 1000_000L;
+
+  static final long NANOS_PER_SECOND = 1000_000_000L;
+
+  static final long NANOS_PER_MINUTE = NANOS_PER_SECOND * SECONDS_PER_MINUTE;
+
+  static final long NANOS_PER_HOUR = NANOS_PER_MINUTE * MINUTES_PER_HOUR;
+
+  static final long NANOS_PER_DAY = NANOS_PER_HOUR * HOURS_PER_DAY;
+
+  private final byte hour;
+
+  private final byte minute;
+
+  private final byte second;
+
+  private final int nano;
+
+  private TLocalTime(int hour, int minute, int second, int nanoOfSecond) {
+
+    this.hour = (byte) hour;
+    this.minute = (byte) minute;
+    this.second = (byte) second;
+    this.nano = nanoOfSecond;
+  }
+
+  @Override
+  public boolean isSupported(TTemporalField field) {
+
+    if (field instanceof TChronoField) {
+      return field.isTimeBased();
+    }
+    return field != null && field.isSupportedBy(this);
+  }
+
+  @Override
+  public boolean isSupported(TTemporalUnit unit) {
+
+    if (unit instanceof TChronoUnit) {
+      return unit.isTimeBased();
+    }
+    return unit != null && unit.isSupportedBy(this);
+  }
+
+  @Override
+  public TValueRange range(TTemporalField field) {
+
+    return TTemporal.super.range(field);
+  }
+
+  @Override
+  public int get(TTemporalField field) {
+
+    if (field instanceof TChronoField) {
+      return get0(field);
+    }
+    return TTemporal.super.get(field);
+  }
+
+  @Override
+  public long getLong(TTemporalField field) {
+
+    if (field instanceof TChronoField) {
+      if (field == NANO_OF_DAY) {
+        return toNanoOfDay();
+      }
+      if (field == MICRO_OF_DAY) {
+        return toNanoOfDay() / 1000;
+      }
+      return get0(field);
+    }
+    return field.getFrom(this);
+  }
+
+  private int get0(TTemporalField field) {
+
+    switch ((TChronoField) field) {
+      case NANO_OF_SECOND:
+        return this.nano;
+      case NANO_OF_DAY:
+        throw new TUnsupportedTemporalTypeException(
+            "Invalid field 'NanoOfDay' for get() method, use getLong() instead");
+      case MICRO_OF_SECOND:
+        return this.nano / 1000;
+      case MICRO_OF_DAY:
+        throw new TUnsupportedTemporalTypeException(
+            "Invalid field 'MicroOfDay' for get() method, use getLong() instead");
+      case MILLI_OF_SECOND:
+        return this.nano / 1000_000;
+      case MILLI_OF_DAY:
+        return (int) (toNanoOfDay() / 1000_000);
+      case SECOND_OF_MINUTE:
+        return this.second;
+      case SECOND_OF_DAY:
+        return toSecondOfDay();
+      case MINUTE_OF_HOUR:
+        return this.minute;
+      case MINUTE_OF_DAY:
+        return this.hour * 60 + this.minute;
+      case HOUR_OF_AMPM:
+        return this.hour % 12;
+      case CLOCK_HOUR_OF_AMPM:
+        int ham = this.hour % 12;
+        return (ham % 12 == 0 ? 12 : ham);
+      case HOUR_OF_DAY:
+        return this.hour;
+      case CLOCK_HOUR_OF_DAY:
+        return (this.hour == 0 ? 24 : this.hour);
+      case AMPM_OF_DAY:
+        return this.hour / 12;
+    }
+    throw new TUnsupportedTemporalTypeException("Unsupported field: " + field);
+  }
+
+  public int getHour() {
+
+    return this.hour;
+  }
+
+  public int getMinute() {
+
+    return this.minute;
+  }
+
+  public int getSecond() {
+
+    return this.second;
+  }
+
+  public int getNano() {
+
+    return this.nano;
+  }
+
+  @Override
+  public TLocalTime with(TTemporalAdjuster adjuster) {
+
+    // optimizations
+    if (adjuster instanceof TLocalTime) {
+      return (TLocalTime) adjuster;
+    }
+    return (TLocalTime) adjuster.adjustInto(this);
+  }
+
+  @Override
+  public TLocalTime with(TTemporalField field, long newValue) {
+
+    if (field instanceof TChronoField) {
+      TChronoField f = (TChronoField) field;
+      f.checkValidValue(newValue);
+      switch (f) {
+        case NANO_OF_SECOND:
+          return withNano((int) newValue);
+        case NANO_OF_DAY:
+          return TLocalTime.ofNanoOfDay(newValue);
+        case MICRO_OF_SECOND:
+          return withNano((int) newValue * 1000);
+        case MICRO_OF_DAY:
+          return TLocalTime.ofNanoOfDay(newValue * 1000);
+        case MILLI_OF_SECOND:
+          return withNano((int) newValue * 1000_000);
+        case MILLI_OF_DAY:
+          return TLocalTime.ofNanoOfDay(newValue * 1000_000);
+        case SECOND_OF_MINUTE:
+          return withSecond((int) newValue);
+        case SECOND_OF_DAY:
+          return plusSeconds(newValue - toSecondOfDay());
+        case MINUTE_OF_HOUR:
+          return withMinute((int) newValue);
+        case MINUTE_OF_DAY:
+          return plusMinutes(newValue - (this.hour * 60 + this.minute));
+        case HOUR_OF_AMPM:
+          return plusHours(newValue - (this.hour % 12));
+        case CLOCK_HOUR_OF_AMPM:
+          return plusHours((newValue == 12 ? 0 : newValue) - (this.hour % 12));
+        case HOUR_OF_DAY:
+          return withHour((int) newValue);
+        case CLOCK_HOUR_OF_DAY:
+          return withHour((int) (newValue == 24 ? 0 : newValue));
+        case AMPM_OF_DAY:
+          return plusHours((newValue - (this.hour / 12)) * 12);
+      }
+      throw new TUnsupportedTemporalTypeException("Unsupported field: " + field);
+    }
+    return field.adjustInto(this, newValue);
+  }
+
+  public TLocalTime withHour(int hour) {
+
+    if (this.hour == hour) {
+      return this;
+    }
+    HOUR_OF_DAY.checkValidValue(hour);
+    return create(hour, this.minute, this.second, this.nano);
+  }
+
+  public TLocalTime withMinute(int minute) {
+
+    if (this.minute == minute) {
+      return this;
+    }
+    MINUTE_OF_HOUR.checkValidValue(minute);
+    return create(this.hour, minute, this.second, this.nano);
+  }
+
+  public TLocalTime withSecond(int second) {
+
+    if (this.second == second) {
+      return this;
+    }
+    SECOND_OF_MINUTE.checkValidValue(second);
+    return create(this.hour, this.minute, second, this.nano);
+  }
+
+  public TLocalTime withNano(int nanoOfSecond) {
+
+    if (this.nano == nanoOfSecond) {
+      return this;
+    }
+    NANO_OF_SECOND.checkValidValue(nanoOfSecond);
+    return create(this.hour, this.minute, this.second, nanoOfSecond);
+  }
+
+  public TLocalTime truncatedTo(TTemporalUnit unit) {
+
+    if (unit == TChronoUnit.NANOS) {
+      return this;
+    }
+    TDuration unitDur = unit.getDuration();
+    if (unitDur.getSeconds() > SECONDS_PER_DAY) {
+      throw new TUnsupportedTemporalTypeException("Unit is too large to be used for truncation");
+    }
+    long dur = unitDur.toNanos();
+    if ((NANOS_PER_DAY % dur) != 0) {
+      throw new TUnsupportedTemporalTypeException("Unit must divide into a standard day without remainder");
+    }
+    long nod = toNanoOfDay();
+    return ofNanoOfDay((nod / dur) * dur);
+  }
+
+  @Override
+  public TLocalTime plus(TTemporalAmount amountToAdd) {
+
+    return (TLocalTime) amountToAdd.addTo(this);
+  }
+
+  @Override
+  public TLocalTime plus(long amountToAdd, TTemporalUnit unit) {
+
+    if (unit instanceof TChronoUnit) {
+      switch ((TChronoUnit) unit) {
+        case NANOS:
+          return plusNanos(amountToAdd);
+        case MICROS:
+          return plusNanos((amountToAdd % MICROS_PER_DAY) * 1000);
+        case MILLIS:
+          return plusNanos((amountToAdd % MILLIS_PER_DAY) * 1000_000);
+        case SECONDS:
+          return plusSeconds(amountToAdd);
+        case MINUTES:
+          return plusMinutes(amountToAdd);
+        case HOURS:
+          return plusHours(amountToAdd);
+        case HALF_DAYS:
+          return plusHours((amountToAdd % 2) * 12);
+      }
+      throw new TUnsupportedTemporalTypeException("Unsupported unit: " + unit);
+    }
+    return unit.addTo(this, amountToAdd);
+  }
+
+  public TLocalTime plusHours(long hoursToAdd) {
+
+    if (hoursToAdd == 0) {
+      return this;
+    }
+    int newHour = ((int) (hoursToAdd % HOURS_PER_DAY) + this.hour + HOURS_PER_DAY) % HOURS_PER_DAY;
+    return create(newHour, this.minute, this.second, this.nano);
+  }
+
+  public TLocalTime plusMinutes(long minutesToAdd) {
+
+    if (minutesToAdd == 0) {
+      return this;
+    }
+    int mofd = this.hour * MINUTES_PER_HOUR + this.minute;
+    int newMofd = ((int) (minutesToAdd % MINUTES_PER_DAY) + mofd + MINUTES_PER_DAY) % MINUTES_PER_DAY;
+    if (mofd == newMofd) {
+      return this;
+    }
+    int newHour = newMofd / MINUTES_PER_HOUR;
+    int newMinute = newMofd % MINUTES_PER_HOUR;
+    return create(newHour, newMinute, this.second, this.nano);
+  }
+
+  public TLocalTime plusSeconds(long secondstoAdd) {
+
+    if (secondstoAdd == 0) {
+      return this;
+    }
+    int sofd = this.hour * SECONDS_PER_HOUR + this.minute * SECONDS_PER_MINUTE + this.second;
+    int newSofd = ((int) (secondstoAdd % SECONDS_PER_DAY) + sofd + SECONDS_PER_DAY) % SECONDS_PER_DAY;
+    if (sofd == newSofd) {
+      return this;
+    }
+    int newHour = newSofd / SECONDS_PER_HOUR;
+    int newMinute = (newSofd / SECONDS_PER_MINUTE) % MINUTES_PER_HOUR;
+    int newSecond = newSofd % SECONDS_PER_MINUTE;
+    return create(newHour, newMinute, newSecond, this.nano);
+  }
+
+  public TLocalTime plusNanos(long nanosToAdd) {
+
+    if (nanosToAdd == 0) {
+      return this;
+    }
+    long nofd = toNanoOfDay();
+    long newNofd = ((nanosToAdd % NANOS_PER_DAY) + nofd + NANOS_PER_DAY) % NANOS_PER_DAY;
+    if (nofd == newNofd) {
+      return this;
+    }
+    int newHour = (int) (newNofd / NANOS_PER_HOUR);
+    int newMinute = (int) ((newNofd / NANOS_PER_MINUTE) % MINUTES_PER_HOUR);
+    int newSecond = (int) ((newNofd / NANOS_PER_SECOND) % SECONDS_PER_MINUTE);
+    int newNano = (int) (newNofd % NANOS_PER_SECOND);
+    return create(newHour, newMinute, newSecond, newNano);
+  }
+
+  @Override
+  public TLocalTime minus(TTemporalAmount amountToSubtract) {
+
+    return (TLocalTime) amountToSubtract.subtractFrom(this);
+  }
+
+  @Override
+  public TLocalTime minus(long amountToSubtract, TTemporalUnit unit) {
+
+    return (amountToSubtract == Long.MIN_VALUE ? plus(Long.MAX_VALUE, unit).plus(1, unit)
+        : plus(-amountToSubtract, unit));
+  }
+
+  public TLocalTime minusHours(long hoursToSubtract) {
+
+    return plusHours(-(hoursToSubtract % HOURS_PER_DAY));
+  }
+
+  public TLocalTime minusMinutes(long minutesToSubtract) {
+
+    return plusMinutes(-(minutesToSubtract % MINUTES_PER_DAY));
+  }
+
+  public TLocalTime minusSeconds(long secondsToSubtract) {
+
+    return plusSeconds(-(secondsToSubtract % SECONDS_PER_DAY));
+  }
+
+  public TLocalTime minusNanos(long nanosToSubtract) {
+
+    return plusNanos(-(nanosToSubtract % NANOS_PER_DAY));
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public <R> R query(TTemporalQuery<R> query) {
+
+    if (query == TTemporalQueries.chronology() || query == TTemporalQueries.zoneId() || query == TTemporalQueries.zone()
+        || query == TTemporalQueries.offset()) {
+      return null;
+    } else if (query == TTemporalQueries.localTime()) {
+      return (R) this;
+    } else if (query == TTemporalQueries.localDate()) {
+      return null;
+    } else if (query == TTemporalQueries.precision()) {
+      return (R) NANOS;
+    }
+    return query.queryFrom(this);
+  }
+
+  @Override
+  public TTemporal adjustInto(TTemporal temporal) {
+
+    return temporal.with(NANO_OF_DAY, toNanoOfDay());
+  }
+
+  @Override
+  public long until(TTemporal endExclusive, TTemporalUnit unit) {
+
+    TLocalTime end = TLocalTime.from(endExclusive);
+    if (unit instanceof TChronoUnit) {
+      long nanosUntil = end.toNanoOfDay() - toNanoOfDay();
+      switch ((TChronoUnit) unit) {
+        case NANOS:
+          return nanosUntil;
+        case MICROS:
+          return nanosUntil / 1000;
+        case MILLIS:
+          return nanosUntil / 1000_000;
+        case SECONDS:
+          return nanosUntil / NANOS_PER_SECOND;
+        case MINUTES:
+          return nanosUntil / NANOS_PER_MINUTE;
+        case HOURS:
+          return nanosUntil / NANOS_PER_HOUR;
+        case HALF_DAYS:
+          return nanosUntil / (12 * NANOS_PER_HOUR);
+      }
+      throw new TUnsupportedTemporalTypeException("Unsupported unit: " + unit);
+    }
+    return unit.between(this, end);
+  }
+
+  public String format(TDateTimeFormatter formatter) {
+
+    TObjects.requireNonNull(formatter, "formatter");
+    return formatter.format(this);
+  }
+
+  public TLocalDateTime atDate(TLocalDate date) {
+
+    return TLocalDateTime.of(date, this);
+  }
+
+  public TOffsetTime atOffset(TZoneOffset offset) {
+
+    return TOffsetTime.of(this, offset);
+  }
+
+  public int toSecondOfDay() {
+
+    int total = this.hour * SECONDS_PER_HOUR;
+    total += this.minute * SECONDS_PER_MINUTE;
+    total += this.second;
+    return total;
+  }
+
+  public long toNanoOfDay() {
+
+    long total = this.hour * NANOS_PER_HOUR;
+    total += this.minute * NANOS_PER_MINUTE;
+    total += this.second * NANOS_PER_SECOND;
+    total += this.nano;
+    return total;
+  }
+
+  public long toEpochSecond(TLocalDate date, TZoneOffset offset) {
+
+    TObjects.requireNonNull(date, "date");
+    TObjects.requireNonNull(offset, "offset");
+    long epochDay = date.toEpochDay();
+    long secs = epochDay * 86400 + toSecondOfDay();
+    secs -= offset.getTotalSeconds();
+    return secs;
+  }
+
+  @Override
+  public int compareTo(TLocalTime other) {
+
+    int cmp = Integer.compare(this.hour, other.hour);
+    if (cmp == 0) {
+      cmp = Integer.compare(this.minute, other.minute);
+      if (cmp == 0) {
+        cmp = Integer.compare(this.second, other.second);
+        if (cmp == 0) {
+          cmp = Integer.compare(this.nano, other.nano);
+        }
+      }
+    }
+    return cmp;
+  }
+
+  public boolean isAfter(TLocalTime other) {
+
+    return compareTo(other) > 0;
+  }
+
+  public boolean isBefore(TLocalTime other) {
+
+    return compareTo(other) < 0;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+
+    if (this == obj) {
+      return true;
+    }
+    if (obj instanceof TLocalTime) {
+      TLocalTime other = (TLocalTime) obj;
+      return this.hour == other.hour && this.minute == other.minute && this.second == other.second
+          && this.nano == other.nano;
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+
+    long nod = toNanoOfDay();
+    return (int) (nod ^ (nod >>> 32));
+  }
+
+  @Override
+  public String toString() {
+
+    StringBuilder buf = new StringBuilder(18);
+    int hourValue = this.hour;
+    int minuteValue = this.minute;
+    int secondValue = this.second;
+    int nanoValue = this.nano;
+    buf.append(hourValue < 10 ? "0" : "").append(hourValue).append(minuteValue < 10 ? ":0" : ":").append(minuteValue);
+    if (secondValue > 0 || nanoValue > 0) {
+      buf.append(secondValue < 10 ? ":0" : ":").append(secondValue);
+      if (nanoValue > 0) {
+        buf.append('.');
+        if (nanoValue % 1000_000 == 0) {
+          buf.append(Integer.toString((nanoValue / 1000_000) + 1000).substring(1));
+        } else if (nanoValue % 1000 == 0) {
+          buf.append(Integer.toString((nanoValue / 1000) + 1000_000).substring(1));
+        } else {
+          buf.append(Integer.toString((nanoValue) + 1000_000_000).substring(1));
+        }
+      }
+    }
+    return buf.toString();
+  }
+
+  public static TLocalTime now() {
+
+    return now(TClock.systemDefaultZone());
+  }
+
+  public static TLocalTime now(TZoneId zone) {
+
+    return now(TClock.system(zone));
+  }
+
+  public static TLocalTime now(TClock clock) {
+
+    TObjects.requireNonNull(clock, "clock");
+    final TInstant now = clock.instant();
+    return ofInstant(now, clock.getZone());
+  }
+
+  public static TLocalTime of(int hour, int minute) {
+
+    HOUR_OF_DAY.checkValidValue(hour);
+    if (minute == 0) {
+      return HOURS[hour];
+    }
+    MINUTE_OF_HOUR.checkValidValue(minute);
+    return new TLocalTime(hour, minute, 0, 0);
+  }
+
+  public static TLocalTime of(int hour, int minute, int second) {
+
+    HOUR_OF_DAY.checkValidValue(hour);
+    if ((minute | second) == 0) {
+      return HOURS[hour];
+    }
+    MINUTE_OF_HOUR.checkValidValue(minute);
+    SECOND_OF_MINUTE.checkValidValue(second);
+    return new TLocalTime(hour, minute, second, 0);
+  }
+
+  public static TLocalTime of(int hour, int minute, int second, int nanoOfSecond) {
+
+    HOUR_OF_DAY.checkValidValue(hour);
+    MINUTE_OF_HOUR.checkValidValue(minute);
+    SECOND_OF_MINUTE.checkValidValue(second);
+    NANO_OF_SECOND.checkValidValue(nanoOfSecond);
+    return create(hour, minute, second, nanoOfSecond);
+  }
+
+  public static TLocalTime ofInstant(TInstant instant, TZoneId zone) {
+
+    TObjects.requireNonNull(instant, "instant");
+    TObjects.requireNonNull(zone, "zone");
+    TZoneOffset offset = zone.getRules().getOffset(instant);
+    long localSecond = instant.getEpochSecond() + offset.getTotalSeconds();
+    int secsOfDay = Math.floorMod(localSecond, SECONDS_PER_DAY);
+    return ofNanoOfDay(secsOfDay * NANOS_PER_SECOND + instant.getNano());
+  }
+
+  public static TLocalTime ofSecondOfDay(long secondOfDay) {
+
+    SECOND_OF_DAY.checkValidValue(secondOfDay);
+    int hours = (int) (secondOfDay / SECONDS_PER_HOUR);
+    secondOfDay -= hours * SECONDS_PER_HOUR;
+    int minutes = (int) (secondOfDay / SECONDS_PER_MINUTE);
+    secondOfDay -= minutes * SECONDS_PER_MINUTE;
+    return create(hours, minutes, (int) secondOfDay, 0);
+  }
+
+  public static TLocalTime ofNanoOfDay(long nanoOfDay) {
+
+    NANO_OF_DAY.checkValidValue(nanoOfDay);
+    int hours = (int) (nanoOfDay / NANOS_PER_HOUR);
+    nanoOfDay -= hours * NANOS_PER_HOUR;
+    int minutes = (int) (nanoOfDay / NANOS_PER_MINUTE);
+    nanoOfDay -= minutes * NANOS_PER_MINUTE;
+    int seconds = (int) (nanoOfDay / NANOS_PER_SECOND);
+    nanoOfDay -= seconds * NANOS_PER_SECOND;
+    return create(hours, minutes, seconds, (int) nanoOfDay);
+  }
+
+  public static TLocalTime from(TTemporalAccessor temporal) {
+
+    TObjects.requireNonNull(temporal, "temporal");
+    TLocalTime time = temporal.query(TTemporalQueries.localTime());
+    if (time == null) {
+      throw new TDateTimeException("Unable to obtain LocalTime from TemporalAccessor: " + temporal + " of type "
+          + temporal.getClass().getName());
+    }
+    return time;
+  }
+
+  public static TLocalTime parse(CharSequence text) {
+
+    return parse(text, TDateTimeFormatter.ISO_LOCAL_TIME);
+  }
+
+  public static TLocalTime parse(CharSequence text, TDateTimeFormatter formatter) {
+
+    TObjects.requireNonNull(formatter, "formatter");
+    return formatter.parse(text, TLocalTime::from);
+  }
+
+  private static TLocalTime create(int hour, int minute, int second, int nanoOfSecond) {
+
+    if ((minute | second | nanoOfSecond) == 0) {
+      return HOURS[hour];
+    }
+    return new TLocalTime(hour, minute, second, nanoOfSecond);
+  }
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/time/TMonth.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/time/TMonth.java
@@ -1,0 +1,209 @@
+package org.teavm.classlib.java.time;
+
+import static org.teavm.classlib.java.time.temporal.TChronoField.MONTH_OF_YEAR;
+import static org.teavm.classlib.java.time.temporal.TChronoUnit.MONTHS;
+
+import org.teavm.classlib.java.time.chrono.TChronology;
+import org.teavm.classlib.java.time.chrono.TIsoChronology;
+import org.teavm.classlib.java.time.format.TDateTimeFormatterBuilder;
+import org.teavm.classlib.java.time.format.TTextStyle;
+import org.teavm.classlib.java.time.temporal.TChronoField;
+import org.teavm.classlib.java.time.temporal.TTemporal;
+import org.teavm.classlib.java.time.temporal.TTemporalAccessor;
+import org.teavm.classlib.java.time.temporal.TTemporalAdjuster;
+import org.teavm.classlib.java.time.temporal.TTemporalField;
+import org.teavm.classlib.java.time.temporal.TTemporalQueries;
+import org.teavm.classlib.java.time.temporal.TTemporalQuery;
+import org.teavm.classlib.java.time.temporal.TUnsupportedTemporalTypeException;
+import org.teavm.classlib.java.time.temporal.TValueRange;
+import org.teavm.classlib.java.util.TLocale;
+
+public enum TMonth implements TTemporalAccessor, TTemporalAdjuster {
+  JANUARY, FEBRUARY, MARCH, APRIL, MAY, JUNE, JULY, AUGUST, SEPTEMBER, OCTOBER, NOVEMBER, DECEMBER;
+
+  private static final TMonth[] ENUMS = TMonth.values();
+
+  public int getValue() {
+
+    return ordinal() + 1;
+  }
+
+  public String getDisplayName(TTextStyle style, TLocale locale) {
+
+    return new TDateTimeFormatterBuilder().appendText(MONTH_OF_YEAR, style).toFormatter(locale).format(this);
+  }
+
+  @Override
+  public boolean isSupported(TTemporalField field) {
+
+    if (field instanceof TChronoField) {
+      return field == MONTH_OF_YEAR;
+    }
+    return field != null && field.isSupportedBy(this);
+  }
+
+  @Override
+  public TValueRange range(TTemporalField field) {
+
+    if (field == MONTH_OF_YEAR) {
+      return field.range();
+    }
+    return TTemporalAccessor.super.range(field);
+  }
+
+  @Override
+  public int get(TTemporalField field) {
+
+    if (field == MONTH_OF_YEAR) {
+      return getValue();
+    }
+    return TTemporalAccessor.super.get(field);
+  }
+
+  @Override
+  public long getLong(TTemporalField field) {
+
+    if (field == MONTH_OF_YEAR) {
+      return getValue();
+    } else if (field instanceof TChronoField) {
+      throw new TUnsupportedTemporalTypeException("Unsupported field: " + field);
+    }
+    return field.getFrom(this);
+  }
+
+  public TMonth plus(long months) {
+
+    int amount = (int) (months % 12);
+    return ENUMS[(ordinal() + (amount + 12)) % 12];
+  }
+
+  public TMonth minus(long months) {
+
+    return plus(-(months % 12));
+  }
+
+  public int length(boolean leapYear) {
+
+    switch (this) {
+      case FEBRUARY:
+        return (leapYear ? 29 : 28);
+      case APRIL:
+      case JUNE:
+      case SEPTEMBER:
+      case NOVEMBER:
+        return 30;
+      default:
+        return 31;
+    }
+  }
+
+  public int minLength() {
+
+    switch (this) {
+      case FEBRUARY:
+        return 28;
+      case APRIL:
+      case JUNE:
+      case SEPTEMBER:
+      case NOVEMBER:
+        return 30;
+      default:
+        return 31;
+    }
+  }
+
+  public int maxLength() {
+
+    switch (this) {
+      case FEBRUARY:
+        return 29;
+      case APRIL:
+      case JUNE:
+      case SEPTEMBER:
+      case NOVEMBER:
+        return 30;
+      default:
+        return 31;
+    }
+  }
+
+  public int firstDayOfYear(boolean leapYear) {
+
+    int leap = leapYear ? 1 : 0;
+    switch (this) {
+      case JANUARY:
+        return 1;
+      case FEBRUARY:
+        return 32;
+      case MARCH:
+        return 60 + leap;
+      case APRIL:
+        return 91 + leap;
+      case MAY:
+        return 121 + leap;
+      case JUNE:
+        return 152 + leap;
+      case JULY:
+        return 182 + leap;
+      case AUGUST:
+        return 213 + leap;
+      case SEPTEMBER:
+        return 244 + leap;
+      case OCTOBER:
+        return 274 + leap;
+      case NOVEMBER:
+        return 305 + leap;
+      case DECEMBER:
+      default:
+        return 335 + leap;
+    }
+  }
+
+  public TMonth firstMonthOfQuarter() {
+
+    return ENUMS[(ordinal() / 3) * 3];
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public <R> R query(TTemporalQuery<R> query) {
+
+    if (query == TTemporalQueries.chronology()) {
+      return (R) TIsoChronology.INSTANCE;
+    } else if (query == TTemporalQueries.precision()) {
+      return (R) MONTHS;
+    }
+    return TTemporalAccessor.super.query(query);
+  }
+
+  @Override
+  public TTemporal adjustInto(TTemporal temporal) {
+
+    return temporal.with(MONTH_OF_YEAR, getValue());
+  }
+
+  public static TMonth of(int month) {
+
+    if (month < 1 || month > 12) {
+      throw new TDateTimeException("Invalid value for MonthOfYear: " + month);
+    }
+    return ENUMS[month - 1];
+  }
+
+  public static TMonth from(TTemporalAccessor temporal) {
+
+    if (temporal instanceof TMonth) {
+      return (TMonth) temporal;
+    }
+    try {
+      if (TIsoChronology.INSTANCE.equals(TChronology.from(temporal)) == false) {
+        temporal = TLocalDate.from(temporal);
+      }
+      return of(temporal.get(MONTH_OF_YEAR));
+    } catch (TDateTimeException ex) {
+      throw new TDateTimeException(
+          "Unable to obtain Month from TemporalAccessor: " + temporal + " of type " + temporal.getClass().getName(),
+          ex);
+    }
+  }
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/time/TMonthDay.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/time/TMonthDay.java
@@ -1,0 +1,263 @@
+package org.teavm.classlib.java.time;
+
+import static org.teavm.classlib.java.time.temporal.TChronoField.DAY_OF_MONTH;
+import static org.teavm.classlib.java.time.temporal.TChronoField.MONTH_OF_YEAR;
+
+import java.util.Objects;
+
+import org.teavm.classlib.java.io.TSerializable;
+import org.teavm.classlib.java.lang.TComparable;
+import org.teavm.classlib.java.lang.TMath;
+import org.teavm.classlib.java.lang.TStringBuilder;
+import org.teavm.classlib.java.time.chrono.TChronology;
+import org.teavm.classlib.java.time.chrono.TIsoChronology;
+import org.teavm.classlib.java.time.format.TDateTimeFormatter;
+import org.teavm.classlib.java.time.format.TDateTimeFormatterBuilder;
+import org.teavm.classlib.java.time.temporal.TChronoField;
+import org.teavm.classlib.java.time.temporal.TTemporal;
+import org.teavm.classlib.java.time.temporal.TTemporalAccessor;
+import org.teavm.classlib.java.time.temporal.TTemporalAdjuster;
+import org.teavm.classlib.java.time.temporal.TTemporalField;
+import org.teavm.classlib.java.time.temporal.TTemporalQueries;
+import org.teavm.classlib.java.time.temporal.TTemporalQuery;
+import org.teavm.classlib.java.time.temporal.TUnsupportedTemporalTypeException;
+import org.teavm.classlib.java.time.temporal.TValueRange;
+import org.teavm.classlib.java.util.TObjects;
+
+public final class TMonthDay implements TTemporalAccessor, TTemporalAdjuster, TComparable<TMonthDay>, TSerializable {
+
+  private static final TDateTimeFormatter PARSER = new TDateTimeFormatterBuilder().appendLiteral("--")
+      .appendValue(MONTH_OF_YEAR, 2).appendLiteral('-').appendValue(DAY_OF_MONTH, 2).toFormatter();
+
+  private final int month;
+
+  private final int day;
+
+  public static TMonthDay now() {
+
+    return now(TClock.systemDefaultZone());
+  }
+
+  public static TMonthDay now(TZoneId zone) {
+
+    return now(TClock.system(zone));
+  }
+
+  public static TMonthDay now(TClock clock) {
+
+    final TLocalDate now = TLocalDate.now(clock);
+    return TMonthDay.of(now.getMonth(), now.getDayOfMonth());
+  }
+
+  public static TMonthDay of(TMonth month, int dayOfMonth) {
+
+    TObjects.requireNonNull(month, "month");
+    DAY_OF_MONTH.checkValidValue(dayOfMonth);
+    if (dayOfMonth > month.maxLength()) {
+      throw new TDateTimeException(
+          "Illegal value for DayOfMonth field, value " + dayOfMonth + " is not valid for month " + month.name());
+    }
+    return new TMonthDay(month.getValue(), dayOfMonth);
+  }
+
+  public static TMonthDay of(int month, int dayOfMonth) {
+
+    return of(TMonth.of(month), dayOfMonth);
+  }
+
+  public static TMonthDay from(TTemporalAccessor temporal) {
+
+    if (temporal instanceof TMonthDay) {
+      return (TMonthDay) temporal;
+    }
+    try {
+      if (TIsoChronology.INSTANCE.equals(TChronology.from(temporal)) == false) {
+        temporal = TLocalDate.from(temporal);
+      }
+      return of(temporal.get(MONTH_OF_YEAR), temporal.get(DAY_OF_MONTH));
+    } catch (TDateTimeException ex) {
+      throw new TDateTimeException(
+          "Unable to obtain MonthDay from TemporalAccessor: " + temporal + " of type " + temporal.getClass().getName(),
+          ex);
+    }
+  }
+
+  public static TMonthDay parse(CharSequence text) {
+
+    return parse(text, PARSER);
+  }
+
+  public static TMonthDay parse(CharSequence text, TDateTimeFormatter formatter) {
+
+    TObjects.requireNonNull(formatter, "formatter");
+    return formatter.parse(text, TMonthDay::from);
+  }
+
+  private TMonthDay(int month, int dayOfMonth) {
+
+    this.month = month;
+    this.day = dayOfMonth;
+  }
+
+  @Override
+  public boolean isSupported(TTemporalField field) {
+
+    if (field instanceof TChronoField) {
+      return field == MONTH_OF_YEAR || field == DAY_OF_MONTH;
+    }
+    return field != null && field.isSupportedBy(this);
+  }
+
+  @Override
+  public TValueRange range(TTemporalField field) {
+
+    if (field == MONTH_OF_YEAR) {
+      return field.range();
+    } else if (field == DAY_OF_MONTH) {
+      return TValueRange.of(1, getMonth().minLength(), getMonth().maxLength());
+    }
+    return TTemporalAccessor.super.range(field);
+  }
+
+  @Override
+  public int get(TTemporalField field) {
+
+    return range(field).checkValidIntValue(getLong(field), field);
+  }
+
+  @Override
+  public long getLong(TTemporalField field) {
+
+    if (field instanceof TChronoField) {
+      switch ((TChronoField) field) {
+        case DAY_OF_MONTH:
+          return this.day;
+        case MONTH_OF_YEAR:
+          return this.month;
+      }
+      throw new TUnsupportedTemporalTypeException("Unsupported field: " + field);
+    }
+    return field.getFrom(this);
+  }
+
+  public int getMonthValue() {
+
+    return this.month;
+  }
+
+  public TMonth getMonth() {
+
+    return TMonth.of(this.month);
+  }
+
+  public int getDayOfMonth() {
+
+    return this.day;
+  }
+
+  public boolean isValidYear(int year) {
+
+    return (this.day == 29 && this.month == 2 && TYear.isLeap(year) == false) == false;
+  }
+
+  public TMonthDay withMonth(int month) {
+
+    return with(TMonth.of(month));
+  }
+
+  public TMonthDay with(TMonth month) {
+
+    Objects.requireNonNull(month, "month");
+    if (month.getValue() == this.month) {
+      return this;
+    }
+    int day = TMath.min(this.day, month.maxLength());
+    return new TMonthDay(month.getValue(), day);
+  }
+
+  public TMonthDay withDayOfMonth(int dayOfMonth) {
+
+    if (dayOfMonth == this.day) {
+      return this;
+    }
+    return of(this.month, dayOfMonth);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public <R> R query(TTemporalQuery<R> query) {
+
+    if (query == TTemporalQueries.chronology()) {
+      return (R) TIsoChronology.INSTANCE;
+    }
+    return TTemporalAccessor.super.query(query);
+  }
+
+  @Override
+  public TTemporal adjustInto(TTemporal temporal) {
+
+    if (TChronology.from(temporal).equals(TIsoChronology.INSTANCE) == false) {
+      throw new TDateTimeException("Adjustment only supported on ISO date-time");
+    }
+    temporal = temporal.with(MONTH_OF_YEAR, this.month);
+    return temporal.with(DAY_OF_MONTH, Math.min(temporal.range(DAY_OF_MONTH).getMaximum(), this.day));
+  }
+
+  public String format(TDateTimeFormatter formatter) {
+
+    TObjects.requireNonNull(formatter, "formatter");
+    return formatter.format(this);
+  }
+
+  public TLocalDate atYear(int year) {
+
+    return TLocalDate.of(year, this.month, isValidYear(year) ? this.day : 28);
+  }
+
+  @Override
+  public int compareTo(TMonthDay other) {
+
+    int cmp = (this.month - other.month);
+    if (cmp == 0) {
+      cmp = (this.day - other.day);
+    }
+    return cmp;
+  }
+
+  public boolean isAfter(TMonthDay other) {
+
+    return compareTo(other) > 0;
+  }
+
+  public boolean isBefore(TMonthDay other) {
+
+    return compareTo(other) < 0;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+
+    if (this == obj) {
+      return true;
+    }
+    if (obj instanceof TMonthDay) {
+      TMonthDay other = (TMonthDay) obj;
+      return this.month == other.month && this.day == other.day;
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+
+    return (this.month << 6) + this.day;
+  }
+
+  @Override
+  public String toString() {
+
+    return new TStringBuilder(10).append("--").append(this.month < 10 ? "0" : "").append(this.month)
+        .append(this.day < 10 ? "-0" : "-").append(this.day).toString();
+  }
+
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/time/TOffsetDateTime.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/time/TOffsetDateTime.java
@@ -1,0 +1,607 @@
+package org.teavm.classlib.java.time;
+
+import static org.teavm.classlib.java.time.temporal.TChronoField.EPOCH_DAY;
+import static org.teavm.classlib.java.time.temporal.TChronoField.INSTANT_SECONDS;
+import static org.teavm.classlib.java.time.temporal.TChronoField.NANO_OF_DAY;
+import static org.teavm.classlib.java.time.temporal.TChronoField.OFFSET_SECONDS;
+import static org.teavm.classlib.java.time.temporal.TChronoUnit.FOREVER;
+import static org.teavm.classlib.java.time.temporal.TChronoUnit.NANOS;
+
+import org.teavm.classlib.java.io.TSerializable;
+import org.teavm.classlib.java.lang.TComparable;
+import org.teavm.classlib.java.time.chrono.TIsoChronology;
+import org.teavm.classlib.java.time.format.TDateTimeFormatter;
+import org.teavm.classlib.java.time.temporal.TChronoField;
+import org.teavm.classlib.java.time.temporal.TChronoUnit;
+import org.teavm.classlib.java.time.temporal.TTemporal;
+import org.teavm.classlib.java.time.temporal.TTemporalAccessor;
+import org.teavm.classlib.java.time.temporal.TTemporalAdjuster;
+import org.teavm.classlib.java.time.temporal.TTemporalAmount;
+import org.teavm.classlib.java.time.temporal.TTemporalField;
+import org.teavm.classlib.java.time.temporal.TTemporalQueries;
+import org.teavm.classlib.java.time.temporal.TTemporalQuery;
+import org.teavm.classlib.java.time.temporal.TTemporalUnit;
+import org.teavm.classlib.java.time.temporal.TUnsupportedTemporalTypeException;
+import org.teavm.classlib.java.time.temporal.TValueRange;
+import org.teavm.classlib.java.time.zone.TZoneRules;
+import org.teavm.classlib.java.util.TComparator;
+import org.teavm.classlib.java.util.TObjects;
+
+public final class TOffsetDateTime
+    implements TTemporal, TTemporalAdjuster, TComparable<TOffsetDateTime>, TSerializable {
+
+  public static final TOffsetDateTime MIN = TLocalDateTime.MIN.atOffset(TZoneOffset.MAX);
+
+  public static final TOffsetDateTime MAX = TLocalDateTime.MAX.atOffset(TZoneOffset.MIN);
+
+  public static TComparator<TOffsetDateTime> timeLineOrder() {
+
+    return TOffsetDateTime::compareInstant;
+  }
+
+  private static int compareInstant(TOffsetDateTime datetime1, TOffsetDateTime datetime2) {
+
+    if (datetime1.getOffset().equals(datetime2.getOffset())) {
+      return datetime1.toLocalDateTime().compareTo(datetime2.toLocalDateTime());
+    }
+    int cmp = Long.compare(datetime1.toEpochSecond(), datetime2.toEpochSecond());
+    if (cmp == 0) {
+      cmp = datetime1.toLocalTime().getNano() - datetime2.toLocalTime().getNano();
+    }
+    return cmp;
+  }
+
+  private final TLocalDateTime dateTime;
+
+  private final TZoneOffset offset;
+
+  public static TOffsetDateTime now() {
+
+    return now(TClock.systemDefaultZone());
+  }
+
+  public static TOffsetDateTime now(TZoneId zone) {
+
+    return now(TClock.system(zone));
+  }
+
+  public static TOffsetDateTime now(TClock clock) {
+
+    TObjects.requireNonNull(clock, "clock");
+    final TInstant now = clock.instant();
+    return ofInstant(now, clock.getZone().getRules().getOffset(now));
+  }
+
+  public static TOffsetDateTime of(TLocalDate date, TLocalTime time, TZoneOffset offset) {
+
+    TLocalDateTime dt = TLocalDateTime.of(date, time);
+    return new TOffsetDateTime(dt, offset);
+  }
+
+  public static TOffsetDateTime of(TLocalDateTime dateTime, TZoneOffset offset) {
+
+    return new TOffsetDateTime(dateTime, offset);
+  }
+
+  public static TOffsetDateTime of(int year, int month, int dayOfMonth, int hour, int minute, int second,
+      int nanoOfSecond, TZoneOffset offset) {
+
+    TLocalDateTime dt = TLocalDateTime.of(year, month, dayOfMonth, hour, minute, second, nanoOfSecond);
+    return new TOffsetDateTime(dt, offset);
+  }
+
+  public static TOffsetDateTime ofInstant(TInstant instant, TZoneId zone) {
+
+    TObjects.requireNonNull(instant, "instant");
+    TObjects.requireNonNull(zone, "zone");
+    TZoneRules rules = zone.getRules();
+    TZoneOffset offset = rules.getOffset(instant);
+    TLocalDateTime ldt = TLocalDateTime.ofEpochSecond(instant.getEpochSecond(), instant.getNano(), offset);
+    return new TOffsetDateTime(ldt, offset);
+  }
+
+  public static TOffsetDateTime from(TTemporalAccessor temporal) {
+
+    if (temporal instanceof TOffsetDateTime) {
+      return (TOffsetDateTime) temporal;
+    }
+    try {
+      TZoneOffset offset = TZoneOffset.from(temporal);
+      TLocalDate date = temporal.query(TTemporalQueries.localDate());
+      TLocalTime time = temporal.query(TTemporalQueries.localTime());
+      if (date != null && time != null) {
+        return TOffsetDateTime.of(date, time, offset);
+      } else {
+        TInstant instant = TInstant.from(temporal);
+        return TOffsetDateTime.ofInstant(instant, offset);
+      }
+    } catch (TDateTimeException ex) {
+      throw new TDateTimeException("Unable to obtain OffsetDateTime from TemporalAccessor: " + temporal + " of type "
+          + temporal.getClass().getName(), ex);
+    }
+  }
+
+  public static TOffsetDateTime parse(CharSequence text) {
+
+    return parse(text, TDateTimeFormatter.ISO_OFFSET_DATE_TIME);
+  }
+
+  public static TOffsetDateTime parse(CharSequence text, TDateTimeFormatter formatter) {
+
+    TObjects.requireNonNull(formatter, "formatter");
+    return formatter.parse(text, TOffsetDateTime::from);
+  }
+
+  private TOffsetDateTime(TLocalDateTime dateTime, TZoneOffset offset) {
+
+    this.dateTime = TObjects.requireNonNull(dateTime, "dateTime");
+    this.offset = TObjects.requireNonNull(offset, "offset");
+  }
+
+  private TOffsetDateTime with(TLocalDateTime dateTime, TZoneOffset offset) {
+
+    if (this.dateTime == dateTime && this.offset.equals(offset)) {
+      return this;
+    }
+    return new TOffsetDateTime(dateTime, offset);
+  }
+
+  @Override
+  public boolean isSupported(TTemporalField field) {
+
+    return field instanceof TChronoField || (field != null && field.isSupportedBy(this));
+  }
+
+  @Override
+  public boolean isSupported(TTemporalUnit unit) {
+
+    if (unit instanceof TChronoUnit) {
+      return unit != FOREVER;
+    }
+    return unit != null && unit.isSupportedBy(this);
+  }
+
+  @Override
+  public TValueRange range(TTemporalField field) {
+
+    if (field instanceof TChronoField) {
+      if (field == INSTANT_SECONDS || field == OFFSET_SECONDS) {
+        return field.range();
+      }
+      return this.dateTime.range(field);
+    }
+    return field.rangeRefinedBy(this);
+  }
+
+  @Override
+  public int get(TTemporalField field) {
+
+    if (field instanceof TChronoField) {
+      switch ((TChronoField) field) {
+        case INSTANT_SECONDS:
+          throw new TUnsupportedTemporalTypeException(
+              "Invalid field 'InstantSeconds' for get() method, use getLong() instead");
+        case OFFSET_SECONDS:
+          return getOffset().getTotalSeconds();
+      }
+      return this.dateTime.get(field);
+    }
+    return TTemporal.super.get(field);
+  }
+
+  @Override
+  public long getLong(TTemporalField field) {
+
+    if (field instanceof TChronoField) {
+      switch ((TChronoField) field) {
+        case INSTANT_SECONDS:
+          return toEpochSecond();
+        case OFFSET_SECONDS:
+          return getOffset().getTotalSeconds();
+      }
+      return this.dateTime.getLong(field);
+    }
+    return field.getFrom(this);
+  }
+
+  public TZoneOffset getOffset() {
+
+    return this.offset;
+  }
+
+  public TOffsetDateTime withOffsetSameLocal(TZoneOffset offset) {
+
+    return with(this.dateTime, offset);
+  }
+
+  public TOffsetDateTime withOffsetSameInstant(TZoneOffset offset) {
+
+    if (offset.equals(this.offset)) {
+      return this;
+    }
+    int difference = offset.getTotalSeconds() - this.offset.getTotalSeconds();
+    TLocalDateTime adjusted = this.dateTime.plusSeconds(difference);
+    return new TOffsetDateTime(adjusted, offset);
+  }
+
+  public TLocalDateTime toLocalDateTime() {
+
+    return this.dateTime;
+  }
+
+  public TLocalDate toLocalDate() {
+
+    return this.dateTime.toLocalDate();
+  }
+
+  public int getYear() {
+
+    return this.dateTime.getYear();
+  }
+
+  public int getMonthValue() {
+
+    return this.dateTime.getMonthValue();
+  }
+
+  public TMonth getMonth() {
+
+    return this.dateTime.getMonth();
+  }
+
+  public int getDayOfMonth() {
+
+    return this.dateTime.getDayOfMonth();
+  }
+
+  public int getDayOfYear() {
+
+    return this.dateTime.getDayOfYear();
+  }
+
+  public TDayOfWeek getDayOfWeek() {
+
+    return this.dateTime.getDayOfWeek();
+  }
+
+  public TLocalTime toLocalTime() {
+
+    return this.dateTime.toLocalTime();
+  }
+
+  public int getHour() {
+
+    return this.dateTime.getHour();
+  }
+
+  public int getMinute() {
+
+    return this.dateTime.getMinute();
+  }
+
+  public int getSecond() {
+
+    return this.dateTime.getSecond();
+  }
+
+  public int getNano() {
+
+    return this.dateTime.getNano();
+  }
+
+  @Override
+  public TOffsetDateTime with(TTemporalAdjuster adjuster) {
+
+    // optimizations
+    if (adjuster instanceof TLocalDate || adjuster instanceof TLocalTime || adjuster instanceof TLocalDateTime) {
+      return with(this.dateTime.with(adjuster), this.offset);
+    } else if (adjuster instanceof TInstant) {
+      return ofInstant((TInstant) adjuster, this.offset);
+    } else if (adjuster instanceof TZoneOffset) {
+      return with(this.dateTime, (TZoneOffset) adjuster);
+    } else if (adjuster instanceof TOffsetDateTime) {
+      return (TOffsetDateTime) adjuster;
+    }
+    return (TOffsetDateTime) adjuster.adjustInto(this);
+  }
+
+  @Override
+  public TOffsetDateTime with(TTemporalField field, long newValue) {
+
+    if (field instanceof TChronoField) {
+      TChronoField f = (TChronoField) field;
+      switch (f) {
+        case INSTANT_SECONDS:
+          return ofInstant(TInstant.ofEpochSecond(newValue, getNano()), this.offset);
+        case OFFSET_SECONDS: {
+          return with(this.dateTime, TZoneOffset.ofTotalSeconds(f.checkValidIntValue(newValue)));
+        }
+      }
+      return with(this.dateTime.with(field, newValue), this.offset);
+    }
+    return field.adjustInto(this, newValue);
+  }
+
+  public TOffsetDateTime withYear(int year) {
+
+    return with(this.dateTime.withYear(year), this.offset);
+  }
+
+  public TOffsetDateTime withMonth(int month) {
+
+    return with(this.dateTime.withMonth(month), this.offset);
+  }
+
+  public TOffsetDateTime withDayOfMonth(int dayOfMonth) {
+
+    return with(this.dateTime.withDayOfMonth(dayOfMonth), this.offset);
+  }
+
+  public TOffsetDateTime withDayOfYear(int dayOfYear) {
+
+    return with(this.dateTime.withDayOfYear(dayOfYear), this.offset);
+  }
+
+  public TOffsetDateTime withHour(int hour) {
+
+    return with(this.dateTime.withHour(hour), this.offset);
+  }
+
+  public TOffsetDateTime withMinute(int minute) {
+
+    return with(this.dateTime.withMinute(minute), this.offset);
+  }
+
+  public TOffsetDateTime withSecond(int second) {
+
+    return with(this.dateTime.withSecond(second), this.offset);
+  }
+
+  public TOffsetDateTime withNano(int nanoOfSecond) {
+
+    return with(this.dateTime.withNano(nanoOfSecond), this.offset);
+  }
+
+  public TOffsetDateTime truncatedTo(TTemporalUnit unit) {
+
+    return with(this.dateTime.truncatedTo(unit), this.offset);
+  }
+
+  @Override
+  public TOffsetDateTime plus(TTemporalAmount amountToAdd) {
+
+    return (TOffsetDateTime) amountToAdd.addTo(this);
+  }
+
+  @Override
+  public TOffsetDateTime plus(long amountToAdd, TTemporalUnit unit) {
+
+    if (unit instanceof TChronoUnit) {
+      return with(this.dateTime.plus(amountToAdd, unit), this.offset);
+    }
+    return unit.addTo(this, amountToAdd);
+  }
+
+  public TOffsetDateTime plusYears(long years) {
+
+    return with(this.dateTime.plusYears(years), this.offset);
+  }
+
+  public TOffsetDateTime plusMonths(long months) {
+
+    return with(this.dateTime.plusMonths(months), this.offset);
+  }
+
+  public TOffsetDateTime plusWeeks(long weeks) {
+
+    return with(this.dateTime.plusWeeks(weeks), this.offset);
+  }
+
+  public TOffsetDateTime plusDays(long days) {
+
+    return with(this.dateTime.plusDays(days), this.offset);
+  }
+
+  public TOffsetDateTime plusHours(long hours) {
+
+    return with(this.dateTime.plusHours(hours), this.offset);
+  }
+
+  public TOffsetDateTime plusMinutes(long minutes) {
+
+    return with(this.dateTime.plusMinutes(minutes), this.offset);
+  }
+
+  public TOffsetDateTime plusSeconds(long seconds) {
+
+    return with(this.dateTime.plusSeconds(seconds), this.offset);
+  }
+
+  public TOffsetDateTime plusNanos(long nanos) {
+
+    return with(this.dateTime.plusNanos(nanos), this.offset);
+  }
+
+  @Override
+  public TOffsetDateTime minus(TTemporalAmount amountToSubtract) {
+
+    return (TOffsetDateTime) amountToSubtract.subtractFrom(this);
+  }
+
+  @Override
+  public TOffsetDateTime minus(long amountToSubtract, TTemporalUnit unit) {
+
+    return (amountToSubtract == Long.MIN_VALUE ? plus(Long.MAX_VALUE, unit).plus(1, unit)
+        : plus(-amountToSubtract, unit));
+  }
+
+  public TOffsetDateTime minusYears(long years) {
+
+    return (years == Long.MIN_VALUE ? plusYears(Long.MAX_VALUE).plusYears(1) : plusYears(-years));
+  }
+
+  public TOffsetDateTime minusMonths(long months) {
+
+    return (months == Long.MIN_VALUE ? plusMonths(Long.MAX_VALUE).plusMonths(1) : plusMonths(-months));
+  }
+
+  public TOffsetDateTime minusWeeks(long weeks) {
+
+    return (weeks == Long.MIN_VALUE ? plusWeeks(Long.MAX_VALUE).plusWeeks(1) : plusWeeks(-weeks));
+  }
+
+  public TOffsetDateTime minusDays(long days) {
+
+    return (days == Long.MIN_VALUE ? plusDays(Long.MAX_VALUE).plusDays(1) : plusDays(-days));
+  }
+
+  public TOffsetDateTime minusHours(long hours) {
+
+    return (hours == Long.MIN_VALUE ? plusHours(Long.MAX_VALUE).plusHours(1) : plusHours(-hours));
+  }
+
+  public TOffsetDateTime minusMinutes(long minutes) {
+
+    return (minutes == Long.MIN_VALUE ? plusMinutes(Long.MAX_VALUE).plusMinutes(1) : plusMinutes(-minutes));
+  }
+
+  public TOffsetDateTime minusSeconds(long seconds) {
+
+    return (seconds == Long.MIN_VALUE ? plusSeconds(Long.MAX_VALUE).plusSeconds(1) : plusSeconds(-seconds));
+  }
+
+  public TOffsetDateTime minusNanos(long nanos) {
+
+    return (nanos == Long.MIN_VALUE ? plusNanos(Long.MAX_VALUE).plusNanos(1) : plusNanos(-nanos));
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public <R> R query(TTemporalQuery<R> query) {
+
+    if (query == TTemporalQueries.offset() || query == TTemporalQueries.zone()) {
+      return (R) getOffset();
+    } else if (query == TTemporalQueries.zoneId()) {
+      return null;
+    } else if (query == TTemporalQueries.localDate()) {
+      return (R) toLocalDate();
+    } else if (query == TTemporalQueries.localTime()) {
+      return (R) toLocalTime();
+    } else if (query == TTemporalQueries.chronology()) {
+      return (R) TIsoChronology.INSTANCE;
+    } else if (query == TTemporalQueries.precision()) {
+      return (R) NANOS;
+    }
+    return query.queryFrom(this);
+  }
+
+  @Override
+  public TTemporal adjustInto(TTemporal temporal) {
+
+    return temporal.with(EPOCH_DAY, toLocalDate().toEpochDay()).with(NANO_OF_DAY, toLocalTime().toNanoOfDay())
+        .with(OFFSET_SECONDS, getOffset().getTotalSeconds());
+  }
+
+  @Override
+  public long until(TTemporal endExclusive, TTemporalUnit unit) {
+
+    TOffsetDateTime end = TOffsetDateTime.from(endExclusive);
+    if (unit instanceof TChronoUnit) {
+      end = end.withOffsetSameInstant(this.offset);
+      return this.dateTime.until(end.dateTime, unit);
+    }
+    return unit.between(this, end);
+  }
+
+  public String format(TDateTimeFormatter formatter) {
+
+    TObjects.requireNonNull(formatter, "formatter");
+    return formatter.format(this);
+  }
+
+  public TZonedDateTime atZoneSameInstant(TZoneId zone) {
+
+    return TZonedDateTime.ofInstant(this.dateTime, this.offset, zone);
+  }
+
+  public TZonedDateTime atZoneSimilarLocal(TZoneId zone) {
+
+    return TZonedDateTime.ofLocal(this.dateTime, zone, this.offset);
+  }
+
+  public TOffsetTime toOffsetTime() {
+
+    return TOffsetTime.of(this.dateTime.toLocalTime(), this.offset);
+  }
+
+  public TZonedDateTime toZonedDateTime() {
+
+    return TZonedDateTime.of(this.dateTime, this.offset);
+  }
+
+  public TInstant toInstant() {
+
+    return this.dateTime.toInstant(this.offset);
+  }
+
+  public long toEpochSecond() {
+
+    return this.dateTime.toEpochSecond(this.offset);
+  }
+
+  @Override
+  public int compareTo(TOffsetDateTime other) {
+
+    int cmp = compareInstant(this, other);
+    if (cmp == 0) {
+      cmp = toLocalDateTime().compareTo(other.toLocalDateTime());
+    }
+    return cmp;
+  }
+
+  public boolean isAfter(TOffsetDateTime other) {
+
+    long thisEpochSec = toEpochSecond();
+    long otherEpochSec = other.toEpochSecond();
+    return thisEpochSec > otherEpochSec
+        || (thisEpochSec == otherEpochSec && toLocalTime().getNano() > other.toLocalTime().getNano());
+  }
+
+  public boolean isBefore(TOffsetDateTime other) {
+
+    long thisEpochSec = toEpochSecond();
+    long otherEpochSec = other.toEpochSecond();
+    return thisEpochSec < otherEpochSec
+        || (thisEpochSec == otherEpochSec && toLocalTime().getNano() < other.toLocalTime().getNano());
+  }
+
+  public boolean isEqual(TOffsetDateTime other) {
+
+    return toEpochSecond() == other.toEpochSecond() && toLocalTime().getNano() == other.toLocalTime().getNano();
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+
+    if (this == obj) {
+      return true;
+    }
+    if (obj instanceof TOffsetDateTime) {
+      TOffsetDateTime other = (TOffsetDateTime) obj;
+      return this.dateTime.equals(other.dateTime) && this.offset.equals(other.offset);
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+
+    return this.dateTime.hashCode() ^ this.offset.hashCode();
+  }
+
+  @Override
+  public String toString() {
+
+    return this.dateTime.toString() + this.offset.toString();
+  }
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/time/TOffsetTime.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/time/TOffsetTime.java
@@ -1,0 +1,460 @@
+package org.teavm.classlib.java.time;
+
+import static org.teavm.classlib.java.time.TLocalTime.NANOS_PER_HOUR;
+import static org.teavm.classlib.java.time.TLocalTime.NANOS_PER_MINUTE;
+import static org.teavm.classlib.java.time.TLocalTime.NANOS_PER_SECOND;
+import static org.teavm.classlib.java.time.TLocalTime.SECONDS_PER_DAY;
+import static org.teavm.classlib.java.time.temporal.TChronoField.NANO_OF_DAY;
+import static org.teavm.classlib.java.time.temporal.TChronoField.OFFSET_SECONDS;
+import static org.teavm.classlib.java.time.temporal.TChronoUnit.NANOS;
+
+import org.teavm.classlib.java.io.TSerializable;
+import org.teavm.classlib.java.lang.TComparable;
+import org.teavm.classlib.java.time.format.TDateTimeFormatter;
+import org.teavm.classlib.java.time.temporal.TChronoField;
+import org.teavm.classlib.java.time.temporal.TChronoUnit;
+import org.teavm.classlib.java.time.temporal.TTemporal;
+import org.teavm.classlib.java.time.temporal.TTemporalAccessor;
+import org.teavm.classlib.java.time.temporal.TTemporalAdjuster;
+import org.teavm.classlib.java.time.temporal.TTemporalAmount;
+import org.teavm.classlib.java.time.temporal.TTemporalField;
+import org.teavm.classlib.java.time.temporal.TTemporalQueries;
+import org.teavm.classlib.java.time.temporal.TTemporalQuery;
+import org.teavm.classlib.java.time.temporal.TTemporalUnit;
+import org.teavm.classlib.java.time.temporal.TUnsupportedTemporalTypeException;
+import org.teavm.classlib.java.time.temporal.TValueRange;
+import org.teavm.classlib.java.time.zone.TZoneRules;
+import org.teavm.classlib.java.util.TObjects;
+
+public final class TOffsetTime implements TTemporal, TTemporalAdjuster, TComparable<TOffsetTime>, TSerializable {
+
+  public static final TOffsetTime MIN = TLocalTime.MIN.atOffset(TZoneOffset.MAX);
+
+  public static final TOffsetTime MAX = TLocalTime.MAX.atOffset(TZoneOffset.MIN);
+
+  private final TLocalTime time;
+
+  private final TZoneOffset offset;
+
+  public static TOffsetTime now() {
+
+    return now(TClock.systemDefaultZone());
+  }
+
+  public static TOffsetTime now(TZoneId zone) {
+
+    return now(TClock.system(zone));
+  }
+
+  public static TOffsetTime now(TClock clock) {
+
+    TObjects.requireNonNull(clock, "clock");
+    final TInstant now = clock.instant();
+    return ofInstant(now, clock.getZone().getRules().getOffset(now));
+  }
+
+  public static TOffsetTime of(TLocalTime time, TZoneOffset offset) {
+
+    return new TOffsetTime(time, offset);
+  }
+
+  public static TOffsetTime of(int hour, int minute, int second, int nanoOfSecond, TZoneOffset offset) {
+
+    return new TOffsetTime(TLocalTime.of(hour, minute, second, nanoOfSecond), offset);
+  }
+
+  public static TOffsetTime ofInstant(TInstant instant, TZoneId zone) {
+
+    TObjects.requireNonNull(instant, "instant");
+    TObjects.requireNonNull(zone, "zone");
+    TZoneRules rules = zone.getRules();
+    TZoneOffset offset = rules.getOffset(instant);
+    long localSecond = instant.getEpochSecond() + offset.getTotalSeconds(); // overflow caught later
+    int secsOfDay = Math.floorMod(localSecond, SECONDS_PER_DAY);
+    TLocalTime time = TLocalTime.ofNanoOfDay(secsOfDay * NANOS_PER_SECOND + instant.getNano());
+    return new TOffsetTime(time, offset);
+  }
+
+  public static TOffsetTime from(TTemporalAccessor temporal) {
+
+    if (temporal instanceof TOffsetTime) {
+      return (TOffsetTime) temporal;
+    }
+    try {
+      TLocalTime time = TLocalTime.from(temporal);
+      TZoneOffset offset = TZoneOffset.from(temporal);
+      return new TOffsetTime(time, offset);
+    } catch (TDateTimeException ex) {
+      throw new TDateTimeException("Unable to obtain OffsetTime from TemporalAccessor: " + temporal + " of type "
+          + temporal.getClass().getName(), ex);
+    }
+  }
+
+  public static TOffsetTime parse(CharSequence text) {
+
+    return parse(text, TDateTimeFormatter.ISO_OFFSET_TIME);
+  }
+
+  public static TOffsetTime parse(CharSequence text, TDateTimeFormatter formatter) {
+
+    TObjects.requireNonNull(formatter, "formatter");
+    return formatter.parse(text, TOffsetTime::from);
+  }
+
+  private TOffsetTime(TLocalTime time, TZoneOffset offset) {
+
+    this.time = TObjects.requireNonNull(time, "time");
+    this.offset = TObjects.requireNonNull(offset, "offset");
+  }
+
+  private TOffsetTime with(TLocalTime time, TZoneOffset offset) {
+
+    if (this.time == time && this.offset.equals(offset)) {
+      return this;
+    }
+    return new TOffsetTime(time, offset);
+  }
+
+  @Override
+  public boolean isSupported(TTemporalField field) {
+
+    if (field instanceof TChronoField) {
+      return field.isTimeBased() || field == OFFSET_SECONDS;
+    }
+    return field != null && field.isSupportedBy(this);
+  }
+
+  @Override
+  public boolean isSupported(TTemporalUnit unit) {
+
+    if (unit instanceof TChronoUnit) {
+      return unit.isTimeBased();
+    }
+    return unit != null && unit.isSupportedBy(this);
+  }
+
+  @Override
+  public TValueRange range(TTemporalField field) {
+
+    if (field instanceof TChronoField) {
+      if (field == OFFSET_SECONDS) {
+        return field.range();
+      }
+      return this.time.range(field);
+    }
+    return field.rangeRefinedBy(this);
+  }
+
+  @Override
+  public int get(TTemporalField field) {
+
+    return TTemporal.super.get(field);
+  }
+
+  @Override
+  public long getLong(TTemporalField field) {
+
+    if (field instanceof TChronoField) {
+      if (field == OFFSET_SECONDS) {
+        return this.offset.getTotalSeconds();
+      }
+      return this.time.getLong(field);
+    }
+    return field.getFrom(this);
+  }
+
+  public TZoneOffset getOffset() {
+
+    return this.offset;
+  }
+
+  public TOffsetTime withOffsetSameLocal(TZoneOffset offset) {
+
+    return offset != null && offset.equals(this.offset) ? this : new TOffsetTime(this.time, offset);
+  }
+
+  public TOffsetTime withOffsetSameInstant(TZoneOffset offset) {
+
+    if (offset.equals(this.offset)) {
+      return this;
+    }
+    int difference = offset.getTotalSeconds() - this.offset.getTotalSeconds();
+    TLocalTime adjusted = this.time.plusSeconds(difference);
+    return new TOffsetTime(adjusted, offset);
+  }
+
+  public TLocalTime toLocalTime() {
+
+    return this.time;
+  }
+
+  public int getHour() {
+
+    return this.time.getHour();
+  }
+
+  public int getMinute() {
+
+    return this.time.getMinute();
+  }
+
+  public int getSecond() {
+
+    return this.time.getSecond();
+  }
+
+  public int getNano() {
+
+    return this.time.getNano();
+  }
+
+  @Override
+  public TOffsetTime with(TTemporalAdjuster adjuster) {
+
+    if (adjuster instanceof TLocalTime) {
+      return with((TLocalTime) adjuster, this.offset);
+    } else if (adjuster instanceof TZoneOffset) {
+      return with(this.time, (TZoneOffset) adjuster);
+    } else if (adjuster instanceof TOffsetTime) {
+      return (TOffsetTime) adjuster;
+    }
+    return (TOffsetTime) adjuster.adjustInto(this);
+  }
+
+  @Override
+  public TOffsetTime with(TTemporalField field, long newValue) {
+
+    if (field instanceof TChronoField) {
+      if (field == OFFSET_SECONDS) {
+        TChronoField f = (TChronoField) field;
+        return with(this.time, TZoneOffset.ofTotalSeconds(f.checkValidIntValue(newValue)));
+      }
+      return with(this.time.with(field, newValue), this.offset);
+    }
+    return field.adjustInto(this, newValue);
+  }
+
+  public TOffsetTime withHour(int hour) {
+
+    return with(this.time.withHour(hour), this.offset);
+  }
+
+  public TOffsetTime withMinute(int minute) {
+
+    return with(this.time.withMinute(minute), this.offset);
+  }
+
+  public TOffsetTime withSecond(int second) {
+
+    return with(this.time.withSecond(second), this.offset);
+  }
+
+  public TOffsetTime withNano(int nanoOfSecond) {
+
+    return with(this.time.withNano(nanoOfSecond), this.offset);
+  }
+
+  public TOffsetTime truncatedTo(TTemporalUnit unit) {
+
+    return with(this.time.truncatedTo(unit), this.offset);
+  }
+
+  @Override
+  public TOffsetTime plus(TTemporalAmount amountToAdd) {
+
+    return (TOffsetTime) amountToAdd.addTo(this);
+  }
+
+  @Override
+  public TOffsetTime plus(long amountToAdd, TTemporalUnit unit) {
+
+    if (unit instanceof TChronoUnit) {
+      return with(this.time.plus(amountToAdd, unit), this.offset);
+    }
+    return unit.addTo(this, amountToAdd);
+  }
+
+  public TOffsetTime plusHours(long hours) {
+
+    return with(this.time.plusHours(hours), this.offset);
+  }
+
+  public TOffsetTime plusMinutes(long minutes) {
+
+    return with(this.time.plusMinutes(minutes), this.offset);
+  }
+
+  public TOffsetTime plusSeconds(long seconds) {
+
+    return with(this.time.plusSeconds(seconds), this.offset);
+  }
+
+  public TOffsetTime plusNanos(long nanos) {
+
+    return with(this.time.plusNanos(nanos), this.offset);
+  }
+
+  @Override
+  public TOffsetTime minus(TTemporalAmount amountToSubtract) {
+
+    return (TOffsetTime) amountToSubtract.subtractFrom(this);
+  }
+
+  @Override
+  public TOffsetTime minus(long amountToSubtract, TTemporalUnit unit) {
+
+    return (amountToSubtract == Long.MIN_VALUE ? plus(Long.MAX_VALUE, unit).plus(1, unit)
+        : plus(-amountToSubtract, unit));
+  }
+
+  public TOffsetTime minusHours(long hours) {
+
+    return with(this.time.minusHours(hours), this.offset);
+  }
+
+  public TOffsetTime minusMinutes(long minutes) {
+
+    return with(this.time.minusMinutes(minutes), this.offset);
+  }
+
+  public TOffsetTime minusSeconds(long seconds) {
+
+    return with(this.time.minusSeconds(seconds), this.offset);
+  }
+
+  public TOffsetTime minusNanos(long nanos) {
+
+    return with(this.time.minusNanos(nanos), this.offset);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public <R> R query(TTemporalQuery<R> query) {
+
+    if (query == TTemporalQueries.offset() || query == TTemporalQueries.zone()) {
+      return (R) this.offset;
+    } else if (query == TTemporalQueries.zoneId() | query == TTemporalQueries.chronology()
+        || query == TTemporalQueries.localDate()) {
+      return null;
+    } else if (query == TTemporalQueries.localTime()) {
+      return (R) this.time;
+    } else if (query == TTemporalQueries.precision()) {
+      return (R) NANOS;
+    }
+    return query.queryFrom(this);
+  }
+
+  @Override
+  public TTemporal adjustInto(TTemporal temporal) {
+
+    return temporal.with(NANO_OF_DAY, this.time.toNanoOfDay()).with(OFFSET_SECONDS, this.offset.getTotalSeconds());
+  }
+
+  @Override
+  public long until(TTemporal endExclusive, TTemporalUnit unit) {
+
+    TOffsetTime end = TOffsetTime.from(endExclusive);
+    if (unit instanceof TChronoUnit) {
+      long nanosUntil = end.toEpochNano() - toEpochNano();
+      switch ((TChronoUnit) unit) {
+        case NANOS:
+          return nanosUntil;
+        case MICROS:
+          return nanosUntil / 1000;
+        case MILLIS:
+          return nanosUntil / 1000_000;
+        case SECONDS:
+          return nanosUntil / NANOS_PER_SECOND;
+        case MINUTES:
+          return nanosUntil / NANOS_PER_MINUTE;
+        case HOURS:
+          return nanosUntil / NANOS_PER_HOUR;
+        case HALF_DAYS:
+          return nanosUntil / (12 * NANOS_PER_HOUR);
+      }
+      throw new TUnsupportedTemporalTypeException("Unsupported unit: " + unit);
+    }
+    return unit.between(this, end);
+  }
+
+  public String format(TDateTimeFormatter formatter) {
+
+    TObjects.requireNonNull(formatter, "formatter");
+    return formatter.format(this);
+  }
+
+  public TOffsetDateTime atDate(TLocalDate date) {
+
+    return TOffsetDateTime.of(date, this.time, this.offset);
+  }
+
+  private long toEpochNano() {
+
+    long nod = this.time.toNanoOfDay();
+    long offsetNanos = this.offset.getTotalSeconds() * NANOS_PER_SECOND;
+    return nod - offsetNanos;
+  }
+
+  public long toEpochSecond(TLocalDate date) {
+
+    TObjects.requireNonNull(date, "date");
+    long epochDay = date.toEpochDay();
+    long secs = epochDay * 86400 + this.time.toSecondOfDay();
+    secs -= this.offset.getTotalSeconds();
+    return secs;
+  }
+
+  @Override
+  public int compareTo(TOffsetTime other) {
+
+    if (this.offset.equals(other.offset)) {
+      return this.time.compareTo(other.time);
+    }
+    int compare = Long.compare(toEpochNano(), other.toEpochNano());
+    if (compare == 0) {
+      compare = this.time.compareTo(other.time);
+    }
+    return compare;
+  }
+
+  public boolean isAfter(TOffsetTime other) {
+
+    return toEpochNano() > other.toEpochNano();
+  }
+
+  public boolean isBefore(TOffsetTime other) {
+
+    return toEpochNano() < other.toEpochNano();
+  }
+
+  public boolean isEqual(TOffsetTime other) {
+
+    return toEpochNano() == other.toEpochNano();
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+
+    if (this == obj) {
+      return true;
+    }
+    if (obj instanceof TOffsetTime) {
+      TOffsetTime other = (TOffsetTime) obj;
+      return this.time.equals(other.time) && this.offset.equals(other.offset);
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+
+    return this.time.hashCode() ^ this.offset.hashCode();
+  }
+
+  @Override
+  public String toString() {
+
+    return this.time.toString() + this.offset.toString();
+  }
+
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/time/TPeriod.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/time/TPeriod.java
@@ -1,0 +1,416 @@
+package org.teavm.classlib.java.time;
+
+import static org.teavm.classlib.java.time.temporal.TChronoUnit.DAYS;
+import static org.teavm.classlib.java.time.temporal.TChronoUnit.MONTHS;
+import static org.teavm.classlib.java.time.temporal.TChronoUnit.YEARS;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.teavm.classlib.java.io.TSerializable;
+import org.teavm.classlib.java.lang.TArithmeticException;
+import org.teavm.classlib.java.lang.TNumberFormatException;
+import org.teavm.classlib.java.lang.TStringBuilder;
+import org.teavm.classlib.java.time.chrono.TChronoPeriod;
+import org.teavm.classlib.java.time.chrono.TChronology;
+import org.teavm.classlib.java.time.chrono.TIsoChronology;
+import org.teavm.classlib.java.time.format.TDateTimeParseException;
+import org.teavm.classlib.java.time.temporal.TChronoUnit;
+import org.teavm.classlib.java.time.temporal.TTemporal;
+import org.teavm.classlib.java.time.temporal.TTemporalAccessor;
+import org.teavm.classlib.java.time.temporal.TTemporalAmount;
+import org.teavm.classlib.java.time.temporal.TTemporalQueries;
+import org.teavm.classlib.java.time.temporal.TTemporalUnit;
+import org.teavm.classlib.java.time.temporal.TUnsupportedTemporalTypeException;
+import org.teavm.classlib.java.util.TObjects;
+import org.teavm.classlib.java.util.regex.TMatcher;
+import org.teavm.classlib.java.util.regex.TPattern;
+
+public final class TPeriod implements TChronoPeriod, TSerializable {
+  public static final TPeriod ZERO = new TPeriod(0, 0, 0);
+
+  private static final TPattern PATTERN = TPattern.compile(
+      "([-+]?)P(?:([-+]?[0-9]+)Y)?(?:([-+]?[0-9]+)M)?(?:([-+]?[0-9]+)W)?(?:([-+]?[0-9]+)D)?",
+      TPattern.CASE_INSENSITIVE);
+
+  private static final List<TTemporalUnit> SUPPORTED_UNITS = List.of(YEARS, MONTHS, DAYS);
+
+  private final int years;
+
+  private final int months;
+
+  private final int days;
+
+  public static TPeriod ofYears(int years) {
+
+    return create(years, 0, 0);
+  }
+
+  public static TPeriod ofMonths(int months) {
+
+    return create(0, months, 0);
+  }
+
+  public static TPeriod ofWeeks(int weeks) {
+
+    return create(0, 0, Math.multiplyExact(weeks, 7));
+  }
+
+  public static TPeriod ofDays(int days) {
+
+    return create(0, 0, days);
+  }
+
+  public static TPeriod of(int years, int months, int days) {
+
+    return create(years, months, days);
+  }
+
+  public static TPeriod from(TTemporalAmount amount) {
+
+    if (amount instanceof TPeriod) {
+      return (TPeriod) amount;
+    }
+    if (amount instanceof TChronoPeriod) {
+      if (TIsoChronology.INSTANCE.equals(((TChronoPeriod) amount).getChronology()) == false) {
+        throw new TDateTimeException("Period requires ISO chronology: " + amount);
+      }
+    }
+    TObjects.requireNonNull(amount, "amount");
+    int years = 0;
+    int months = 0;
+    int days = 0;
+    for (TTemporalUnit unit : amount.getUnits()) {
+      long unitAmount = amount.get(unit);
+      if (unit == TChronoUnit.YEARS) {
+        years = Math.toIntExact(unitAmount);
+      } else if (unit == TChronoUnit.MONTHS) {
+        months = Math.toIntExact(unitAmount);
+      } else if (unit == TChronoUnit.DAYS) {
+        days = Math.toIntExact(unitAmount);
+      } else {
+        throw new TDateTimeException("Unit must be Years, Months or Days, but was " + unit);
+      }
+    }
+    return create(years, months, days);
+  }
+
+  public static TPeriod parse(CharSequence text) {
+
+    TObjects.requireNonNull(text, "text");
+    TMatcher matcher = PATTERN.matcher(text);
+    if (matcher.matches()) {
+      int negate = (charMatch(text, matcher.start(1), matcher.end(1), '-') ? -1 : 1);
+      int yearStart = matcher.start(2), yearEnd = matcher.end(2);
+      int monthStart = matcher.start(3), monthEnd = matcher.end(3);
+      int weekStart = matcher.start(4), weekEnd = matcher.end(4);
+      int dayStart = matcher.start(5), dayEnd = matcher.end(5);
+      if (yearStart >= 0 || monthStart >= 0 || weekStart >= 0 || dayStart >= 0) {
+        try {
+          int years = parseNumber(text, yearStart, yearEnd, negate);
+          int months = parseNumber(text, monthStart, monthEnd, negate);
+          int weeks = parseNumber(text, weekStart, weekEnd, negate);
+          int days = parseNumber(text, dayStart, dayEnd, negate);
+          days = Math.addExact(days, Math.multiplyExact(weeks, 7));
+          return create(years, months, days);
+        } catch (TNumberFormatException ex) {
+          throw new TDateTimeParseException("Text cannot be parsed to a Period", text, 0, ex);
+        }
+      }
+    }
+    throw new TDateTimeParseException("Text cannot be parsed to a Period", text, 0);
+  }
+
+  private static boolean charMatch(CharSequence text, int start, int end, char c) {
+
+    return (start >= 0 && end == start + 1 && text.charAt(start) == c);
+  }
+
+  private static int parseNumber(CharSequence text, int start, int end, int negate) {
+
+    if (start < 0 || end < 0) {
+      return 0;
+    }
+    int val = Integer.parseInt(text, start, end, 10);
+    try {
+      return Math.multiplyExact(val, negate);
+    } catch (TArithmeticException ex) {
+      throw new TDateTimeParseException("Text cannot be parsed to a Period", text, 0, ex);
+    }
+  }
+
+  public static TPeriod between(TLocalDate startDateInclusive, TLocalDate endDateExclusive) {
+
+    return startDateInclusive.until(endDateExclusive);
+  }
+
+  private static TPeriod create(int years, int months, int days) {
+
+    if ((years | months | days) == 0) {
+      return ZERO;
+    }
+    return new TPeriod(years, months, days);
+  }
+
+  private TPeriod(int years, int months, int days) {
+
+    this.years = years;
+    this.months = months;
+    this.days = days;
+  }
+
+  @Override
+  public long get(TTemporalUnit unit) {
+
+    if (unit == TChronoUnit.YEARS) {
+      return getYears();
+    } else if (unit == TChronoUnit.MONTHS) {
+      return getMonths();
+    } else if (unit == TChronoUnit.DAYS) {
+      return getDays();
+    } else {
+      throw new TUnsupportedTemporalTypeException("Unsupported unit: " + unit);
+    }
+  }
+
+  @Override
+  public List<TTemporalUnit> getUnits() {
+
+    return SUPPORTED_UNITS;
+  }
+
+  @Override
+  public TIsoChronology getChronology() {
+
+    return TIsoChronology.INSTANCE;
+  }
+
+  @Override
+  public boolean isZero() {
+
+    return (this == ZERO);
+  }
+
+  @Override
+  public boolean isNegative() {
+
+    return this.years < 0 || this.months < 0 || this.days < 0;
+  }
+
+  public int getYears() {
+
+    return this.years;
+  }
+
+  public int getMonths() {
+
+    return this.months;
+  }
+
+  public int getDays() {
+
+    return this.days;
+  }
+
+  public TPeriod withYears(int years) {
+
+    if (years == this.years) {
+      return this;
+    }
+    return create(years, this.months, this.days);
+  }
+
+  public TPeriod withMonths(int months) {
+
+    if (months == this.months) {
+      return this;
+    }
+    return create(this.years, months, this.days);
+  }
+
+  public TPeriod withDays(int days) {
+
+    if (days == this.days) {
+      return this;
+    }
+    return create(this.years, this.months, days);
+  }
+
+  @Override
+  public TPeriod plus(TTemporalAmount amountToAdd) {
+
+    TPeriod isoAmount = TPeriod.from(amountToAdd);
+    return create(Math.addExact(this.years, isoAmount.years), Math.addExact(this.months, isoAmount.months),
+        Math.addExact(this.days, isoAmount.days));
+  }
+
+  public TPeriod plusYears(long yearsToAdd) {
+
+    if (yearsToAdd == 0) {
+      return this;
+    }
+    return create(Math.toIntExact(Math.addExact(this.years, yearsToAdd)), this.months, this.days);
+  }
+
+  public TPeriod plusMonths(long monthsToAdd) {
+
+    if (monthsToAdd == 0) {
+      return this;
+    }
+    return create(this.years, Math.toIntExact(Math.addExact(this.months, monthsToAdd)), this.days);
+  }
+
+  public TPeriod plusDays(long daysToAdd) {
+
+    if (daysToAdd == 0) {
+      return this;
+    }
+    return create(this.years, this.months, Math.toIntExact(Math.addExact(this.days, daysToAdd)));
+  }
+
+  @Override
+  public TPeriod minus(TTemporalAmount amountToSubtract) {
+
+    TPeriod isoAmount = TPeriod.from(amountToSubtract);
+    return create(Math.subtractExact(this.years, isoAmount.years), Math.subtractExact(this.months, isoAmount.months),
+        Math.subtractExact(this.days, isoAmount.days));
+  }
+
+  public TPeriod minusYears(long yearsToSubtract) {
+
+    return (yearsToSubtract == Long.MIN_VALUE ? plusYears(Long.MAX_VALUE).plusYears(1) : plusYears(-yearsToSubtract));
+  }
+
+  public TPeriod minusMonths(long monthsToSubtract) {
+
+    return (monthsToSubtract == Long.MIN_VALUE ? plusMonths(Long.MAX_VALUE).plusMonths(1)
+        : plusMonths(-monthsToSubtract));
+  }
+
+  public TPeriod minusDays(long daysToSubtract) {
+
+    return (daysToSubtract == Long.MIN_VALUE ? plusDays(Long.MAX_VALUE).plusDays(1) : plusDays(-daysToSubtract));
+  }
+
+  @Override
+  public TPeriod multipliedBy(int scalar) {
+
+    if (this == ZERO || scalar == 1) {
+      return this;
+    }
+    return create(Math.multiplyExact(this.years, scalar), Math.multiplyExact(this.months, scalar),
+        Math.multiplyExact(this.days, scalar));
+  }
+
+  @Override
+  public TPeriod negated() {
+
+    return multipliedBy(-1);
+  }
+
+  @Override
+  public TPeriod normalized() {
+
+    long totalMonths = toTotalMonths();
+    long splitYears = totalMonths / 12;
+    int splitMonths = (int) (totalMonths % 12);
+    if (splitYears == this.years && splitMonths == this.months) {
+      return this;
+    }
+    return create(Math.toIntExact(splitYears), splitMonths, this.days);
+  }
+
+  public long toTotalMonths() {
+
+    return this.years * 12L + this.months;
+  }
+
+  @Override
+  public TTemporal addTo(TTemporal temporal) {
+
+    validateChrono(temporal);
+    if (this.months == 0) {
+      if (this.years != 0) {
+        temporal = temporal.plus(this.years, YEARS);
+      }
+    } else {
+      long totalMonths = toTotalMonths();
+      if (totalMonths != 0) {
+        temporal = temporal.plus(totalMonths, MONTHS);
+      }
+    }
+    if (this.days != 0) {
+      temporal = temporal.plus(this.days, DAYS);
+    }
+    return temporal;
+  }
+
+  @Override
+  public TTemporal subtractFrom(TTemporal temporal) {
+
+    validateChrono(temporal);
+    if (this.months == 0) {
+      if (this.years != 0) {
+        temporal = temporal.minus(this.years, YEARS);
+      }
+    } else {
+      long totalMonths = toTotalMonths();
+      if (totalMonths != 0) {
+        temporal = temporal.minus(totalMonths, MONTHS);
+      }
+    }
+    if (this.days != 0) {
+      temporal = temporal.minus(this.days, DAYS);
+    }
+    return temporal;
+  }
+
+  private void validateChrono(TTemporalAccessor temporal) {
+
+    Objects.requireNonNull(temporal, "temporal");
+    TChronology temporalChrono = temporal.query(TTemporalQueries.chronology());
+    if (temporalChrono != null && TIsoChronology.INSTANCE.equals(temporalChrono) == false) {
+      throw new TDateTimeException("Chronology mismatch, expected: ISO, actual: " + temporalChrono.getId());
+    }
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+
+    if (this == obj) {
+      return true;
+    }
+    if (obj instanceof TPeriod) {
+      TPeriod other = (TPeriod) obj;
+      return this.years == other.years && this.months == other.months && this.days == other.days;
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+
+    return this.years + Integer.rotateLeft(this.months, 8) + Integer.rotateLeft(this.days, 16);
+  }
+
+  @Override
+  public String toString() {
+
+    if (this == ZERO) {
+      return "P0D";
+    } else {
+      TStringBuilder buf = new TStringBuilder();
+      buf.append('P');
+      if (this.years != 0) {
+        buf.append(this.years).append('Y');
+      }
+      if (this.months != 0) {
+        buf.append(this.months).append('M');
+      }
+      if (this.days != 0) {
+        buf.append(this.days).append('D');
+      }
+      return buf.toString();
+    }
+  }
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/time/TYear.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/time/TYear.java
@@ -1,0 +1,360 @@
+/* Copyright (c) The m-m-m Team, Licensed under the Apache License, Version 2.0
+ * http://www.apache.org/licenses/LICENSE-2.0 */
+package org.teavm.classlib.java.time;
+
+import static org.teavm.classlib.java.time.temporal.TChronoField.ERA;
+import static org.teavm.classlib.java.time.temporal.TChronoField.YEAR;
+import static org.teavm.classlib.java.time.temporal.TChronoField.YEAR_OF_ERA;
+import static org.teavm.classlib.java.time.temporal.TChronoUnit.CENTURIES;
+import static org.teavm.classlib.java.time.temporal.TChronoUnit.DECADES;
+import static org.teavm.classlib.java.time.temporal.TChronoUnit.ERAS;
+import static org.teavm.classlib.java.time.temporal.TChronoUnit.MILLENNIA;
+import static org.teavm.classlib.java.time.temporal.TChronoUnit.YEARS;
+
+import org.teavm.classlib.java.io.TSerializable;
+import org.teavm.classlib.java.lang.TComparable;
+import org.teavm.classlib.java.time.chrono.TChronology;
+import org.teavm.classlib.java.time.chrono.TIsoChronology;
+import org.teavm.classlib.java.time.format.TDateTimeFormatter;
+import org.teavm.classlib.java.time.format.TDateTimeFormatterBuilder;
+import org.teavm.classlib.java.time.format.TSignStyle;
+import org.teavm.classlib.java.time.temporal.TChronoField;
+import org.teavm.classlib.java.time.temporal.TChronoUnit;
+import org.teavm.classlib.java.time.temporal.TTemporal;
+import org.teavm.classlib.java.time.temporal.TTemporalAccessor;
+import org.teavm.classlib.java.time.temporal.TTemporalAdjuster;
+import org.teavm.classlib.java.time.temporal.TTemporalAmount;
+import org.teavm.classlib.java.time.temporal.TTemporalField;
+import org.teavm.classlib.java.time.temporal.TTemporalQueries;
+import org.teavm.classlib.java.time.temporal.TTemporalQuery;
+import org.teavm.classlib.java.time.temporal.TTemporalUnit;
+import org.teavm.classlib.java.time.temporal.TUnsupportedTemporalTypeException;
+import org.teavm.classlib.java.time.temporal.TValueRange;
+import org.teavm.classlib.java.util.TObjects;
+
+public final class TYear implements TTemporal, TTemporalAdjuster, TComparable<TYear>, TSerializable {
+
+  public static final int MIN_VALUE = -999_999_999;
+
+  public static final int MAX_VALUE = 999_999_999;
+
+  private static final TDateTimeFormatter PARSER = new TDateTimeFormatterBuilder()
+      .appendValue(YEAR, 4, 10, TSignStyle.EXCEEDS_PAD).toFormatter();
+
+  private final int year;
+
+  private TYear(int year) {
+
+    this.year = year;
+  }
+
+  public int getValue() {
+
+    return this.year;
+  }
+
+  @Override
+  public boolean isSupported(TTemporalField field) {
+
+    if (field instanceof TChronoField) {
+      return field == YEAR || field == YEAR_OF_ERA || field == ERA;
+    }
+    return field != null && field.isSupportedBy(this);
+  }
+
+  @Override
+  public boolean isSupported(TTemporalUnit unit) {
+
+    if (unit instanceof TChronoUnit) {
+      return unit == YEARS || unit == DECADES || unit == CENTURIES || unit == MILLENNIA || unit == ERAS;
+    }
+    return unit != null && unit.isSupportedBy(this);
+  }
+
+  @Override
+  public TValueRange range(TTemporalField field) {
+
+    if (field == YEAR_OF_ERA) {
+      return (this.year <= 0 ? TValueRange.of(1, MAX_VALUE + 1) : TValueRange.of(1, MAX_VALUE));
+    }
+    return TTemporal.super.range(field);
+  }
+
+  @Override
+  public int get(TTemporalField field) {
+
+    return range(field).checkValidIntValue(getLong(field), field);
+  }
+
+  @Override
+  public long getLong(TTemporalField field) {
+
+    if (field instanceof TChronoField) {
+      switch ((TChronoField) field) {
+        case YEAR_OF_ERA:
+          return (this.year < 1 ? 1 - this.year : this.year);
+        case YEAR:
+          return this.year;
+        case ERA:
+          return (this.year < 1 ? 0 : 1);
+      }
+      throw new TUnsupportedTemporalTypeException("Unsupported field: " + field);
+    }
+    return field.getFrom(this);
+  }
+
+  public boolean isLeap() {
+
+    return TYear.isLeap(this.year);
+  }
+
+  public boolean isValidMonthDay(TMonthDay monthDay) {
+
+    return monthDay != null && monthDay.isValidYear(this.year);
+  }
+
+  public int length() {
+
+    return isLeap() ? 366 : 365;
+  }
+
+  @Override
+  public TYear with(TTemporalAdjuster adjuster) {
+
+    return (TYear) adjuster.adjustInto(this);
+  }
+
+  @Override
+  public TYear with(TTemporalField field, long newValue) {
+
+    if (field instanceof TChronoField) {
+      TChronoField f = (TChronoField) field;
+      f.checkValidValue(newValue);
+      switch (f) {
+        case YEAR_OF_ERA:
+          return TYear.of((int) (this.year < 1 ? 1 - newValue : newValue));
+        case YEAR:
+          return TYear.of((int) newValue);
+        case ERA:
+          return (getLong(ERA) == newValue ? this : TYear.of(1 - this.year));
+      }
+      throw new TUnsupportedTemporalTypeException("Unsupported field: " + field);
+    }
+    return field.adjustInto(this, newValue);
+  }
+
+  @Override
+  public TYear plus(TTemporalAmount amountToAdd) {
+
+    return (TYear) amountToAdd.addTo(this);
+  }
+
+  @Override
+  public TYear plus(long amountToAdd, TTemporalUnit unit) {
+
+    if (unit instanceof TChronoUnit) {
+      switch ((TChronoUnit) unit) {
+        case YEARS:
+          return plusYears(amountToAdd);
+        case DECADES:
+          return plusYears(Math.multiplyExact(amountToAdd, 10));
+        case CENTURIES:
+          return plusYears(Math.multiplyExact(amountToAdd, 100));
+        case MILLENNIA:
+          return plusYears(Math.multiplyExact(amountToAdd, 1000));
+        case ERAS:
+          return with(ERA, Math.addExact(getLong(ERA), amountToAdd));
+      }
+      throw new TUnsupportedTemporalTypeException("Unsupported unit: " + unit);
+    }
+    return unit.addTo(this, amountToAdd);
+  }
+
+  public TYear plusYears(long yearsToAdd) {
+
+    if (yearsToAdd == 0) {
+      return this;
+    }
+    return of(YEAR.checkValidIntValue(this.year + yearsToAdd));
+  }
+
+  @Override
+  public TYear minus(TTemporalAmount amountToSubtract) {
+
+    return (TYear) amountToSubtract.subtractFrom(this);
+  }
+
+  @Override
+  public TYear minus(long amountToSubtract, TTemporalUnit unit) {
+
+    return (amountToSubtract == Long.MIN_VALUE ? plus(Long.MAX_VALUE, unit).plus(1, unit)
+        : plus(-amountToSubtract, unit));
+  }
+
+  public TYear minusYears(long yearsToSubtract) {
+
+    return (yearsToSubtract == Long.MIN_VALUE ? plusYears(Long.MAX_VALUE).plusYears(1) : plusYears(-yearsToSubtract));
+  }
+
+  @Override
+  public <R> R query(TTemporalQuery<R> query) {
+
+    if (query == TTemporalQueries.chronology()) {
+      return (R) TIsoChronology.INSTANCE;
+    } else if (query == TTemporalQueries.precision()) {
+      return (R) YEARS;
+    }
+    return TTemporal.super.query(query);
+  }
+
+  @Override
+  public TTemporal adjustInto(TTemporal temporal) {
+
+    if (TChronology.from(temporal).equals(TIsoChronology.INSTANCE) == false) {
+      throw new TDateTimeException("Adjustment only supported on ISO date-time");
+    }
+    return temporal.with(YEAR, this.year);
+  }
+
+  @Override
+  public long until(TTemporal endExclusive, TTemporalUnit unit) {
+
+    TYear end = TYear.from(endExclusive);
+    if (unit instanceof TChronoUnit) {
+      long yearsUntil = ((long) end.year) - this.year; // no overflow
+      switch ((TChronoUnit) unit) {
+        case YEARS:
+          return yearsUntil;
+        case DECADES:
+          return yearsUntil / 10;
+        case CENTURIES:
+          return yearsUntil / 100;
+        case MILLENNIA:
+          return yearsUntil / 1000;
+        case ERAS:
+          return end.getLong(ERA) - getLong(ERA);
+      }
+      throw new TUnsupportedTemporalTypeException("Unsupported unit: " + unit);
+    }
+    return unit.between(this, end);
+  }
+
+  public String format(TDateTimeFormatter formatter) {
+
+    TObjects.requireNonNull(formatter, "formatter");
+    return formatter.format(this);
+  }
+
+  public TLocalDate atDay(int dayOfYear) {
+
+    return TLocalDate.ofYearDay(this.year, dayOfYear);
+  }
+
+  public TYearMonth atMonth(TMonth month) {
+
+    return TYearMonth.of(this.year, month);
+  }
+
+  public TYearMonth atMonth(int month) {
+
+    return TYearMonth.of(this.year, month);
+  }
+
+  public TLocalDate atMonthDay(TMonthDay monthDay) {
+
+    return monthDay.atYear(this.year);
+  }
+
+  @Override
+  public int compareTo(TYear other) {
+
+    return this.year - other.year;
+  }
+
+  public boolean isAfter(TYear other) {
+
+    return this.year > other.year;
+  }
+
+  public boolean isBefore(TYear other) {
+
+    return this.year < other.year;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+
+    if (this == obj) {
+      return true;
+    }
+    if (obj instanceof TYear) {
+      return this.year == ((TYear) obj).year;
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+
+    return this.year;
+  }
+
+  @Override
+  public String toString() {
+
+    return Integer.toString(this.year);
+  }
+
+  public static TYear now() {
+
+    return now(TClock.systemDefaultZone());
+  }
+
+  public static TYear now(TZoneId zone) {
+
+    return now(TClock.system(zone));
+  }
+
+  public static TYear now(TClock clock) {
+
+    final TLocalDate now = TLocalDate.now(clock);
+    return TYear.of(now.getYear());
+  }
+
+  public static TYear of(int isoYear) {
+
+    YEAR.checkValidValue(isoYear);
+    return new TYear(isoYear);
+  }
+
+  public static TYear from(TTemporalAccessor temporal) {
+
+    if (temporal instanceof TYear) {
+      return (TYear) temporal;
+    }
+    TObjects.requireNonNull(temporal, "temporal");
+    try {
+      return of(temporal.get(YEAR));
+    } catch (TDateTimeException ex) {
+      throw new TDateTimeException(
+          "Unable to obtain Year from TemporalAccessor: " + temporal + " of type " + temporal.getClass().getName(), ex);
+    }
+  }
+
+  public static TYear parse(CharSequence text) {
+
+    return parse(text, PARSER);
+  }
+
+  public static TYear parse(CharSequence text, TDateTimeFormatter formatter) {
+
+    TObjects.requireNonNull(formatter, "formatter");
+    return formatter.parse(text, TYear::from);
+  }
+
+  public static boolean isLeap(long year) {
+
+    return ((year & 3) == 0) && ((year % 100) != 0 || (year % 400) == 0);
+  }
+
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/time/TYearMonth.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/time/TYearMonth.java
@@ -1,0 +1,446 @@
+package org.teavm.classlib.java.time;
+
+import static org.teavm.classlib.java.time.temporal.TChronoField.ERA;
+import static org.teavm.classlib.java.time.temporal.TChronoField.MONTH_OF_YEAR;
+import static org.teavm.classlib.java.time.temporal.TChronoField.PROLEPTIC_MONTH;
+import static org.teavm.classlib.java.time.temporal.TChronoField.YEAR;
+import static org.teavm.classlib.java.time.temporal.TChronoField.YEAR_OF_ERA;
+import static org.teavm.classlib.java.time.temporal.TChronoUnit.CENTURIES;
+import static org.teavm.classlib.java.time.temporal.TChronoUnit.DECADES;
+import static org.teavm.classlib.java.time.temporal.TChronoUnit.ERAS;
+import static org.teavm.classlib.java.time.temporal.TChronoUnit.MILLENNIA;
+import static org.teavm.classlib.java.time.temporal.TChronoUnit.MONTHS;
+import static org.teavm.classlib.java.time.temporal.TChronoUnit.YEARS;
+
+import org.teavm.classlib.java.io.TSerializable;
+import org.teavm.classlib.java.lang.TComparable;
+import org.teavm.classlib.java.time.chrono.TChronology;
+import org.teavm.classlib.java.time.chrono.TIsoChronology;
+import org.teavm.classlib.java.time.format.TDateTimeFormatter;
+import org.teavm.classlib.java.time.format.TDateTimeFormatterBuilder;
+import org.teavm.classlib.java.time.format.TSignStyle;
+import org.teavm.classlib.java.time.temporal.TChronoField;
+import org.teavm.classlib.java.time.temporal.TChronoUnit;
+import org.teavm.classlib.java.time.temporal.TTemporal;
+import org.teavm.classlib.java.time.temporal.TTemporalAccessor;
+import org.teavm.classlib.java.time.temporal.TTemporalAdjuster;
+import org.teavm.classlib.java.time.temporal.TTemporalAmount;
+import org.teavm.classlib.java.time.temporal.TTemporalField;
+import org.teavm.classlib.java.time.temporal.TTemporalQueries;
+import org.teavm.classlib.java.time.temporal.TTemporalQuery;
+import org.teavm.classlib.java.time.temporal.TTemporalUnit;
+import org.teavm.classlib.java.time.temporal.TUnsupportedTemporalTypeException;
+import org.teavm.classlib.java.time.temporal.TValueRange;
+import org.teavm.classlib.java.util.TObjects;
+
+public final class TYearMonth implements TTemporal, TTemporalAdjuster, TComparable<TYearMonth>, TSerializable {
+
+  private static final TDateTimeFormatter PARSER = new TDateTimeFormatterBuilder()
+      .appendValue(YEAR, 4, 10, TSignStyle.EXCEEDS_PAD).appendLiteral('-').appendValue(MONTH_OF_YEAR, 2).toFormatter();
+
+  private final int year;
+
+  private final int month;
+
+  private TYearMonth(int year, int month) {
+
+    this.year = year;
+    this.month = month;
+  }
+
+  public int getYear() {
+
+    return this.year;
+  }
+
+  public int getMonthValue() {
+
+    return this.month;
+  }
+
+  public TMonth getMonth() {
+
+    return TMonth.of(this.month);
+  }
+
+  private TYearMonth with(int newYear, int newMonth) {
+
+    if (this.year == newYear && this.month == newMonth) {
+      return this;
+    }
+    return new TYearMonth(newYear, newMonth);
+  }
+
+  @Override
+  public boolean isSupported(TTemporalField field) {
+
+    if (field instanceof TChronoField) {
+      return field == YEAR || field == MONTH_OF_YEAR || field == PROLEPTIC_MONTH || field == YEAR_OF_ERA
+          || field == ERA;
+    }
+    return field != null && field.isSupportedBy(this);
+  }
+
+  @Override
+  public boolean isSupported(TTemporalUnit unit) {
+
+    if (unit instanceof TChronoUnit) {
+      return unit == MONTHS || unit == YEARS || unit == DECADES || unit == CENTURIES || unit == MILLENNIA
+          || unit == ERAS;
+    }
+    return unit != null && unit.isSupportedBy(this);
+  }
+
+  @Override
+  public TValueRange range(TTemporalField field) {
+
+    if (field == YEAR_OF_ERA) {
+      return (getYear() <= 0 ? TValueRange.of(1, TYear.MAX_VALUE + 1) : TValueRange.of(1, TYear.MAX_VALUE));
+    }
+    return TTemporal.super.range(field);
+  }
+
+  @Override
+  public int get(TTemporalField field) {
+
+    return range(field).checkValidIntValue(getLong(field), field);
+  }
+
+  @Override
+  public long getLong(TTemporalField field) {
+
+    if (field instanceof TChronoField) {
+      switch ((TChronoField) field) {
+        case MONTH_OF_YEAR:
+          return this.month;
+        case PROLEPTIC_MONTH:
+          return getProlepticMonth();
+        case YEAR_OF_ERA:
+          return (this.year < 1 ? 1 - this.year : this.year);
+        case YEAR:
+          return this.year;
+        case ERA:
+          return (this.year < 1 ? 0 : 1);
+      }
+      throw new TUnsupportedTemporalTypeException("Unsupported field: " + field);
+    }
+    return field.getFrom(this);
+  }
+
+  private long getProlepticMonth() {
+
+    return (this.year * 12L + this.month - 1);
+  }
+
+  public boolean isLeapYear() {
+
+    return TYear.isLeap(this.year);
+  }
+
+  public boolean isValidDay(int dayOfMonth) {
+
+    return dayOfMonth >= 1 && dayOfMonth <= lengthOfMonth();
+  }
+
+  public int lengthOfMonth() {
+
+    return getMonth().length(isLeapYear());
+  }
+
+  public int lengthOfYear() {
+
+    return (isLeapYear() ? 366 : 365);
+  }
+
+  @Override
+  public TYearMonth with(TTemporalAdjuster adjuster) {
+
+    return (TYearMonth) adjuster.adjustInto(this);
+  }
+
+  @Override
+  public TYearMonth with(TTemporalField field, long newValue) {
+
+    if (field instanceof TChronoField) {
+      TChronoField f = (TChronoField) field;
+      f.checkValidValue(newValue);
+      switch (f) {
+        case MONTH_OF_YEAR:
+          return withMonth((int) newValue);
+        case PROLEPTIC_MONTH:
+          return plusMonths(newValue - getProlepticMonth());
+        case YEAR_OF_ERA:
+          return withYear((int) (this.year < 1 ? 1 - newValue : newValue));
+        case YEAR:
+          return withYear((int) newValue);
+        case ERA:
+          return (getLong(ERA) == newValue ? this : withYear(1 - this.year));
+      }
+      throw new TUnsupportedTemporalTypeException("Unsupported field: " + field);
+    }
+    return field.adjustInto(this, newValue);
+  }
+
+  public TYearMonth withYear(int year) {
+
+    YEAR.checkValidValue(year);
+    return with(year, this.month);
+  }
+
+  public TYearMonth withMonth(int month) {
+
+    MONTH_OF_YEAR.checkValidValue(month);
+    return with(this.year, month);
+  }
+
+  @Override
+  public TYearMonth plus(TTemporalAmount amountToAdd) {
+
+    return (TYearMonth) amountToAdd.addTo(this);
+  }
+
+  @Override
+  public TYearMonth plus(long amountToAdd, TTemporalUnit unit) {
+
+    if (unit instanceof TChronoUnit) {
+      switch ((TChronoUnit) unit) {
+        case MONTHS:
+          return plusMonths(amountToAdd);
+        case YEARS:
+          return plusYears(amountToAdd);
+        case DECADES:
+          return plusYears(Math.multiplyExact(amountToAdd, 10));
+        case CENTURIES:
+          return plusYears(Math.multiplyExact(amountToAdd, 100));
+        case MILLENNIA:
+          return plusYears(Math.multiplyExact(amountToAdd, 1000));
+        case ERAS:
+          return with(ERA, Math.addExact(getLong(ERA), amountToAdd));
+      }
+      throw new TUnsupportedTemporalTypeException("Unsupported unit: " + unit);
+    }
+    return unit.addTo(this, amountToAdd);
+  }
+
+  public TYearMonth plusYears(long yearsToAdd) {
+
+    if (yearsToAdd == 0) {
+      return this;
+    }
+    int newYear = YEAR.checkValidIntValue(this.year + yearsToAdd);
+    return with(newYear, this.month);
+  }
+
+  public TYearMonth plusMonths(long monthsToAdd) {
+
+    if (monthsToAdd == 0) {
+      return this;
+    }
+    long monthCount = this.year * 12L + (this.month - 1);
+    long calcMonths = monthCount + monthsToAdd;
+    int newYear = YEAR.checkValidIntValue(Math.floorDiv(calcMonths, 12));
+    int newMonth = Math.floorMod(calcMonths, 12) + 1;
+    return with(newYear, newMonth);
+  }
+
+  @Override
+  public TYearMonth minus(TTemporalAmount amountToSubtract) {
+
+    return (TYearMonth) amountToSubtract.subtractFrom(this);
+  }
+
+  @Override
+  public TYearMonth minus(long amountToSubtract, TTemporalUnit unit) {
+
+    return (amountToSubtract == Long.MIN_VALUE ? plus(Long.MAX_VALUE, unit).plus(1, unit)
+        : plus(-amountToSubtract, unit));
+  }
+
+  public TYearMonth minusYears(long yearsToSubtract) {
+
+    return (yearsToSubtract == Long.MIN_VALUE ? plusYears(Long.MAX_VALUE).plusYears(1) : plusYears(-yearsToSubtract));
+  }
+
+  public TYearMonth minusMonths(long monthsToSubtract) {
+
+    return (monthsToSubtract == Long.MIN_VALUE ? plusMonths(Long.MAX_VALUE).plusMonths(1)
+        : plusMonths(-monthsToSubtract));
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public <R> R query(TTemporalQuery<R> query) {
+
+    if (query == TTemporalQueries.chronology()) {
+      return (R) TIsoChronology.INSTANCE;
+    } else if (query == TTemporalQueries.precision()) {
+      return (R) MONTHS;
+    }
+    return TTemporal.super.query(query);
+  }
+
+  @Override
+  public TTemporal adjustInto(TTemporal temporal) {
+
+    if (TChronology.from(temporal).equals(TIsoChronology.INSTANCE) == false) {
+      throw new TDateTimeException("Adjustment only supported on ISO date-time");
+    }
+    return temporal.with(PROLEPTIC_MONTH, getProlepticMonth());
+  }
+
+  @Override
+  public long until(TTemporal endExclusive, TTemporalUnit unit) {
+
+    TYearMonth end = TYearMonth.from(endExclusive);
+    if (unit instanceof TChronoUnit) {
+      long monthsUntil = end.getProlepticMonth() - getProlepticMonth();
+      switch ((TChronoUnit) unit) {
+        case MONTHS:
+          return monthsUntil;
+        case YEARS:
+          return monthsUntil / 12;
+        case DECADES:
+          return monthsUntil / 120;
+        case CENTURIES:
+          return monthsUntil / 1200;
+        case MILLENNIA:
+          return monthsUntil / 12000;
+        case ERAS:
+          return end.getLong(ERA) - getLong(ERA);
+      }
+      throw new TUnsupportedTemporalTypeException("Unsupported unit: " + unit);
+    }
+    return unit.between(this, end);
+  }
+
+  public String format(TDateTimeFormatter formatter) {
+
+    TObjects.requireNonNull(formatter, "formatter");
+    return formatter.format(this);
+  }
+
+  public TLocalDate atDay(int dayOfMonth) {
+
+    return TLocalDate.of(this.year, this.month, dayOfMonth);
+  }
+
+  public TLocalDate atEndOfMonth() {
+
+    return TLocalDate.of(this.year, this.month, lengthOfMonth());
+  }
+
+  @Override
+  public int compareTo(TYearMonth other) {
+
+    int cmp = (this.year - other.year);
+    if (cmp == 0) {
+      cmp = (this.month - other.month);
+    }
+    return cmp;
+  }
+
+  public boolean isAfter(TYearMonth other) {
+
+    return compareTo(other) > 0;
+  }
+
+  public boolean isBefore(TYearMonth other) {
+
+    return compareTo(other) < 0;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+
+    if (this == obj) {
+      return true;
+    }
+    if (obj instanceof TYearMonth) {
+      TYearMonth other = (TYearMonth) obj;
+      return this.year == other.year && this.month == other.month;
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+
+    return this.year ^ (this.month << 27);
+  }
+
+  @Override
+  public String toString() {
+
+    int absYear = Math.abs(this.year);
+    StringBuilder buf = new StringBuilder(9);
+    if (absYear < 1000) {
+      if (this.year < 0) {
+        buf.append(this.year - 10000).deleteCharAt(1);
+      } else {
+        buf.append(this.year + 10000).deleteCharAt(0);
+      }
+    } else {
+      buf.append(this.year);
+    }
+    return buf.append(this.month < 10 ? "-0" : "-").append(this.month).toString();
+  }
+
+  public static TYearMonth now() {
+
+    return now(TClock.systemDefaultZone());
+  }
+
+  public static TYearMonth now(TZoneId zone) {
+
+    return now(TClock.system(zone));
+  }
+
+  public static TYearMonth now(TClock clock) {
+
+    final TLocalDate now = TLocalDate.now(clock);
+    return TYearMonth.of(now.getYear(), now.getMonth());
+  }
+
+  public static TYearMonth of(int year, TMonth month) {
+
+    TObjects.requireNonNull(month, "month");
+    return of(year, month.getValue());
+  }
+
+  public static TYearMonth of(int year, int month) {
+
+    YEAR.checkValidValue(year);
+    MONTH_OF_YEAR.checkValidValue(month);
+    return new TYearMonth(year, month);
+  }
+
+  public static TYearMonth from(TTemporalAccessor temporal) {
+
+    if (temporal instanceof TYearMonth) {
+      return (TYearMonth) temporal;
+    }
+    TObjects.requireNonNull(temporal, "temporal");
+    try {
+      if (TIsoChronology.INSTANCE.equals(TChronology.from(temporal)) == false) {
+        temporal = TLocalDate.from(temporal);
+      }
+      return of(temporal.get(YEAR), temporal.get(MONTH_OF_YEAR));
+    } catch (TDateTimeException ex) {
+      throw new TDateTimeException(
+          "Unable to obtain YearMonth from TemporalAccessor: " + temporal + " of type " + temporal.getClass().getName(),
+          ex);
+    }
+  }
+
+  public static TYearMonth parse(CharSequence text) {
+
+    return parse(text, PARSER);
+  }
+
+  public static TYearMonth parse(CharSequence text, TDateTimeFormatter formatter) {
+
+    TObjects.requireNonNull(formatter, "formatter");
+    return formatter.parse(text, TYearMonth::from);
+  }
+
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/time/TZoneId.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/time/TZoneId.java
@@ -1,0 +1,183 @@
+package org.teavm.classlib.java.time;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+import org.teavm.classlib.java.lang.TIllegalArgumentException;
+import org.teavm.classlib.java.time.format.TDateTimeFormatterBuilder;
+import org.teavm.classlib.java.time.format.TTextStyle;
+import org.teavm.classlib.java.time.temporal.TTemporalAccessor;
+import org.teavm.classlib.java.time.temporal.TTemporalField;
+import org.teavm.classlib.java.time.temporal.TTemporalQueries;
+import org.teavm.classlib.java.time.temporal.TTemporalQuery;
+import org.teavm.classlib.java.time.temporal.TUnsupportedTemporalTypeException;
+import org.teavm.classlib.java.time.zone.TZoneRules;
+import org.teavm.classlib.java.util.TLocale;
+import org.teavm.classlib.java.util.TMap;
+import org.teavm.classlib.java.util.TObjects;
+
+public abstract class TZoneId {
+
+  private static Set<String> AVAILABLE_ZONE_IDS = Collections
+      .unmodifiableSet(new HashSet<>(Arrays.asList("Z", "GMT", "GMT0", "UTC")));
+
+  TZoneId() {
+
+  }
+
+  public abstract String getId();
+
+  public String getDisplayName(TTextStyle style, TLocale locale) {
+
+    return new TDateTimeFormatterBuilder().appendZoneText(style).toFormatter(locale).format(toTemporal());
+  }
+
+  private TTemporalAccessor toTemporal() {
+
+    return new TTemporalAccessor() {
+      @Override
+      public boolean isSupported(TTemporalField field) {
+
+        return false;
+      }
+
+      @Override
+      public long getLong(TTemporalField field) {
+
+        throw new TUnsupportedTemporalTypeException("Unsupported field: " + field);
+      }
+
+      @SuppressWarnings("unchecked")
+      @Override
+      public <R> R query(TTemporalQuery<R> query) {
+
+        if (query == TTemporalQueries.zoneId()) {
+          return (R) TZoneId.this;
+        }
+        return TTemporalAccessor.super.query(query);
+      }
+    };
+  }
+
+  public abstract TZoneRules getRules();
+
+  public TZoneId normalized() {
+
+    try {
+      TZoneRules rules = getRules();
+      if (rules.isFixedOffset()) {
+        return rules.getOffset(TInstant.EPOCH);
+      }
+    } catch (RuntimeException ex) {
+    }
+    return this;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+
+    if (this == obj) {
+      return true;
+    }
+    if (obj instanceof TZoneId) {
+      TZoneId other = (TZoneId) obj;
+      return getId().equals(other.getId());
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+
+    return getId().hashCode();
+  }
+
+  public static TZoneId systemDefault() {
+
+    // return TTimeZone.getDefault().toZoneId();
+    return TZoneOffset.UTC;
+  }
+
+  public static Set<String> getAvailableZoneIds() {
+
+    return AVAILABLE_ZONE_IDS;
+  }
+
+  public static TZoneId of(String zoneId, TMap<String, String> aliasMap) {
+
+    Objects.requireNonNull(zoneId, "zoneId");
+    Objects.requireNonNull(aliasMap, "aliasMap");
+    String id = Objects.requireNonNullElse(aliasMap.get(zoneId), zoneId);
+    return of(id);
+  }
+
+  public static TZoneId of(String zoneId) {
+
+    return of(zoneId, true);
+  }
+
+  public static TZoneId ofOffset(String prefix, TZoneOffset offset) {
+
+    TObjects.requireNonNull(prefix, "prefix");
+    TObjects.requireNonNull(offset, "offset");
+    if (prefix.isEmpty()) {
+      return offset;
+    }
+
+    if (!prefix.equals("GMT") && !prefix.equals("UTC") && !prefix.equals("UT")) {
+      throw new TIllegalArgumentException("prefix should be GMT, UTC or UT, is: " + prefix);
+    }
+
+    if (offset.getTotalSeconds() != 0) {
+      prefix = prefix.concat(offset.getId());
+    }
+    return new TZoneRegion(prefix, offset.getRules());
+  }
+
+  static TZoneId of(String zoneId, boolean checkAvailable) {
+
+    TObjects.requireNonNull(zoneId, "zoneId");
+    if (zoneId.length() <= 1 || zoneId.startsWith("+") || zoneId.startsWith("-")) {
+      return TZoneOffset.of(zoneId);
+    } else if (zoneId.startsWith("UTC") || zoneId.startsWith("GMT")) {
+      return ofWithPrefix(zoneId, 3, checkAvailable);
+    } else if (zoneId.startsWith("UT")) {
+      return ofWithPrefix(zoneId, 2, checkAvailable);
+    }
+    return TZoneRegion.ofId(zoneId, checkAvailable);
+  }
+
+  private static TZoneId ofWithPrefix(String zoneId, int prefixLength, boolean checkAvailable) {
+
+    String prefix = zoneId.substring(0, prefixLength);
+    if (zoneId.length() == prefixLength) {
+      return ofOffset(prefix, TZoneOffset.UTC);
+    }
+    if (zoneId.charAt(prefixLength) != '+' && zoneId.charAt(prefixLength) != '-') {
+      return TZoneRegion.ofId(zoneId, checkAvailable);
+    }
+    try {
+      TZoneOffset offset = TZoneOffset.of(zoneId.substring(prefixLength));
+      if (offset == TZoneOffset.UTC) {
+        return ofOffset(prefix, offset);
+      }
+      return ofOffset(prefix, offset);
+    } catch (TDateTimeException ex) {
+      throw new TDateTimeException("Invalid ID for offset-based ZoneId: " + zoneId, ex);
+    }
+  }
+
+  public static TZoneId from(TTemporalAccessor temporal) {
+
+    TZoneId obj = temporal.query(TTemporalQueries.zone());
+    if (obj == null) {
+      throw new TDateTimeException(
+          "Unable to obtain ZoneId from TemporalAccessor: " + temporal + " of type " + temporal.getClass().getName());
+    }
+    return obj;
+  }
+
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/time/TZoneOffset.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/time/TZoneOffset.java
@@ -1,0 +1,290 @@
+package org.teavm.classlib.java.time;
+
+import static org.teavm.classlib.java.time.TLocalTime.MINUTES_PER_HOUR;
+import static org.teavm.classlib.java.time.TLocalTime.SECONDS_PER_HOUR;
+import static org.teavm.classlib.java.time.TLocalTime.SECONDS_PER_MINUTE;
+
+import org.teavm.classlib.java.io.TSerializable;
+import org.teavm.classlib.java.lang.TComparable;
+import org.teavm.classlib.java.lang.TMath;
+import org.teavm.classlib.java.lang.TStringBuilder;
+import org.teavm.classlib.java.time.temporal.TChronoField;
+import org.teavm.classlib.java.time.temporal.TTemporal;
+import org.teavm.classlib.java.time.temporal.TTemporalAccessor;
+import org.teavm.classlib.java.time.temporal.TTemporalAdjuster;
+import org.teavm.classlib.java.time.temporal.TTemporalField;
+import org.teavm.classlib.java.time.temporal.TTemporalQueries;
+import org.teavm.classlib.java.time.temporal.TTemporalQuery;
+import org.teavm.classlib.java.time.temporal.TUnsupportedTemporalTypeException;
+import org.teavm.classlib.java.time.zone.TZoneRules;
+import org.teavm.classlib.java.util.TObjects;
+
+public class TZoneOffset extends TZoneId
+    implements TTemporalAccessor, TTemporalAdjuster, TComparable<TZoneOffset>, TSerializable {
+
+  private static final int MAX_SECONDS = 18 * SECONDS_PER_HOUR;
+
+  public static final TZoneOffset UTC = TZoneOffset.ofTotalSeconds(0);
+
+  public static final TZoneOffset MIN = TZoneOffset.ofTotalSeconds(-MAX_SECONDS);
+
+  public static final TZoneOffset MAX = TZoneOffset.ofTotalSeconds(MAX_SECONDS);
+
+  private final int totalSeconds;
+
+  private final transient String id;
+
+  private TZoneOffset(int totalSeconds) {
+
+    super();
+    this.totalSeconds = totalSeconds;
+    this.id = buildId(totalSeconds);
+  }
+
+  private static String buildId(int totalSeconds) {
+
+    if (totalSeconds == 0) {
+      return "Z";
+    } else {
+      int absTotalSeconds = TMath.abs(totalSeconds);
+      TStringBuilder buf = new TStringBuilder();
+      int absHours = absTotalSeconds / SECONDS_PER_HOUR;
+      int absMinutes = (absTotalSeconds / SECONDS_PER_MINUTE) % MINUTES_PER_HOUR;
+      buf.append(totalSeconds < 0 ? "-" : "+").append(absHours < 10 ? "0" : "").append(absHours)
+          .append(absMinutes < 10 ? ":0" : ":").append(absMinutes);
+      int absSeconds = absTotalSeconds % SECONDS_PER_MINUTE;
+      if (absSeconds != 0) {
+        buf.append(absSeconds < 10 ? ":0" : ":").append(absSeconds);
+      }
+      return buf.toString();
+    }
+  }
+
+  public int getTotalSeconds() {
+
+    return this.totalSeconds;
+  }
+
+  @Override
+  public String getId() {
+
+    return this.id;
+  }
+
+  @Override
+  public TZoneRules getRules() {
+
+    return TZoneRules.of(this);
+  }
+
+  @Override
+  public boolean isSupported(TTemporalField field) {
+
+    if (field instanceof TChronoField) {
+      return field == TChronoField.OFFSET_SECONDS;
+    }
+    return field != null && field.isSupportedBy(this);
+  }
+
+  @Override
+  public int get(TTemporalField field) {
+
+    if (field == TChronoField.OFFSET_SECONDS) {
+      return this.totalSeconds;
+    } else if (field instanceof TChronoField) {
+      throw new TUnsupportedTemporalTypeException("Unsupported field: " + field);
+    }
+    return range(field).checkValidIntValue(getLong(field), field);
+  }
+
+  @Override
+  public long getLong(TTemporalField field) {
+
+    if (field == TChronoField.OFFSET_SECONDS) {
+      return this.totalSeconds;
+    } else if (field instanceof TChronoField) {
+      throw new TUnsupportedTemporalTypeException("Unsupported field: " + field);
+    }
+    return field.getFrom(this);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public <R> R query(TTemporalQuery<R> query) {
+
+    if (query == TTemporalQueries.offset() || query == TTemporalQueries.zone()) {
+      return (R) this;
+    }
+    return TTemporalAccessor.super.query(query);
+  }
+
+  @Override
+  public TTemporal adjustInto(TTemporal temporal) {
+
+    return temporal.with(TChronoField.OFFSET_SECONDS, this.totalSeconds);
+  }
+
+  @Override
+  public int compareTo(TZoneOffset other) {
+
+    return other.totalSeconds - this.totalSeconds;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+
+    if (this == obj) {
+      return true;
+    }
+    if (obj instanceof TZoneOffset) {
+      return this.totalSeconds == ((TZoneOffset) obj).totalSeconds;
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+
+    return this.totalSeconds;
+  }
+
+  @Override
+  public String toString() {
+
+    return this.id;
+  }
+
+  public static TZoneOffset of(String offsetId) {
+
+    TObjects.requireNonNull(offsetId, "offsetId");
+    if (offsetId.equals("Z")) {
+      return UTC;
+    }
+
+    final int hours, minutes, seconds;
+    switch (offsetId.length()) {
+      case 2:
+        offsetId = offsetId.charAt(0) + "0" + offsetId.charAt(1); // fallthru
+      case 3:
+        hours = parseNumber(offsetId, 1, false);
+        minutes = 0;
+        seconds = 0;
+        break;
+      case 5:
+        hours = parseNumber(offsetId, 1, false);
+        minutes = parseNumber(offsetId, 3, false);
+        seconds = 0;
+        break;
+      case 6:
+        hours = parseNumber(offsetId, 1, false);
+        minutes = parseNumber(offsetId, 4, true);
+        seconds = 0;
+        break;
+      case 7:
+        hours = parseNumber(offsetId, 1, false);
+        minutes = parseNumber(offsetId, 3, false);
+        seconds = parseNumber(offsetId, 5, false);
+        break;
+      case 9:
+        hours = parseNumber(offsetId, 1, false);
+        minutes = parseNumber(offsetId, 4, true);
+        seconds = parseNumber(offsetId, 7, true);
+        break;
+      default:
+        throw new TDateTimeException("Invalid ID for ZoneOffset, invalid format: " + offsetId);
+    }
+    char first = offsetId.charAt(0);
+    if (first != '+' && first != '-') {
+      throw new TDateTimeException("Invalid ID for ZoneOffset, plus/minus not found when expected: " + offsetId);
+    }
+    if (first == '-') {
+      return ofHoursMinutesSeconds(-hours, -minutes, -seconds);
+    } else {
+      return ofHoursMinutesSeconds(hours, minutes, seconds);
+    }
+  }
+
+  private static int parseNumber(CharSequence offsetId, int pos, boolean precededByColon) {
+
+    if (precededByColon && offsetId.charAt(pos - 1) != ':') {
+      throw new TDateTimeException("Invalid ID for ZoneOffset, colon not found when expected: " + offsetId);
+    }
+    char ch1 = offsetId.charAt(pos);
+    char ch2 = offsetId.charAt(pos + 1);
+    if (ch1 < '0' || ch1 > '9' || ch2 < '0' || ch2 > '9') {
+      throw new TDateTimeException("Invalid ID for ZoneOffset, non numeric characters found: " + offsetId);
+    }
+    return (ch1 - 48) * 10 + (ch2 - 48);
+  }
+
+  public static TZoneOffset ofHours(int hours) {
+
+    return ofHoursMinutesSeconds(hours, 0, 0);
+  }
+
+  public static TZoneOffset ofHoursMinutes(int hours, int minutes) {
+
+    return ofHoursMinutesSeconds(hours, minutes, 0);
+  }
+
+  public static TZoneOffset ofHoursMinutesSeconds(int hours, int minutes, int seconds) {
+
+    validate(hours, minutes, seconds);
+    int totalSeconds = totalSeconds(hours, minutes, seconds);
+    return ofTotalSeconds(totalSeconds);
+  }
+
+  public static TZoneOffset from(TTemporalAccessor temporal) {
+
+    TObjects.requireNonNull(temporal, "temporal");
+    TZoneOffset offset = temporal.query(TTemporalQueries.offset());
+    if (offset == null) {
+      throw new TDateTimeException("Unable to obtain ZoneOffset from TemporalAccessor: " + temporal + " of type "
+          + temporal.getClass().getName());
+    }
+    return offset;
+  }
+
+  private static void validate(int hours, int minutes, int seconds) {
+
+    if (hours < -18 || hours > 18) {
+      throw new TDateTimeException(
+          "Zone offset hours not in valid range: value " + hours + " is not in the range -18 to 18");
+    }
+    if (hours > 0) {
+      if (minutes < 0 || seconds < 0) {
+        throw new TDateTimeException("Zone offset minutes and seconds must be positive because hours is positive");
+      }
+    } else if (hours < 0) {
+      if (minutes > 0 || seconds > 0) {
+        throw new TDateTimeException("Zone offset minutes and seconds must be negative because hours is negative");
+      }
+    } else if ((minutes > 0 && seconds < 0) || (minutes < 0 && seconds > 0)) {
+      throw new TDateTimeException("Zone offset minutes and seconds must have the same sign");
+    }
+    if (minutes < -59 || minutes > 59) {
+      throw new TDateTimeException(
+          "Zone offset minutes not in valid range: value " + minutes + " is not in the range -59 to 59");
+    }
+    if (seconds < -59 || seconds > 59) {
+      throw new TDateTimeException(
+          "Zone offset seconds not in valid range: value " + seconds + " is not in the range -59 to 59");
+    }
+    if (TMath.abs(hours) == 18 && (minutes | seconds) != 0) {
+      throw new TDateTimeException("Zone offset not in valid range: -18:00 to +18:00");
+    }
+  }
+
+  private static int totalSeconds(int hours, int minutes, int seconds) {
+
+    return hours * SECONDS_PER_HOUR + minutes * SECONDS_PER_MINUTE + seconds;
+  }
+
+  public static TZoneOffset ofTotalSeconds(int totalSeconds) {
+
+    if (totalSeconds < -MAX_SECONDS || totalSeconds > MAX_SECONDS) {
+      throw new TDateTimeException("Zone offset not in valid range: -18:00 to +18:00");
+    }
+    return new TZoneOffset(totalSeconds);
+  }
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/time/TZoneRegion.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/time/TZoneRegion.java
@@ -1,0 +1,69 @@
+package org.teavm.classlib.java.time;
+
+import org.teavm.classlib.java.io.TSerializable;
+import org.teavm.classlib.java.time.zone.TZoneRules;
+import org.teavm.classlib.java.util.TObjects;
+
+final class TZoneRegion extends TZoneId implements TSerializable {
+
+  private final String id;
+
+  private final transient TZoneRules rules;
+
+  static TZoneRegion ofId(String zoneId, boolean checkAvailable) {
+
+    TObjects.requireNonNull(zoneId, "zoneId");
+    checkName(zoneId);
+    TZoneRules rules = null;
+    return new TZoneRegion(zoneId, rules);
+  }
+
+  private static void checkName(String zoneId) {
+
+    int n = zoneId.length();
+    if (n < 2) {
+      throw new TDateTimeException("Invalid ID for region-based ZoneId, invalid format: " + zoneId);
+    }
+    for (int i = 0; i < n; i++) {
+      char c = zoneId.charAt(i);
+      if (c >= 'a' && c <= 'z')
+        continue;
+      if (c >= 'A' && c <= 'Z')
+        continue;
+      if (c == '/' && i != 0)
+        continue;
+      if (c >= '0' && c <= '9' && i != 0)
+        continue;
+      if (c == '~' && i != 0)
+        continue;
+      if (c == '.' && i != 0)
+        continue;
+      if (c == '_' && i != 0)
+        continue;
+      if (c == '+' && i != 0)
+        continue;
+      if (c == '-' && i != 0)
+        continue;
+      throw new TDateTimeException("Invalid ID for region-based ZoneId, invalid format: " + zoneId);
+    }
+  }
+
+  TZoneRegion(String id, TZoneRules rules) {
+
+    this.id = id;
+    this.rules = rules;
+  }
+
+  @Override
+  public String getId() {
+
+    return this.id;
+  }
+
+  @Override
+  public TZoneRules getRules() {
+
+    return this.rules;
+  }
+
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/time/TZonedDateTime.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/time/TZonedDateTime.java
@@ -1,0 +1,664 @@
+package org.teavm.classlib.java.time;
+
+import static org.teavm.classlib.java.time.temporal.TChronoField.INSTANT_SECONDS;
+import static org.teavm.classlib.java.time.temporal.TChronoField.NANO_OF_SECOND;
+import static org.teavm.classlib.java.time.temporal.TChronoField.OFFSET_SECONDS;
+
+import java.util.List;
+
+import org.teavm.classlib.java.io.TSerializable;
+import org.teavm.classlib.java.lang.TIllegalArgumentException;
+import org.teavm.classlib.java.time.chrono.TChronoZonedDateTime;
+import org.teavm.classlib.java.time.format.TDateTimeFormatter;
+import org.teavm.classlib.java.time.temporal.TChronoField;
+import org.teavm.classlib.java.time.temporal.TChronoUnit;
+import org.teavm.classlib.java.time.temporal.TTemporal;
+import org.teavm.classlib.java.time.temporal.TTemporalAccessor;
+import org.teavm.classlib.java.time.temporal.TTemporalAdjuster;
+import org.teavm.classlib.java.time.temporal.TTemporalAmount;
+import org.teavm.classlib.java.time.temporal.TTemporalField;
+import org.teavm.classlib.java.time.temporal.TTemporalQueries;
+import org.teavm.classlib.java.time.temporal.TTemporalQuery;
+import org.teavm.classlib.java.time.temporal.TTemporalUnit;
+import org.teavm.classlib.java.time.temporal.TUnsupportedTemporalTypeException;
+import org.teavm.classlib.java.time.temporal.TValueRange;
+import org.teavm.classlib.java.time.zone.TZoneOffsetTransition;
+import org.teavm.classlib.java.time.zone.TZoneRules;
+import org.teavm.classlib.java.util.TObjects;
+
+public final class TZonedDateTime implements TTemporal, TChronoZonedDateTime<TLocalDate>, TSerializable {
+
+  private final TLocalDateTime dateTime;
+
+  private final TZoneOffset offset;
+
+  private final TZoneId zone;
+
+  private TZonedDateTime(TLocalDateTime dateTime, TZoneOffset offset, TZoneId zone) {
+
+    this.dateTime = dateTime;
+    this.offset = offset;
+    this.zone = zone;
+  }
+
+  private TZonedDateTime resolveLocal(TLocalDateTime newDateTime) {
+
+    return ofLocal(newDateTime, this.zone, this.offset);
+  }
+
+  private TZonedDateTime resolveInstant(TLocalDateTime newDateTime) {
+
+    return ofInstant(newDateTime, this.offset, this.zone);
+  }
+
+  private TZonedDateTime resolveOffset(TZoneOffset offset) {
+
+    if (offset.equals(this.offset) == false && this.zone.getRules().isValidOffset(this.dateTime, offset)) {
+      return new TZonedDateTime(this.dateTime, offset, this.zone);
+    }
+    return this;
+  }
+
+  @Override
+  public boolean isSupported(TTemporalField field) {
+
+    return field instanceof TChronoField || (field != null && field.isSupportedBy(this));
+  }
+
+  @Override
+  public boolean isSupported(TTemporalUnit unit) {
+
+    return TChronoZonedDateTime.super.isSupported(unit);
+  }
+
+  @Override
+  public TValueRange range(TTemporalField field) {
+
+    if (field instanceof TChronoField) {
+      if (field == INSTANT_SECONDS || field == OFFSET_SECONDS) {
+        return field.range();
+      }
+      return this.dateTime.range(field);
+    }
+    return field.rangeRefinedBy(this);
+  }
+
+  @Override
+  public int get(TTemporalField field) {
+
+    if (field instanceof TChronoField) {
+      switch ((TChronoField) field) {
+        case INSTANT_SECONDS:
+          throw new TUnsupportedTemporalTypeException(
+              "Invalid field 'InstantSeconds' for get() method, use getLong() instead");
+        case OFFSET_SECONDS:
+          return getOffset().getTotalSeconds();
+      }
+      return this.dateTime.get(field);
+    }
+    return TChronoZonedDateTime.super.get(field);
+  }
+
+  @Override
+  public long getLong(TTemporalField field) {
+
+    if (field instanceof TChronoField) {
+      switch ((TChronoField) field) {
+        case INSTANT_SECONDS:
+          return toEpochSecond();
+        case OFFSET_SECONDS:
+          return getOffset().getTotalSeconds();
+      }
+      return this.dateTime.getLong(field);
+    }
+    return field.getFrom(this);
+  }
+
+  @Override
+  public TZoneOffset getOffset() {
+
+    return this.offset;
+  }
+
+  @Override
+  public TZonedDateTime withEarlierOffsetAtOverlap() {
+
+    TZoneOffsetTransition trans = getZone().getRules().getTransition(this.dateTime);
+    if (trans != null && trans.isOverlap()) {
+      TZoneOffset earlierOffset = trans.getOffsetBefore();
+      if (earlierOffset.equals(this.offset) == false) {
+        return new TZonedDateTime(this.dateTime, earlierOffset, this.zone);
+      }
+    }
+    return this;
+  }
+
+  @Override
+  public TZonedDateTime withLaterOffsetAtOverlap() {
+
+    TZoneOffsetTransition trans = getZone().getRules().getTransition(toLocalDateTime());
+    if (trans != null) {
+      TZoneOffset laterOffset = trans.getOffsetAfter();
+      if (laterOffset.equals(this.offset) == false) {
+        return new TZonedDateTime(this.dateTime, laterOffset, this.zone);
+      }
+    }
+    return this;
+  }
+
+  @Override
+  public TZoneId getZone() {
+
+    return this.zone;
+  }
+
+  @Override
+  public TZonedDateTime withZoneSameLocal(TZoneId zone) {
+
+    TObjects.requireNonNull(zone, "zone");
+    return this.zone.equals(zone) ? this : ofLocal(this.dateTime, zone, this.offset);
+  }
+
+  @Override
+  public TZonedDateTime withZoneSameInstant(TZoneId zone) {
+
+    TObjects.requireNonNull(zone, "zone");
+    return this.zone.equals(zone) ? this
+        : create(this.dateTime.toEpochSecond(this.offset), this.dateTime.getNano(), zone);
+  }
+
+  public TZonedDateTime withFixedOffsetZone() {
+
+    return this.zone.equals(this.offset) ? this : new TZonedDateTime(this.dateTime, this.offset, this.offset);
+  }
+
+  @Override
+  public TLocalDateTime toLocalDateTime() {
+
+    return this.dateTime;
+  }
+
+  @Override
+  public TLocalDate toLocalDate() {
+
+    return this.dateTime.toLocalDate();
+  }
+
+  public int getYear() {
+
+    return this.dateTime.getYear();
+  }
+
+  public int getMonthValue() {
+
+    return this.dateTime.getMonthValue();
+  }
+
+  public TMonth getMonth() {
+
+    return this.dateTime.getMonth();
+  }
+
+  public int getDayOfMonth() {
+
+    return this.dateTime.getDayOfMonth();
+  }
+
+  public int getDayOfYear() {
+
+    return this.dateTime.getDayOfYear();
+  }
+
+  public TDayOfWeek getDayOfWeek() {
+
+    return this.dateTime.getDayOfWeek();
+  }
+
+  @Override
+  public TLocalTime toLocalTime() {
+
+    return this.dateTime.toLocalTime();
+  }
+
+  public int getHour() {
+
+    return this.dateTime.getHour();
+  }
+
+  public int getMinute() {
+
+    return this.dateTime.getMinute();
+  }
+
+  public int getSecond() {
+
+    return this.dateTime.getSecond();
+  }
+
+  public int getNano() {
+
+    return this.dateTime.getNano();
+  }
+
+  @Override
+  public TZonedDateTime with(TTemporalAdjuster adjuster) {
+
+    // optimizations
+    if (adjuster instanceof TLocalDate) {
+      return resolveLocal(TLocalDateTime.of((TLocalDate) adjuster, this.dateTime.toLocalTime()));
+    } else if (adjuster instanceof TLocalTime) {
+      return resolveLocal(TLocalDateTime.of(this.dateTime.toLocalDate(), (TLocalTime) adjuster));
+    } else if (adjuster instanceof TLocalDateTime) {
+      return resolveLocal((TLocalDateTime) adjuster);
+    } else if (adjuster instanceof TOffsetDateTime) {
+      TOffsetDateTime odt = (TOffsetDateTime) adjuster;
+      return ofLocal(odt.toLocalDateTime(), this.zone, odt.getOffset());
+    } else if (adjuster instanceof TInstant) {
+      TInstant instant = (TInstant) adjuster;
+      return create(instant.getEpochSecond(), instant.getNano(), this.zone);
+    } else if (adjuster instanceof TZoneOffset) {
+      return resolveOffset((TZoneOffset) adjuster);
+    }
+    return (TZonedDateTime) adjuster.adjustInto(this);
+  }
+
+  @Override
+  public TZonedDateTime with(TTemporalField field, long newValue) {
+
+    if (field instanceof TChronoField) {
+      TChronoField f = (TChronoField) field;
+      switch (f) {
+        case INSTANT_SECONDS:
+          return create(newValue, getNano(), this.zone);
+        case OFFSET_SECONDS:
+          TZoneOffset offset = TZoneOffset.ofTotalSeconds(f.checkValidIntValue(newValue));
+          return resolveOffset(offset);
+      }
+      return resolveLocal(this.dateTime.with(field, newValue));
+    }
+    return field.adjustInto(this, newValue);
+  }
+
+  public TZonedDateTime withYear(int year) {
+
+    return resolveLocal(this.dateTime.withYear(year));
+  }
+
+  public TZonedDateTime withMonth(int month) {
+
+    return resolveLocal(this.dateTime.withMonth(month));
+  }
+
+  public TZonedDateTime withDayOfMonth(int dayOfMonth) {
+
+    return resolveLocal(this.dateTime.withDayOfMonth(dayOfMonth));
+  }
+
+  public TZonedDateTime withDayOfYear(int dayOfYear) {
+
+    return resolveLocal(this.dateTime.withDayOfYear(dayOfYear));
+  }
+
+  public TZonedDateTime withHour(int hour) {
+
+    return resolveLocal(this.dateTime.withHour(hour));
+  }
+
+  public TZonedDateTime withMinute(int minute) {
+
+    return resolveLocal(this.dateTime.withMinute(minute));
+  }
+
+  public TZonedDateTime withSecond(int second) {
+
+    return resolveLocal(this.dateTime.withSecond(second));
+  }
+
+  public TZonedDateTime withNano(int nanoOfSecond) {
+
+    return resolveLocal(this.dateTime.withNano(nanoOfSecond));
+  }
+
+  public TZonedDateTime truncatedTo(TTemporalUnit unit) {
+
+    return resolveLocal(this.dateTime.truncatedTo(unit));
+  }
+
+  @Override
+  public TZonedDateTime plus(TTemporalAmount amountToAdd) {
+
+    if (amountToAdd instanceof TPeriod) {
+      TPeriod periodToAdd = (TPeriod) amountToAdd;
+      return resolveLocal(this.dateTime.plus(periodToAdd));
+    }
+    TObjects.requireNonNull(amountToAdd, "amountToAdd");
+    return (TZonedDateTime) amountToAdd.addTo(this);
+  }
+
+  @Override
+  public TZonedDateTime plus(long amountToAdd, TTemporalUnit unit) {
+
+    if (unit instanceof TChronoUnit) {
+      if (unit.isDateBased()) {
+        return resolveLocal(this.dateTime.plus(amountToAdd, unit));
+      } else {
+        return resolveInstant(this.dateTime.plus(amountToAdd, unit));
+      }
+    }
+    return unit.addTo(this, amountToAdd);
+  }
+
+  public TZonedDateTime plusYears(long years) {
+
+    return resolveLocal(this.dateTime.plusYears(years));
+  }
+
+  public TZonedDateTime plusMonths(long months) {
+
+    return resolveLocal(this.dateTime.plusMonths(months));
+  }
+
+  public TZonedDateTime plusWeeks(long weeks) {
+
+    return resolveLocal(this.dateTime.plusWeeks(weeks));
+  }
+
+  public TZonedDateTime plusDays(long days) {
+
+    return resolveLocal(this.dateTime.plusDays(days));
+  }
+
+  public TZonedDateTime plusHours(long hours) {
+
+    return resolveInstant(this.dateTime.plusHours(hours));
+  }
+
+  public TZonedDateTime plusMinutes(long minutes) {
+
+    return resolveInstant(this.dateTime.plusMinutes(minutes));
+  }
+
+  public TZonedDateTime plusSeconds(long seconds) {
+
+    return resolveInstant(this.dateTime.plusSeconds(seconds));
+  }
+
+  public TZonedDateTime plusNanos(long nanos) {
+
+    return resolveInstant(this.dateTime.plusNanos(nanos));
+  }
+
+  @Override
+  public TZonedDateTime minus(TTemporalAmount amountToSubtract) {
+
+    if (amountToSubtract instanceof TPeriod) {
+      TPeriod periodToSubtract = (TPeriod) amountToSubtract;
+      return resolveLocal(this.dateTime.minus(periodToSubtract));
+    }
+    TObjects.requireNonNull(amountToSubtract, "amountToSubtract");
+    return (TZonedDateTime) amountToSubtract.subtractFrom(this);
+  }
+
+  @Override
+  public TZonedDateTime minus(long amountToSubtract, TTemporalUnit unit) {
+
+    return (amountToSubtract == Long.MIN_VALUE ? plus(Long.MAX_VALUE, unit).plus(1, unit)
+        : plus(-amountToSubtract, unit));
+  }
+
+  public TZonedDateTime minusYears(long years) {
+
+    return (years == Long.MIN_VALUE ? plusYears(Long.MAX_VALUE).plusYears(1) : plusYears(-years));
+  }
+
+  public TZonedDateTime minusMonths(long months) {
+
+    return (months == Long.MIN_VALUE ? plusMonths(Long.MAX_VALUE).plusMonths(1) : plusMonths(-months));
+  }
+
+  public TZonedDateTime minusWeeks(long weeks) {
+
+    return (weeks == Long.MIN_VALUE ? plusWeeks(Long.MAX_VALUE).plusWeeks(1) : plusWeeks(-weeks));
+  }
+
+  public TZonedDateTime minusDays(long days) {
+
+    return (days == Long.MIN_VALUE ? plusDays(Long.MAX_VALUE).plusDays(1) : plusDays(-days));
+  }
+
+  public TZonedDateTime minusHours(long hours) {
+
+    return (hours == Long.MIN_VALUE ? plusHours(Long.MAX_VALUE).plusHours(1) : plusHours(-hours));
+  }
+
+  public TZonedDateTime minusMinutes(long minutes) {
+
+    return (minutes == Long.MIN_VALUE ? plusMinutes(Long.MAX_VALUE).plusMinutes(1) : plusMinutes(-minutes));
+  }
+
+  public TZonedDateTime minusSeconds(long seconds) {
+
+    return (seconds == Long.MIN_VALUE ? plusSeconds(Long.MAX_VALUE).plusSeconds(1) : plusSeconds(-seconds));
+  }
+
+  public TZonedDateTime minusNanos(long nanos) {
+
+    return (nanos == Long.MIN_VALUE ? plusNanos(Long.MAX_VALUE).plusNanos(1) : plusNanos(-nanos));
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public <R> R query(TTemporalQuery<R> query) {
+
+    if (query == TTemporalQueries.localDate()) {
+      return (R) toLocalDate();
+    }
+    return TChronoZonedDateTime.super.query(query);
+  }
+
+  @Override
+  public long until(TTemporal endExclusive, TTemporalUnit unit) {
+
+    TZonedDateTime end = TZonedDateTime.from(endExclusive);
+    if (unit instanceof TChronoUnit) {
+      end = end.withZoneSameInstant(this.zone);
+      if (unit.isDateBased()) {
+        return this.dateTime.until(end.dateTime, unit);
+      } else {
+        return toOffsetDateTime().until(end.toOffsetDateTime(), unit);
+      }
+    }
+    return unit.between(this, end);
+  }
+
+  @Override
+  public String format(TDateTimeFormatter formatter) {
+
+    TObjects.requireNonNull(formatter, "formatter");
+    return formatter.format(this);
+  }
+
+  public TOffsetDateTime toOffsetDateTime() {
+
+    return TOffsetDateTime.of(this.dateTime, this.offset);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+
+    if (this == obj) {
+      return true;
+    }
+    if (obj instanceof TZonedDateTime) {
+      TZonedDateTime other = (TZonedDateTime) obj;
+      return this.dateTime.equals(other.dateTime) && this.offset.equals(other.offset) && this.zone.equals(other.zone);
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+
+    return this.dateTime.hashCode() ^ this.offset.hashCode() ^ Integer.rotateLeft(this.zone.hashCode(), 3);
+  }
+
+  @Override
+  public String toString() {
+
+    String str = this.dateTime.toString() + this.offset.toString();
+    if (this.offset != this.zone) {
+      str += '[' + this.zone.toString() + ']';
+    }
+    return str;
+  }
+
+  public static TZonedDateTime now() {
+
+    return now(TClock.systemDefaultZone());
+  }
+
+  public static TZonedDateTime now(TZoneId zone) {
+
+    return now(TClock.system(zone));
+  }
+
+  public static TZonedDateTime now(TClock clock) {
+
+    TObjects.requireNonNull(clock, "clock");
+    final TInstant now = clock.instant();
+    return ofInstant(now, clock.getZone());
+  }
+
+  public static TZonedDateTime of(TLocalDate date, TLocalTime time, TZoneId zone) {
+
+    return of(TLocalDateTime.of(date, time), zone);
+  }
+
+  public static TZonedDateTime of(TLocalDateTime localDateTime, TZoneId zone) {
+
+    return ofLocal(localDateTime, zone, null);
+  }
+
+  public static TZonedDateTime of(int year, int month, int dayOfMonth, int hour, int minute, int second,
+      int nanoOfSecond, TZoneId zone) {
+
+    TLocalDateTime dt = TLocalDateTime.of(year, month, dayOfMonth, hour, minute, second, nanoOfSecond);
+    return ofLocal(dt, zone, null);
+  }
+
+  public static TZonedDateTime ofLocal(TLocalDateTime localDateTime, TZoneId zone, TZoneOffset preferredOffset) {
+
+    TObjects.requireNonNull(localDateTime, "localDateTime");
+    TObjects.requireNonNull(zone, "zone");
+    if (zone instanceof TZoneOffset) {
+      return new TZonedDateTime(localDateTime, (TZoneOffset) zone, zone);
+    }
+    TZoneRules rules = zone.getRules();
+    List<TZoneOffset> validOffsets = rules.getValidOffsets(localDateTime);
+    TZoneOffset offset;
+    if (validOffsets.size() == 1) {
+      offset = validOffsets.get(0);
+    } else if (validOffsets.size() == 0) {
+      TZoneOffsetTransition trans = rules.getTransition(localDateTime);
+      localDateTime = localDateTime.plusSeconds(trans.getDuration().getSeconds());
+      offset = trans.getOffsetAfter();
+    } else {
+      if (preferredOffset != null && validOffsets.contains(preferredOffset)) {
+        offset = preferredOffset;
+      } else {
+        offset = TObjects.requireNonNull(validOffsets.get(0), "offset");
+      }
+    }
+    return new TZonedDateTime(localDateTime, offset, zone);
+  }
+
+  public static TZonedDateTime ofInstant(TInstant instant, TZoneId zone) {
+
+    TObjects.requireNonNull(instant, "instant");
+    TObjects.requireNonNull(zone, "zone");
+    return create(instant.getEpochSecond(), instant.getNano(), zone);
+  }
+
+  public static TZonedDateTime ofInstant(TLocalDateTime localDateTime, TZoneOffset offset, TZoneId zone) {
+
+    TObjects.requireNonNull(localDateTime, "localDateTime");
+    TObjects.requireNonNull(offset, "offset");
+    TObjects.requireNonNull(zone, "zone");
+    if (zone.getRules().isValidOffset(localDateTime, offset)) {
+      return new TZonedDateTime(localDateTime, offset, zone);
+    }
+    return create(localDateTime.toEpochSecond(offset), localDateTime.getNano(), zone);
+  }
+
+  private static TZonedDateTime create(long epochSecond, int nanoOfSecond, TZoneId zone) {
+
+    TZoneRules rules = zone.getRules();
+    TInstant instant = TInstant.ofEpochSecond(epochSecond, nanoOfSecond);
+    TZoneOffset offset = rules.getOffset(instant);
+    TLocalDateTime ldt = TLocalDateTime.ofEpochSecond(epochSecond, nanoOfSecond, offset);
+    return new TZonedDateTime(ldt, offset, zone);
+  }
+
+  public static TZonedDateTime ofStrict(TLocalDateTime localDateTime, TZoneOffset offset, TZoneId zone) {
+
+    TObjects.requireNonNull(localDateTime, "localDateTime");
+    TObjects.requireNonNull(offset, "offset");
+    TObjects.requireNonNull(zone, "zone");
+    TZoneRules rules = zone.getRules();
+    if (rules.isValidOffset(localDateTime, offset) == false) {
+      TZoneOffsetTransition trans = rules.getTransition(localDateTime);
+      if (trans != null && trans.isGap()) {
+        throw new TDateTimeException("LocalDateTime '" + localDateTime + "' does not exist in zone '" + zone
+            + "' due to a gap in the local time-line, typically caused by daylight savings");
+      }
+      throw new TDateTimeException(
+          "ZoneOffset '" + offset + "' is not valid for LocalDateTime '" + localDateTime + "' in zone '" + zone + "'");
+    }
+    return new TZonedDateTime(localDateTime, offset, zone);
+  }
+
+  private static TZonedDateTime ofLenient(TLocalDateTime localDateTime, TZoneOffset offset, TZoneId zone) {
+
+    TObjects.requireNonNull(localDateTime, "localDateTime");
+    TObjects.requireNonNull(offset, "offset");
+    TObjects.requireNonNull(zone, "zone");
+    if (zone instanceof TZoneOffset && offset.equals(zone) == false) {
+      throw new TIllegalArgumentException("ZoneId must match ZoneOffset");
+    }
+    return new TZonedDateTime(localDateTime, offset, zone);
+  }
+
+  public static TZonedDateTime from(TTemporalAccessor temporal) {
+
+    if (temporal instanceof TZonedDateTime) {
+      return (TZonedDateTime) temporal;
+    }
+    try {
+      TZoneId zone = TZoneId.from(temporal);
+      if (temporal.isSupported(INSTANT_SECONDS)) {
+        long epochSecond = temporal.getLong(INSTANT_SECONDS);
+        int nanoOfSecond = temporal.get(NANO_OF_SECOND);
+        return create(epochSecond, nanoOfSecond, zone);
+      } else {
+        TLocalDate date = TLocalDate.from(temporal);
+        TLocalTime time = TLocalTime.from(temporal);
+        return of(date, time, zone);
+      }
+    } catch (TDateTimeException ex) {
+      throw new TDateTimeException("Unable to obtain ZonedDateTime from TemporalAccessor: " + temporal + " of type "
+          + temporal.getClass().getName(), ex);
+    }
+  }
+
+  public static TZonedDateTime parse(CharSequence text) {
+
+    return parse(text, TDateTimeFormatter.ISO_ZONED_DATE_TIME);
+  }
+
+  public static TZonedDateTime parse(CharSequence text, TDateTimeFormatter formatter) {
+
+    TObjects.requireNonNull(formatter, "formatter");
+    return formatter.parse(text, TZonedDateTime::from);
+  }
+
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/time/chrono/TAbstractChronology.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/time/chrono/TAbstractChronology.java
@@ -1,0 +1,289 @@
+package org.teavm.classlib.java.time.chrono;
+
+import static org.teavm.classlib.java.time.temporal.TChronoField.ALIGNED_DAY_OF_WEEK_IN_MONTH;
+import static org.teavm.classlib.java.time.temporal.TChronoField.ALIGNED_DAY_OF_WEEK_IN_YEAR;
+import static org.teavm.classlib.java.time.temporal.TChronoField.ALIGNED_WEEK_OF_MONTH;
+import static org.teavm.classlib.java.time.temporal.TChronoField.ALIGNED_WEEK_OF_YEAR;
+import static org.teavm.classlib.java.time.temporal.TChronoField.DAY_OF_MONTH;
+import static org.teavm.classlib.java.time.temporal.TChronoField.DAY_OF_WEEK;
+import static org.teavm.classlib.java.time.temporal.TChronoField.DAY_OF_YEAR;
+import static org.teavm.classlib.java.time.temporal.TChronoField.EPOCH_DAY;
+import static org.teavm.classlib.java.time.temporal.TChronoField.ERA;
+import static org.teavm.classlib.java.time.temporal.TChronoField.MONTH_OF_YEAR;
+import static org.teavm.classlib.java.time.temporal.TChronoField.PROLEPTIC_MONTH;
+import static org.teavm.classlib.java.time.temporal.TChronoField.YEAR;
+import static org.teavm.classlib.java.time.temporal.TChronoField.YEAR_OF_ERA;
+import static org.teavm.classlib.java.time.temporal.TChronoUnit.DAYS;
+import static org.teavm.classlib.java.time.temporal.TChronoUnit.MONTHS;
+import static org.teavm.classlib.java.time.temporal.TChronoUnit.WEEKS;
+
+import java.util.List;
+import java.util.Map;
+
+import org.teavm.classlib.java.time.TDateTimeException;
+import org.teavm.classlib.java.time.TDayOfWeek;
+import org.teavm.classlib.java.time.format.TResolverStyle;
+import org.teavm.classlib.java.time.temporal.TChronoField;
+import org.teavm.classlib.java.time.temporal.TTemporalAdjusters;
+import org.teavm.classlib.java.time.temporal.TTemporalField;
+import org.teavm.classlib.java.time.temporal.TValueRange;
+
+public abstract class TAbstractChronology implements TChronology {
+  @Override
+  public int compareTo(TChronology other) {
+
+    return getId().compareTo(other.getId());
+  }
+
+  @Override
+  public TChronoLocalDate resolveDate(Map<TTemporalField, Long> fieldValues, TResolverStyle resolverStyle) {
+
+    if (fieldValues.containsKey(EPOCH_DAY)) {
+      return dateEpochDay(fieldValues.remove(EPOCH_DAY));
+    }
+
+    resolveProlepticMonth(fieldValues, resolverStyle);
+
+    TChronoLocalDate resolved = resolveYearOfEra(fieldValues, resolverStyle);
+    if (resolved != null) {
+      return resolved;
+    }
+
+    if (fieldValues.containsKey(YEAR)) {
+      if (fieldValues.containsKey(MONTH_OF_YEAR)) {
+        if (fieldValues.containsKey(DAY_OF_MONTH)) {
+          return resolveYMD(fieldValues, resolverStyle);
+        }
+        if (fieldValues.containsKey(ALIGNED_WEEK_OF_MONTH)) {
+          if (fieldValues.containsKey(ALIGNED_DAY_OF_WEEK_IN_MONTH)) {
+            return resolveYMAA(fieldValues, resolverStyle);
+          }
+          if (fieldValues.containsKey(DAY_OF_WEEK)) {
+            return resolveYMAD(fieldValues, resolverStyle);
+          }
+        }
+      }
+      if (fieldValues.containsKey(DAY_OF_YEAR)) {
+        return resolveYD(fieldValues, resolverStyle);
+      }
+      if (fieldValues.containsKey(ALIGNED_WEEK_OF_YEAR)) {
+        if (fieldValues.containsKey(ALIGNED_DAY_OF_WEEK_IN_YEAR)) {
+          return resolveYAA(fieldValues, resolverStyle);
+        }
+        if (fieldValues.containsKey(DAY_OF_WEEK)) {
+          return resolveYAD(fieldValues, resolverStyle);
+        }
+      }
+    }
+    return null;
+  }
+
+  void resolveProlepticMonth(Map<TTemporalField, Long> fieldValues, TResolverStyle resolverStyle) {
+
+    Long pMonth = fieldValues.remove(PROLEPTIC_MONTH);
+    if (pMonth != null) {
+      if (resolverStyle != TResolverStyle.LENIENT) {
+        PROLEPTIC_MONTH.checkValidValue(pMonth);
+      }
+      TChronoLocalDate chronoDate = dateNow().with(DAY_OF_MONTH, 1).with(PROLEPTIC_MONTH, pMonth);
+      addFieldValue(fieldValues, MONTH_OF_YEAR, chronoDate.get(MONTH_OF_YEAR));
+      addFieldValue(fieldValues, YEAR, chronoDate.get(YEAR));
+    }
+  }
+
+  TChronoLocalDate resolveYearOfEra(Map<TTemporalField, Long> fieldValues, TResolverStyle resolverStyle) {
+
+    Long yoeLong = fieldValues.remove(YEAR_OF_ERA);
+    if (yoeLong != null) {
+      Long eraLong = fieldValues.remove(ERA);
+      int yoe;
+      if (resolverStyle != TResolverStyle.LENIENT) {
+        yoe = range(YEAR_OF_ERA).checkValidIntValue(yoeLong, YEAR_OF_ERA);
+      } else {
+        yoe = Math.toIntExact(yoeLong);
+      }
+      if (eraLong != null) {
+        TEra eraObj = eraOf(range(ERA).checkValidIntValue(eraLong, ERA));
+        addFieldValue(fieldValues, YEAR, prolepticYear(eraObj, yoe));
+      } else {
+        if (fieldValues.containsKey(YEAR)) {
+          int year = range(YEAR).checkValidIntValue(fieldValues.get(YEAR), YEAR);
+          TChronoLocalDate chronoDate = dateYearDay(year, 1);
+          addFieldValue(fieldValues, YEAR, prolepticYear(chronoDate.getEra(), yoe));
+        } else if (resolverStyle == TResolverStyle.STRICT) {
+          fieldValues.put(YEAR_OF_ERA, yoeLong);
+        } else {
+          List<TEra> eras = eras();
+          if (eras.isEmpty()) {
+            addFieldValue(fieldValues, YEAR, yoe);
+          } else {
+            TEra eraObj = eras.get(eras.size() - 1);
+            addFieldValue(fieldValues, YEAR, prolepticYear(eraObj, yoe));
+          }
+        }
+      }
+    } else if (fieldValues.containsKey(ERA)) {
+      range(ERA).checkValidValue(fieldValues.get(ERA), ERA);
+    }
+    return null;
+  }
+
+  TChronoLocalDate resolveYMD(Map<TTemporalField, Long> fieldValues, TResolverStyle resolverStyle) {
+
+    int y = range(YEAR).checkValidIntValue(fieldValues.remove(YEAR), YEAR);
+    if (resolverStyle == TResolverStyle.LENIENT) {
+      long months = Math.subtractExact(fieldValues.remove(MONTH_OF_YEAR), 1);
+      long days = Math.subtractExact(fieldValues.remove(DAY_OF_MONTH), 1);
+      return date(y, 1, 1).plus(months, MONTHS).plus(days, DAYS);
+    }
+    int moy = range(MONTH_OF_YEAR).checkValidIntValue(fieldValues.remove(MONTH_OF_YEAR), MONTH_OF_YEAR);
+    TValueRange domRange = range(DAY_OF_MONTH);
+    int dom = domRange.checkValidIntValue(fieldValues.remove(DAY_OF_MONTH), DAY_OF_MONTH);
+    if (resolverStyle == TResolverStyle.SMART) {
+      try {
+        return date(y, moy, dom);
+      } catch (TDateTimeException ex) {
+        return date(y, moy, 1).with(TTemporalAdjusters.lastDayOfMonth());
+      }
+    }
+    return date(y, moy, dom);
+  }
+
+  TChronoLocalDate resolveYD(Map<TTemporalField, Long> fieldValues, TResolverStyle resolverStyle) {
+
+    int y = range(YEAR).checkValidIntValue(fieldValues.remove(YEAR), YEAR);
+    if (resolverStyle == TResolverStyle.LENIENT) {
+      long days = Math.subtractExact(fieldValues.remove(DAY_OF_YEAR), 1);
+      return dateYearDay(y, 1).plus(days, DAYS);
+    }
+    int doy = range(DAY_OF_YEAR).checkValidIntValue(fieldValues.remove(DAY_OF_YEAR), DAY_OF_YEAR);
+    return dateYearDay(y, doy);
+  }
+
+  TChronoLocalDate resolveYMAA(Map<TTemporalField, Long> fieldValues, TResolverStyle resolverStyle) {
+
+    int y = range(YEAR).checkValidIntValue(fieldValues.remove(YEAR), YEAR);
+    if (resolverStyle == TResolverStyle.LENIENT) {
+      long months = Math.subtractExact(fieldValues.remove(MONTH_OF_YEAR), 1);
+      long weeks = Math.subtractExact(fieldValues.remove(ALIGNED_WEEK_OF_MONTH), 1);
+      long days = Math.subtractExact(fieldValues.remove(ALIGNED_DAY_OF_WEEK_IN_MONTH), 1);
+      return date(y, 1, 1).plus(months, MONTHS).plus(weeks, WEEKS).plus(days, DAYS);
+    }
+    int moy = range(MONTH_OF_YEAR).checkValidIntValue(fieldValues.remove(MONTH_OF_YEAR), MONTH_OF_YEAR);
+    int aw = range(ALIGNED_WEEK_OF_MONTH).checkValidIntValue(fieldValues.remove(ALIGNED_WEEK_OF_MONTH),
+        ALIGNED_WEEK_OF_MONTH);
+    int ad = range(ALIGNED_DAY_OF_WEEK_IN_MONTH).checkValidIntValue(fieldValues.remove(ALIGNED_DAY_OF_WEEK_IN_MONTH),
+        ALIGNED_DAY_OF_WEEK_IN_MONTH);
+    TChronoLocalDate date = date(y, moy, 1).plus((aw - 1) * 7 + (ad - 1), DAYS);
+    if (resolverStyle == TResolverStyle.STRICT && date.get(MONTH_OF_YEAR) != moy) {
+      throw new TDateTimeException("Strict mode rejected resolved date as it is in a different month");
+    }
+    return date;
+  }
+
+  TChronoLocalDate resolveYMAD(Map<TTemporalField, Long> fieldValues, TResolverStyle resolverStyle) {
+
+    int y = range(YEAR).checkValidIntValue(fieldValues.remove(YEAR), YEAR);
+    if (resolverStyle == TResolverStyle.LENIENT) {
+      long months = Math.subtractExact(fieldValues.remove(MONTH_OF_YEAR), 1);
+      long weeks = Math.subtractExact(fieldValues.remove(ALIGNED_WEEK_OF_MONTH), 1);
+      long dow = Math.subtractExact(fieldValues.remove(DAY_OF_WEEK), 1);
+      return resolveAligned(date(y, 1, 1), months, weeks, dow);
+    }
+    int moy = range(MONTH_OF_YEAR).checkValidIntValue(fieldValues.remove(MONTH_OF_YEAR), MONTH_OF_YEAR);
+    int aw = range(ALIGNED_WEEK_OF_MONTH).checkValidIntValue(fieldValues.remove(ALIGNED_WEEK_OF_MONTH),
+        ALIGNED_WEEK_OF_MONTH);
+    int dow = range(DAY_OF_WEEK).checkValidIntValue(fieldValues.remove(DAY_OF_WEEK), DAY_OF_WEEK);
+    TChronoLocalDate date = date(y, moy, 1).plus((aw - 1) * 7, DAYS)
+        .with(TTemporalAdjusters.nextOrSame(TDayOfWeek.of(dow)));
+    if (resolverStyle == TResolverStyle.STRICT && date.get(MONTH_OF_YEAR) != moy) {
+      throw new TDateTimeException("Strict mode rejected resolved date as it is in a different month");
+    }
+    return date;
+  }
+
+  TChronoLocalDate resolveYAA(Map<TTemporalField, Long> fieldValues, TResolverStyle resolverStyle) {
+
+    int y = range(YEAR).checkValidIntValue(fieldValues.remove(YEAR), YEAR);
+    if (resolverStyle == TResolverStyle.LENIENT) {
+      long weeks = Math.subtractExact(fieldValues.remove(ALIGNED_WEEK_OF_YEAR), 1);
+      long days = Math.subtractExact(fieldValues.remove(ALIGNED_DAY_OF_WEEK_IN_YEAR), 1);
+      return dateYearDay(y, 1).plus(weeks, WEEKS).plus(days, DAYS);
+    }
+    int aw = range(ALIGNED_WEEK_OF_YEAR).checkValidIntValue(fieldValues.remove(ALIGNED_WEEK_OF_YEAR),
+        ALIGNED_WEEK_OF_YEAR);
+    int ad = range(ALIGNED_DAY_OF_WEEK_IN_YEAR).checkValidIntValue(fieldValues.remove(ALIGNED_DAY_OF_WEEK_IN_YEAR),
+        ALIGNED_DAY_OF_WEEK_IN_YEAR);
+    TChronoLocalDate date = dateYearDay(y, 1).plus((aw - 1) * 7 + (ad - 1), DAYS);
+    if (resolverStyle == TResolverStyle.STRICT && date.get(YEAR) != y) {
+      throw new TDateTimeException("Strict mode rejected resolved date as it is in a different year");
+    }
+    return date;
+  }
+
+  TChronoLocalDate resolveYAD(Map<TTemporalField, Long> fieldValues, TResolverStyle resolverStyle) {
+
+    int y = range(YEAR).checkValidIntValue(fieldValues.remove(YEAR), YEAR);
+    if (resolverStyle == TResolverStyle.LENIENT) {
+      long weeks = Math.subtractExact(fieldValues.remove(ALIGNED_WEEK_OF_YEAR), 1);
+      long dow = Math.subtractExact(fieldValues.remove(DAY_OF_WEEK), 1);
+      return resolveAligned(dateYearDay(y, 1), 0, weeks, dow);
+    }
+    int aw = range(ALIGNED_WEEK_OF_YEAR).checkValidIntValue(fieldValues.remove(ALIGNED_WEEK_OF_YEAR),
+        ALIGNED_WEEK_OF_YEAR);
+    int dow = range(DAY_OF_WEEK).checkValidIntValue(fieldValues.remove(DAY_OF_WEEK), DAY_OF_WEEK);
+    TChronoLocalDate date = dateYearDay(y, 1).plus((aw - 1) * 7, DAYS)
+        .with(TTemporalAdjusters.nextOrSame(TDayOfWeek.of(dow)));
+    if (resolverStyle == TResolverStyle.STRICT && date.get(YEAR) != y) {
+      throw new TDateTimeException("Strict mode rejected resolved date as it is in a different year");
+    }
+    return date;
+  }
+
+  TChronoLocalDate resolveAligned(TChronoLocalDate base, long months, long weeks, long dow) {
+
+    TChronoLocalDate date = base.plus(months, MONTHS).plus(weeks, WEEKS);
+    if (dow > 7) {
+      date = date.plus((dow - 1) / 7, WEEKS);
+      dow = ((dow - 1) % 7) + 1;
+    } else if (dow < 1) {
+      date = date.plus(Math.subtractExact(dow, 7) / 7, WEEKS);
+      dow = ((dow + 6) % 7) + 1;
+    }
+    return date.with(TTemporalAdjusters.nextOrSame(TDayOfWeek.of((int) dow)));
+  }
+
+  void addFieldValue(Map<TTemporalField, Long> fieldValues, TChronoField field, long value) {
+
+    Long old = fieldValues.get(field);
+    if (old != null && old.longValue() != value) {
+      throw new TDateTimeException("Conflict found: " + field + " " + old + " differs from " + field + " " + value);
+    }
+    fieldValues.put(field, value);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+
+    if (this == obj) {
+      return true;
+    }
+    if (obj instanceof TAbstractChronology) {
+      return compareTo((TAbstractChronology) obj) == 0;
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+
+    return getClass().hashCode() ^ getId().hashCode();
+  }
+
+  @Override
+  public String toString() {
+
+    return getId();
+  }
+
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/time/chrono/TChronoLocalDate.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/time/chrono/TChronoLocalDate.java
@@ -1,0 +1,141 @@
+package org.teavm.classlib.java.time.chrono;
+
+import static org.teavm.classlib.java.time.temporal.TChronoField.EPOCH_DAY;
+import static org.teavm.classlib.java.time.temporal.TChronoField.ERA;
+import static org.teavm.classlib.java.time.temporal.TChronoField.YEAR;
+import static org.teavm.classlib.java.time.temporal.TChronoUnit.DAYS;
+
+import org.teavm.classlib.java.lang.TComparable;
+import org.teavm.classlib.java.time.TLocalTime;
+import org.teavm.classlib.java.time.format.TDateTimeFormatter;
+import org.teavm.classlib.java.time.temporal.TChronoField;
+import org.teavm.classlib.java.time.temporal.TChronoUnit;
+import org.teavm.classlib.java.time.temporal.TTemporal;
+import org.teavm.classlib.java.time.temporal.TTemporalAdjuster;
+import org.teavm.classlib.java.time.temporal.TTemporalAmount;
+import org.teavm.classlib.java.time.temporal.TTemporalField;
+import org.teavm.classlib.java.time.temporal.TTemporalQueries;
+import org.teavm.classlib.java.time.temporal.TTemporalQuery;
+import org.teavm.classlib.java.time.temporal.TTemporalUnit;
+import org.teavm.classlib.java.util.TObjects;
+
+public interface TChronoLocalDate extends TTemporal, TTemporalAdjuster, TComparable<TChronoLocalDate> {
+  TChronology getChronology();
+
+  default TEra getEra() {
+
+    return getChronology().eraOf(get(ERA));
+  }
+
+  default boolean isLeapYear() {
+
+    return getChronology().isLeapYear(getLong(YEAR));
+  }
+
+  int lengthOfMonth();
+
+  default int lengthOfYear() {
+
+    return (isLeapYear() ? 366 : 365);
+  }
+
+  @Override
+  default boolean isSupported(TTemporalField field) {
+
+    if (field instanceof TChronoField) {
+      return field.isDateBased();
+    }
+    return field != null && field.isSupportedBy(this);
+  }
+
+  @Override
+  default boolean isSupported(TTemporalUnit unit) {
+
+    if (unit instanceof TChronoUnit) {
+      return unit.isDateBased();
+    }
+    return unit != null && unit.isSupportedBy(this);
+  }
+
+  TChronoLocalDateTime<?> atTime(TLocalTime localTime);
+
+  @Override
+  TChronoLocalDate with(TTemporalAdjuster adjuster);
+
+  @Override
+  TChronoLocalDate with(TTemporalField field, long newValue);
+
+  @Override
+  TChronoLocalDate plus(TTemporalAmount amount);
+
+  @Override
+  TChronoLocalDate plus(long amountToAdd, TTemporalUnit unit);
+
+  @Override
+  TChronoLocalDate minus(TTemporalAmount amount);
+
+  @Override
+  TChronoLocalDate minus(long amountToSubtract, TTemporalUnit unit);
+
+  @Override
+  @SuppressWarnings("unchecked")
+  default <R> R query(TTemporalQuery<R> query) {
+
+    if (query == TTemporalQueries.zoneId() || query == TTemporalQueries.zone() || query == TTemporalQueries.offset()) {
+      return null;
+    } else if (query == TTemporalQueries.localTime()) {
+      return null;
+    } else if (query == TTemporalQueries.chronology()) {
+      return (R) getChronology();
+    } else if (query == TTemporalQueries.precision()) {
+      return (R) DAYS;
+    }
+    return query.queryFrom(this);
+  }
+
+  @Override
+  default TTemporal adjustInto(TTemporal temporal) {
+
+    return temporal.with(EPOCH_DAY, toEpochDay());
+  }
+
+  TChronoPeriod until(TChronoLocalDate endDateExclusive);
+
+  default String format(TDateTimeFormatter formatter) {
+
+    TObjects.requireNonNull(formatter, "formatter");
+    return formatter.format(this);
+  }
+
+  // TChronoLocalDateTime<?> atTime(TLocalTime localTime);
+  default long toEpochDay() {
+
+    return getLong(EPOCH_DAY);
+  }
+
+  @Override
+  default int compareTo(TChronoLocalDate other) {
+
+    int cmp = Long.compare(toEpochDay(), other.toEpochDay());
+    if (cmp == 0) {
+      cmp = getChronology().compareTo(other.getChronology());
+    }
+    return cmp;
+  }
+
+  default boolean isAfter(TChronoLocalDate other) {
+
+    return toEpochDay() > other.toEpochDay();
+  }
+
+  default boolean isBefore(TChronoLocalDate other) {
+
+    return toEpochDay() < other.toEpochDay();
+  }
+
+  default boolean isEqual(TChronoLocalDate other) {
+
+    return toEpochDay() == other.toEpochDay();
+  }
+
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/time/chrono/TChronoLocalDateTime.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/time/chrono/TChronoLocalDateTime.java
@@ -1,0 +1,143 @@
+package org.teavm.classlib.java.time.chrono;
+
+import static org.teavm.classlib.java.time.temporal.TChronoField.EPOCH_DAY;
+import static org.teavm.classlib.java.time.temporal.TChronoField.NANO_OF_DAY;
+import static org.teavm.classlib.java.time.temporal.TChronoUnit.FOREVER;
+import static org.teavm.classlib.java.time.temporal.TChronoUnit.NANOS;
+
+import org.teavm.classlib.java.lang.TComparable;
+import org.teavm.classlib.java.time.TInstant;
+import org.teavm.classlib.java.time.TLocalTime;
+import org.teavm.classlib.java.time.TZoneId;
+import org.teavm.classlib.java.time.TZoneOffset;
+import org.teavm.classlib.java.time.format.TDateTimeFormatter;
+import org.teavm.classlib.java.time.temporal.TChronoUnit;
+import org.teavm.classlib.java.time.temporal.TTemporal;
+import org.teavm.classlib.java.time.temporal.TTemporalAdjuster;
+import org.teavm.classlib.java.time.temporal.TTemporalAmount;
+import org.teavm.classlib.java.time.temporal.TTemporalField;
+import org.teavm.classlib.java.time.temporal.TTemporalQueries;
+import org.teavm.classlib.java.time.temporal.TTemporalQuery;
+import org.teavm.classlib.java.time.temporal.TTemporalUnit;
+import org.teavm.classlib.java.util.TObjects;
+
+public interface TChronoLocalDateTime<D extends TChronoLocalDate>
+    extends TTemporal, TTemporalAdjuster, TComparable<TChronoLocalDateTime<?>> {
+
+  default TChronology getChronology() {
+
+    return toLocalDate().getChronology();
+  }
+
+  D toLocalDate();
+
+  TLocalTime toLocalTime();
+
+  @Override
+  default boolean isSupported(TTemporalUnit unit) {
+
+    if (unit instanceof TChronoUnit) {
+      return unit != FOREVER;
+    }
+    return unit != null && unit.isSupportedBy(this);
+  }
+
+  @Override
+  TChronoLocalDateTime<D> with(TTemporalAdjuster adjuster);
+
+  @Override
+  TChronoLocalDateTime<D> with(TTemporalField field, long newValue);
+
+  @Override
+  TChronoLocalDateTime<D> plus(TTemporalAmount amount);
+
+  @Override
+  TChronoLocalDateTime<D> plus(long amountToAdd, TTemporalUnit unit);
+
+  @Override
+  TChronoLocalDateTime<D> minus(TTemporalAmount amount);
+
+  @Override
+  TChronoLocalDateTime<D> minus(long amountToSubtract, TTemporalUnit unit);
+
+  @SuppressWarnings("unchecked")
+  @Override
+  default <R> R query(TTemporalQuery<R> query) {
+
+    if (query == TTemporalQueries.zoneId() || query == TTemporalQueries.zone() || query == TTemporalQueries.offset()) {
+      return null;
+    } else if (query == TTemporalQueries.localTime()) {
+      return (R) toLocalTime();
+    } else if (query == TTemporalQueries.chronology()) {
+      return (R) getChronology();
+    } else if (query == TTemporalQueries.precision()) {
+      return (R) NANOS;
+    }
+    return query.queryFrom(this);
+  }
+
+  @Override
+  default TTemporal adjustInto(TTemporal temporal) {
+
+    return temporal.with(EPOCH_DAY, toLocalDate().toEpochDay()).with(NANO_OF_DAY, toLocalTime().toNanoOfDay());
+  }
+
+  default String format(TDateTimeFormatter formatter) {
+
+    TObjects.requireNonNull(formatter, "formatter");
+    return formatter.format(this);
+  }
+
+  TChronoZonedDateTime<D> atZone(TZoneId zone);
+
+  default TInstant toInstant(TZoneOffset offset) {
+
+    return TInstant.ofEpochSecond(toEpochSecond(offset), toLocalTime().getNano());
+  }
+
+  default long toEpochSecond(TZoneOffset offset) {
+
+    TObjects.requireNonNull(offset, "offset");
+    long epochDay = toLocalDate().toEpochDay();
+    long secs = epochDay * 86400 + toLocalTime().toSecondOfDay();
+    secs -= offset.getTotalSeconds();
+    return secs;
+  }
+
+  @Override
+  default int compareTo(TChronoLocalDateTime<?> other) {
+
+    int cmp = toLocalDate().compareTo(other.toLocalDate());
+    if (cmp == 0) {
+      cmp = toLocalTime().compareTo(other.toLocalTime());
+      if (cmp == 0) {
+        cmp = getChronology().compareTo(other.getChronology());
+      }
+    }
+    return cmp;
+  }
+
+  default boolean isAfter(TChronoLocalDateTime<?> other) {
+
+    long thisEpDay = this.toLocalDate().toEpochDay();
+    long otherEpDay = other.toLocalDate().toEpochDay();
+    return thisEpDay > otherEpDay
+        || (thisEpDay == otherEpDay && this.toLocalTime().toNanoOfDay() > other.toLocalTime().toNanoOfDay());
+  }
+
+  default boolean isBefore(TChronoLocalDateTime<?> other) {
+
+    long thisEpDay = this.toLocalDate().toEpochDay();
+    long otherEpDay = other.toLocalDate().toEpochDay();
+    return thisEpDay < otherEpDay
+        || (thisEpDay == otherEpDay && this.toLocalTime().toNanoOfDay() < other.toLocalTime().toNanoOfDay());
+  }
+
+  default boolean isEqual(TChronoLocalDateTime<?> other) {
+
+    // Do the time check first, it is cheaper than computing EPOCH day.
+    return this.toLocalTime().toNanoOfDay() == other.toLocalTime().toNanoOfDay()
+        && this.toLocalDate().toEpochDay() == other.toLocalDate().toEpochDay();
+  }
+
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/time/chrono/TChronoPeriod.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/time/chrono/TChronoPeriod.java
@@ -1,0 +1,42 @@
+package org.teavm.classlib.java.time.chrono;
+
+import org.teavm.classlib.java.time.temporal.TTemporalAmount;
+import org.teavm.classlib.java.time.temporal.TTemporalUnit;
+
+public interface TChronoPeriod extends TTemporalAmount {
+  TChronology getChronology();
+
+  default boolean isZero() {
+
+    for (TTemporalUnit unit : getUnits()) {
+      if (get(unit) != 0) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  default boolean isNegative() {
+
+    for (TTemporalUnit unit : getUnits()) {
+      if (get(unit) < 0) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  TChronoPeriod plus(TTemporalAmount amountToAdd);
+
+  TChronoPeriod minus(TTemporalAmount amountToSubtract);
+
+  TChronoPeriod multipliedBy(int scalar);
+
+  default TChronoPeriod negated() {
+
+    return multipliedBy(-1);
+  }
+
+  TChronoPeriod normalized();
+
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/time/chrono/TChronoZonedDateTime.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/time/chrono/TChronoZonedDateTime.java
@@ -1,0 +1,206 @@
+package org.teavm.classlib.java.time.chrono;
+
+import static org.teavm.classlib.java.time.temporal.TChronoField.INSTANT_SECONDS;
+import static org.teavm.classlib.java.time.temporal.TChronoField.OFFSET_SECONDS;
+import static org.teavm.classlib.java.time.temporal.TChronoUnit.FOREVER;
+import static org.teavm.classlib.java.time.temporal.TChronoUnit.NANOS;
+
+import org.teavm.classlib.java.lang.TComparable;
+import org.teavm.classlib.java.time.TInstant;
+import org.teavm.classlib.java.time.TLocalTime;
+import org.teavm.classlib.java.time.TZoneId;
+import org.teavm.classlib.java.time.TZoneOffset;
+import org.teavm.classlib.java.time.format.TDateTimeFormatter;
+import org.teavm.classlib.java.time.temporal.TChronoField;
+import org.teavm.classlib.java.time.temporal.TChronoUnit;
+import org.teavm.classlib.java.time.temporal.TTemporal;
+import org.teavm.classlib.java.time.temporal.TTemporalAdjuster;
+import org.teavm.classlib.java.time.temporal.TTemporalAmount;
+import org.teavm.classlib.java.time.temporal.TTemporalField;
+import org.teavm.classlib.java.time.temporal.TTemporalQueries;
+import org.teavm.classlib.java.time.temporal.TTemporalQuery;
+import org.teavm.classlib.java.time.temporal.TTemporalUnit;
+import org.teavm.classlib.java.time.temporal.TUnsupportedTemporalTypeException;
+import org.teavm.classlib.java.time.temporal.TValueRange;
+import org.teavm.classlib.java.util.TObjects;
+
+public interface TChronoZonedDateTime<D extends TChronoLocalDate>
+    extends TTemporal, TComparable<TChronoZonedDateTime<?>> {
+
+  @Override
+  default TValueRange range(TTemporalField field) {
+
+    if (field instanceof TChronoField) {
+      if (field == INSTANT_SECONDS || field == OFFSET_SECONDS) {
+        return field.range();
+      }
+      return toLocalDateTime().range(field);
+    }
+    return field.rangeRefinedBy(this);
+  }
+
+  @Override
+  default int get(TTemporalField field) {
+
+    if (field instanceof TChronoField) {
+      switch ((TChronoField) field) {
+        case INSTANT_SECONDS:
+          throw new TUnsupportedTemporalTypeException(
+              "Invalid field 'InstantSeconds' for get() method, use getLong() instead");
+        case OFFSET_SECONDS:
+          return getOffset().getTotalSeconds();
+      }
+      return toLocalDateTime().get(field);
+    }
+    return TTemporal.super.get(field);
+  }
+
+  @Override
+  default long getLong(TTemporalField field) {
+
+    if (field instanceof TChronoField) {
+      switch ((TChronoField) field) {
+        case INSTANT_SECONDS:
+          return toEpochSecond();
+        case OFFSET_SECONDS:
+          return getOffset().getTotalSeconds();
+      }
+      return toLocalDateTime().getLong(field);
+    }
+    return field.getFrom(this);
+  }
+
+  default D toLocalDate() {
+
+    return toLocalDateTime().toLocalDate();
+  }
+
+  default TLocalTime toLocalTime() {
+
+    return toLocalDateTime().toLocalTime();
+  }
+
+  TChronoLocalDateTime<D> toLocalDateTime();
+
+  default TChronology getChronology() {
+
+    return toLocalDate().getChronology();
+  }
+
+  TZoneOffset getOffset();
+
+  TZoneId getZone();
+
+  TChronoZonedDateTime<D> withEarlierOffsetAtOverlap();
+
+  TChronoZonedDateTime<D> withLaterOffsetAtOverlap();
+
+  TChronoZonedDateTime<D> withZoneSameLocal(TZoneId zone);
+
+  TChronoZonedDateTime<D> withZoneSameInstant(TZoneId zone);
+
+  @Override
+  default boolean isSupported(TTemporalUnit unit) {
+
+    if (unit instanceof TChronoUnit) {
+      return unit != FOREVER;
+    }
+    return unit != null && unit.isSupportedBy(this);
+  }
+
+  @Override
+  TChronoZonedDateTime<D> with(TTemporalAdjuster adjuster);
+
+  @Override
+  TChronoZonedDateTime<D> with(TTemporalField field, long newValue);
+
+  @Override
+  TChronoZonedDateTime<D> plus(TTemporalAmount amount);
+
+  @Override
+  TChronoZonedDateTime<D> plus(long amountToAdd, TTemporalUnit unit);
+
+  @Override
+  TChronoZonedDateTime<D> minus(TTemporalAmount amount);
+
+  @Override
+  TChronoZonedDateTime<D> minus(long amountToSubtract, TTemporalUnit unit);
+
+  @SuppressWarnings("unchecked")
+  @Override
+  default <R> R query(TTemporalQuery<R> query) {
+
+    if (query == TTemporalQueries.zone() || query == TTemporalQueries.zoneId()) {
+      return (R) getZone();
+    } else if (query == TTemporalQueries.offset()) {
+      return (R) getOffset();
+    } else if (query == TTemporalQueries.localTime()) {
+      return (R) toLocalTime();
+    } else if (query == TTemporalQueries.chronology()) {
+      return (R) getChronology();
+    } else if (query == TTemporalQueries.precision()) {
+      return (R) NANOS;
+    }
+    return query.queryFrom(this);
+  }
+
+  default String format(TDateTimeFormatter formatter) {
+
+    TObjects.requireNonNull(formatter, "formatter");
+    return formatter.format(this);
+  }
+
+  default TInstant toInstant() {
+
+    return TInstant.ofEpochSecond(toEpochSecond(), toLocalTime().getNano());
+  }
+
+  default long toEpochSecond() {
+
+    long epochDay = toLocalDate().toEpochDay();
+    long secs = epochDay * 86400 + toLocalTime().toSecondOfDay();
+    secs -= getOffset().getTotalSeconds();
+    return secs;
+  }
+
+  @Override
+  default int compareTo(TChronoZonedDateTime<?> other) {
+
+    int cmp = Long.compare(toEpochSecond(), other.toEpochSecond());
+    if (cmp == 0) {
+      cmp = toLocalTime().getNano() - other.toLocalTime().getNano();
+      if (cmp == 0) {
+        cmp = toLocalDateTime().compareTo(other.toLocalDateTime());
+        if (cmp == 0) {
+          cmp = getZone().getId().compareTo(other.getZone().getId());
+          if (cmp == 0) {
+            cmp = getChronology().compareTo(other.getChronology());
+          }
+        }
+      }
+    }
+    return cmp;
+  }
+
+  default boolean isBefore(TChronoZonedDateTime<?> other) {
+
+    long thisEpochSec = toEpochSecond();
+    long otherEpochSec = other.toEpochSecond();
+    return thisEpochSec < otherEpochSec
+        || (thisEpochSec == otherEpochSec && toLocalTime().getNano() < other.toLocalTime().getNano());
+  }
+
+  default boolean isAfter(TChronoZonedDateTime<?> other) {
+
+    long thisEpochSec = toEpochSecond();
+    long otherEpochSec = other.toEpochSecond();
+    return thisEpochSec > otherEpochSec
+        || (thisEpochSec == otherEpochSec && toLocalTime().getNano() > other.toLocalTime().getNano());
+  }
+
+  default boolean isEqual(TChronoZonedDateTime<?> other) {
+
+    return toEpochSecond() == other.toEpochSecond() && toLocalTime().getNano() == other.toLocalTime().getNano();
+  }
+
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/time/chrono/TChronology.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/time/chrono/TChronology.java
@@ -1,0 +1,147 @@
+package org.teavm.classlib.java.time.chrono;
+
+import static java.time.temporal.ChronoField.HOUR_OF_DAY;
+import static java.time.temporal.ChronoField.MINUTE_OF_HOUR;
+import static java.time.temporal.ChronoField.SECOND_OF_MINUTE;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import org.teavm.classlib.java.lang.TComparable;
+import org.teavm.classlib.java.time.TClock;
+import org.teavm.classlib.java.time.TDateTimeException;
+import org.teavm.classlib.java.time.TInstant;
+import org.teavm.classlib.java.time.TLocalDate;
+import org.teavm.classlib.java.time.TLocalTime;
+import org.teavm.classlib.java.time.TZoneId;
+import org.teavm.classlib.java.time.TZoneOffset;
+import org.teavm.classlib.java.time.format.TResolverStyle;
+import org.teavm.classlib.java.time.format.TTextStyle;
+import org.teavm.classlib.java.time.temporal.TChronoField;
+import org.teavm.classlib.java.time.temporal.TTemporalAccessor;
+import org.teavm.classlib.java.time.temporal.TTemporalField;
+import org.teavm.classlib.java.time.temporal.TTemporalQueries;
+import org.teavm.classlib.java.time.temporal.TValueRange;
+import org.teavm.classlib.java.util.TLocale;
+import org.teavm.classlib.java.util.TObjects;
+
+public interface TChronology extends TComparable<TChronology> {
+
+  String getId();
+
+  String getCalendarType();
+
+  default TChronoLocalDate date(TEra era, int yearOfEra, int month, int dayOfMonth) {
+
+    return date(prolepticYear(era, yearOfEra), month, dayOfMonth);
+  }
+
+  TChronoLocalDate date(int prolepticYear, int month, int dayOfMonth);
+
+  default TChronoLocalDate dateYearDay(TEra era, int yearOfEra, int dayOfYear) {
+
+    return dateYearDay(prolepticYear(era, yearOfEra), dayOfYear);
+  }
+
+  TChronoLocalDate dateYearDay(int prolepticYear, int dayOfYear);
+
+  TChronoLocalDate dateEpochDay(long epochDay);
+
+  default TChronoLocalDate dateNow() {
+
+    return dateNow(TClock.systemDefaultZone());
+  }
+
+  default TChronoLocalDate dateNow(TZoneId zone) {
+
+    return dateNow(TClock.system(zone));
+  }
+
+  default TChronoLocalDate dateNow(TClock clock) {
+
+    TObjects.requireNonNull(clock, "clock");
+    return date(TLocalDate.now(clock));
+  }
+
+  TChronoLocalDate date(TTemporalAccessor temporal);
+
+  default TChronoLocalDateTime<? extends TChronoLocalDate> localDateTime(TTemporalAccessor temporal) {
+
+    try {
+      return date(temporal).atTime(TLocalTime.from(temporal));
+    } catch (TDateTimeException ex) {
+      throw new TDateTimeException("Unable to obtain ChronoLocalDateTime from TemporalAccessor: " + temporal.getClass(),
+          ex);
+    }
+  }
+
+  TChronoZonedDateTime<? extends TChronoLocalDate> zonedDateTime(TInstant instant, TZoneId zone);
+
+  TChronoZonedDateTime<? extends TChronoLocalDate> zonedDateTime(TTemporalAccessor temporal);
+
+  boolean isLeapYear(long prolepticYear);
+
+  int prolepticYear(TEra era, int yearOfEra);
+
+  TEra eraOf(int eraValue);
+
+  List<TEra> eras();
+
+  TValueRange range(TChronoField field);
+
+  default String getDisplayName(TTextStyle style, TLocale locale) {
+
+    return getId();
+  }
+
+  TChronoPeriod period(int years, int months, int days);
+
+  default long epochSecond(int prolepticYear, int month, int dayOfMonth, int hour, int minute, int second,
+      TZoneOffset zoneOffset) {
+
+    TObjects.requireNonNull(zoneOffset, "zoneOffset");
+    HOUR_OF_DAY.checkValidValue(hour);
+    MINUTE_OF_HOUR.checkValidValue(minute);
+    SECOND_OF_MINUTE.checkValidValue(second);
+    long daysInSec = Math.multiplyExact(date(prolepticYear, month, dayOfMonth).toEpochDay(), 86400);
+    long timeinSec = (hour * 60 + minute) * 60 + second;
+    return Math.addExact(daysInSec, timeinSec - zoneOffset.getTotalSeconds());
+  }
+
+  public default long epochSecond(TEra era, int yearOfEra, int month, int dayOfMonth, int hour, int minute, int second,
+      TZoneOffset zoneOffset) {
+
+    TObjects.requireNonNull(era, "era");
+    return epochSecond(prolepticYear(era, yearOfEra), month, dayOfMonth, hour, minute, second, zoneOffset);
+  }
+
+  TChronoLocalDate resolveDate(Map<TTemporalField, Long> fieldValues, TResolverStyle resolverStyle);
+
+  static TChronology from(TTemporalAccessor temporal) {
+
+    TObjects.requireNonNull(temporal, "temporal");
+    TChronology obj = temporal.query(TTemporalQueries.chronology());
+    return Objects.requireNonNullElse(obj, TIsoChronology.INSTANCE);
+  }
+
+  static TChronology ofLocale(TLocale locale) {
+
+    return TIsoChronology.INSTANCE;
+  }
+
+  static TChronology of(String id) {
+
+    if (id.equals(TIsoChronology.INSTANCE.getId())) {
+      return TIsoChronology.INSTANCE;
+    }
+    throw new TDateTimeException("Unknown chronology: " + id);
+  }
+
+  static Set<TChronology> getAvailableChronologies() {
+
+    return Collections.singleton(TIsoChronology.INSTANCE);
+  }
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/time/chrono/TEra.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/time/chrono/TEra.java
@@ -1,0 +1,67 @@
+package org.teavm.classlib.java.time.chrono;
+
+import org.teavm.classlib.java.time.temporal.TChronoField;
+import org.teavm.classlib.java.time.temporal.TChronoUnit;
+import org.teavm.classlib.java.time.temporal.TTemporal;
+import org.teavm.classlib.java.time.temporal.TTemporalAccessor;
+import org.teavm.classlib.java.time.temporal.TTemporalAdjuster;
+import org.teavm.classlib.java.time.temporal.TTemporalField;
+import org.teavm.classlib.java.time.temporal.TTemporalQueries;
+import org.teavm.classlib.java.time.temporal.TTemporalQuery;
+import org.teavm.classlib.java.time.temporal.TUnsupportedTemporalTypeException;
+
+public interface TEra extends TTemporalAccessor, TTemporalAdjuster {
+
+  int getValue();
+
+  @Override
+  default boolean isSupported(TTemporalField field) {
+
+    if (field instanceof TChronoField) {
+      return field == TChronoField.ERA;
+    }
+    return field != null && field.isSupportedBy(this);
+  }
+
+  @Override
+  default int get(TTemporalField field) {
+
+    if (field == TChronoField.ERA) {
+      return getValue();
+    }
+    return TTemporalAccessor.super.get(field);
+  }
+
+  @Override
+  default long getLong(TTemporalField field) {
+
+    if (field == TChronoField.ERA) {
+      return getValue();
+    } else if (field instanceof TChronoField) {
+      throw new TUnsupportedTemporalTypeException("Unsupported field: " + field);
+    }
+    return field.getFrom(this);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  default <R> R query(TTemporalQuery<R> query) {
+
+    if (query == TTemporalQueries.precision()) {
+      return (R) TChronoUnit.ERAS;
+    }
+    return TTemporalAccessor.super.query(query);
+  }
+
+  @Override
+  default TTemporal adjustInto(TTemporal temporal) {
+
+    return temporal.with(TChronoField.ERA, getValue());
+  }
+
+  // default String getDisplayName(TTextStyle style, TLocale locale) {
+  //
+  // return new TDateTimeFormatterBuilder().appendText(TChronoField.ERA, style).toFormatter(locale).format(this);
+  // }
+
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/time/chrono/TIsoChronology.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/time/chrono/TIsoChronology.java
@@ -1,0 +1,235 @@
+package org.teavm.classlib.java.time.chrono;
+
+import static org.teavm.classlib.java.time.temporal.TChronoField.DAY_OF_MONTH;
+import static org.teavm.classlib.java.time.temporal.TChronoField.HOUR_OF_DAY;
+import static org.teavm.classlib.java.time.temporal.TChronoField.MINUTE_OF_HOUR;
+import static org.teavm.classlib.java.time.temporal.TChronoField.MONTH_OF_YEAR;
+import static org.teavm.classlib.java.time.temporal.TChronoField.SECOND_OF_MINUTE;
+import static org.teavm.classlib.java.time.temporal.TChronoField.YEAR;
+
+import java.util.List;
+import java.util.Map;
+
+import org.teavm.classlib.java.io.TSerializable;
+import org.teavm.classlib.java.lang.TClassCastException;
+import org.teavm.classlib.java.time.TClock;
+import org.teavm.classlib.java.time.TDateTimeException;
+import org.teavm.classlib.java.time.TInstant;
+import org.teavm.classlib.java.time.TLocalDate;
+import org.teavm.classlib.java.time.TLocalDateTime;
+import org.teavm.classlib.java.time.TMonth;
+import org.teavm.classlib.java.time.TPeriod;
+import org.teavm.classlib.java.time.TYear;
+import org.teavm.classlib.java.time.TZoneId;
+import org.teavm.classlib.java.time.TZoneOffset;
+import org.teavm.classlib.java.time.TZonedDateTime;
+import org.teavm.classlib.java.time.format.TResolverStyle;
+import org.teavm.classlib.java.time.temporal.TChronoField;
+import org.teavm.classlib.java.time.temporal.TTemporalAccessor;
+import org.teavm.classlib.java.time.temporal.TTemporalField;
+import org.teavm.classlib.java.time.temporal.TValueRange;
+import org.teavm.classlib.java.util.TObjects;
+
+public class TIsoChronology extends TAbstractChronology implements TSerializable {
+
+  public static final TIsoChronology INSTANCE = new TIsoChronology();
+
+  private static final long DAYS_0000_TO_1970 = (146097 * 5L) - (30L * 365L + 7L);
+
+  private TIsoChronology() {
+
+  }
+
+  @Override
+  public String getId() {
+
+    return "ISO";
+  }
+
+  @Override
+  public String getCalendarType() {
+
+    return "iso8601";
+  }
+
+  @Override
+  public TLocalDate date(TEra era, int yearOfEra, int month, int dayOfMonth) {
+
+    return date(prolepticYear(era, yearOfEra), month, dayOfMonth);
+  }
+
+  @Override
+  public TLocalDate date(int prolepticYear, int month, int dayOfMonth) {
+
+    return TLocalDate.of(prolepticYear, month, dayOfMonth);
+  }
+
+  @Override
+  public TLocalDate dateYearDay(TEra era, int yearOfEra, int dayOfYear) {
+
+    return dateYearDay(prolepticYear(era, yearOfEra), dayOfYear);
+  }
+
+  @Override
+  public TLocalDate dateYearDay(int prolepticYear, int dayOfYear) {
+
+    return TLocalDate.ofYearDay(prolepticYear, dayOfYear);
+  }
+
+  @Override
+  public TLocalDate dateEpochDay(long epochDay) {
+
+    return TLocalDate.ofEpochDay(epochDay);
+  }
+
+  @Override
+  public TLocalDate date(TTemporalAccessor temporal) {
+
+    return TLocalDate.from(temporal);
+  }
+
+  @Override
+  public long epochSecond(int prolepticYear, int month, int dayOfMonth, int hour, int minute, int second,
+      TZoneOffset zoneOffset) {
+
+    YEAR.checkValidValue(prolepticYear);
+    MONTH_OF_YEAR.checkValidValue(month);
+    DAY_OF_MONTH.checkValidValue(dayOfMonth);
+    HOUR_OF_DAY.checkValidValue(hour);
+    MINUTE_OF_HOUR.checkValidValue(minute);
+    SECOND_OF_MINUTE.checkValidValue(second);
+    TObjects.requireNonNull(zoneOffset, "zoneOffset");
+    if (dayOfMonth > 28) {
+      int dom = numberOfDaysOfMonth(prolepticYear, month);
+      if (dayOfMonth > dom) {
+        if (dayOfMonth == 29) {
+          throw new TDateTimeException("Invalid date 'February 29' as '" + prolepticYear + "' is not a leap year");
+        } else {
+          throw new TDateTimeException("Invalid date '" + TMonth.of(month).name() + " " + dayOfMonth + "'");
+        }
+      }
+    }
+
+    long totalDays = 0;
+    int timeinSec = 0;
+    totalDays += 365L * prolepticYear;
+    if (prolepticYear >= 0) {
+      totalDays += (prolepticYear + 3L) / 4 - (prolepticYear + 99L) / 100 + (prolepticYear + 399L) / 400;
+    } else {
+      totalDays -= prolepticYear / -4 - prolepticYear / -100 + prolepticYear / -400;
+    }
+    totalDays += (367 * month - 362) / 12;
+    totalDays += dayOfMonth - 1;
+    if (month > 2) {
+      totalDays--;
+      if (TYear.isLeap(prolepticYear) == false) {
+        totalDays--;
+      }
+    }
+    totalDays -= DAYS_0000_TO_1970;
+    timeinSec = (hour * 60 + minute) * 60 + second;
+    return Math.addExact(Math.multiplyExact(totalDays, 86400L), timeinSec - zoneOffset.getTotalSeconds());
+  }
+
+  private int numberOfDaysOfMonth(int year, int month) {
+
+    int dom;
+    switch (month) {
+      case 2:
+        dom = (TYear.isLeap(year) ? 29 : 28);
+        break;
+      case 4:
+      case 6:
+      case 9:
+      case 11:
+        dom = 30;
+        break;
+      default:
+        dom = 31;
+        break;
+    }
+    return dom;
+  }
+
+  @Override
+  public TLocalDateTime localDateTime(TTemporalAccessor temporal) {
+
+    return TLocalDateTime.from(temporal);
+  }
+
+  @Override
+  public TZonedDateTime zonedDateTime(TTemporalAccessor temporal) {
+
+    return TZonedDateTime.from(temporal);
+  }
+
+  @Override
+  public TZonedDateTime zonedDateTime(TInstant instant, TZoneId zone) {
+
+    return TZonedDateTime.ofInstant(instant, zone);
+  }
+
+  @Override
+  public TLocalDate dateNow() {
+
+    return dateNow(TClock.systemDefaultZone());
+  }
+
+  @Override
+  public TLocalDate dateNow(TZoneId zone) {
+
+    return dateNow(TClock.system(zone));
+  }
+
+  @Override
+  public TLocalDate dateNow(TClock clock) {
+
+    TObjects.requireNonNull(clock, "clock");
+    return date(TLocalDate.now(clock));
+  }
+
+  @Override
+  public boolean isLeapYear(long prolepticYear) {
+
+    return ((prolepticYear & 3) == 0) && ((prolepticYear % 100) != 0 || (prolepticYear % 400) == 0);
+  }
+
+  @Override
+  public int prolepticYear(TEra era, int yearOfEra) {
+
+    if (era instanceof TIsoEra == false) {
+      throw new TClassCastException("Era must be IsoEra");
+    }
+    return (era == TIsoEra.CE ? yearOfEra : 1 - yearOfEra);
+  }
+
+  @Override
+  public TIsoEra eraOf(int eraValue) {
+
+    return TIsoEra.of(eraValue);
+  }
+
+  @Override
+  public List<TEra> eras() {
+
+    return List.of(TIsoEra.values());
+  }
+
+  @Override
+  public TValueRange range(TChronoField field) {
+
+    return field.range();
+  }
+
+  @Override
+  public TPeriod period(int years, int months, int days) {
+
+    return TPeriod.of(years, months, days);
+  }
+
+  @Override
+  public TLocalDate resolveDate(Map<TTemporalField, Long> fieldValues, TResolverStyle resolverStyle) {
+
+    return (TLocalDate) super.resolveDate(fieldValues, resolverStyle);
+  }
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/time/chrono/TIsoEra.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/time/chrono/TIsoEra.java
@@ -1,0 +1,27 @@
+package org.teavm.classlib.java.time.chrono;
+
+import org.teavm.classlib.java.time.TDateTimeException;
+
+public enum TIsoEra implements TEra {
+
+  BCE, CE;
+
+  public static TIsoEra of(int isoEra) {
+
+    switch (isoEra) {
+      case 0:
+        return BCE;
+      case 1:
+        return CE;
+      default:
+        throw new TDateTimeException("Invalid era: " + isoEra);
+    }
+  }
+
+  @Override
+  public int getValue() {
+
+    return ordinal();
+  }
+
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/time/format/TDateTimeFormatter.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/time/format/TDateTimeFormatter.java
@@ -1,0 +1,615 @@
+package org.teavm.classlib.java.time.format;
+
+import static org.teavm.classlib.java.time.temporal.TChronoField.DAY_OF_MONTH;
+import static org.teavm.classlib.java.time.temporal.TChronoField.DAY_OF_WEEK;
+import static org.teavm.classlib.java.time.temporal.TChronoField.DAY_OF_YEAR;
+import static org.teavm.classlib.java.time.temporal.TChronoField.HOUR_OF_DAY;
+import static org.teavm.classlib.java.time.temporal.TChronoField.MINUTE_OF_HOUR;
+import static org.teavm.classlib.java.time.temporal.TChronoField.MONTH_OF_YEAR;
+import static org.teavm.classlib.java.time.temporal.TChronoField.NANO_OF_SECOND;
+import static org.teavm.classlib.java.time.temporal.TChronoField.SECOND_OF_MINUTE;
+import static org.teavm.classlib.java.time.temporal.TChronoField.YEAR;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import org.teavm.classlib.java.text.TFieldPosition;
+import org.teavm.classlib.java.text.TFormat;
+import org.teavm.classlib.java.text.TParseException;
+import org.teavm.classlib.java.text.TParsePosition;
+import org.teavm.classlib.java.time.TDateTimeException;
+import org.teavm.classlib.java.time.TPeriod;
+import org.teavm.classlib.java.time.TZoneId;
+import org.teavm.classlib.java.time.chrono.TChronology;
+import org.teavm.classlib.java.time.chrono.TIsoChronology;
+import org.teavm.classlib.java.time.format.TDateTimeFormatterBuilder.TCompositePrinterParser;
+import org.teavm.classlib.java.time.temporal.TTemporalAccessor;
+import org.teavm.classlib.java.time.temporal.TTemporalField;
+import org.teavm.classlib.java.time.temporal.TTemporalQuery;
+import org.teavm.classlib.java.util.TLocale;
+import org.teavm.classlib.java.util.TObjects;
+
+public final class TDateTimeFormatter {
+
+  private final TCompositePrinterParser printerParser;
+
+  private final TLocale locale;
+
+  private final TDecimalStyle decimalStyle;
+
+  private final TResolverStyle resolverStyle;
+
+  private final Set<TTemporalField> resolverFields;
+
+  private final TChronology chrono;
+
+  private final TZoneId zone;
+
+  public static TDateTimeFormatter ofPattern(String pattern) {
+
+    return new TDateTimeFormatterBuilder().appendPattern(pattern).toFormatter();
+  }
+
+  public static TDateTimeFormatter ofPattern(String pattern, TLocale locale) {
+
+    return new TDateTimeFormatterBuilder().appendPattern(pattern).toFormatter(locale);
+  }
+
+  public static TDateTimeFormatter ofLocalizedDate(TFormatStyle dateStyle) {
+
+    TObjects.requireNonNull(dateStyle, "dateStyle");
+    return new TDateTimeFormatterBuilder().appendLocalized(dateStyle, null).toFormatter(TResolverStyle.SMART,
+        TIsoChronology.INSTANCE);
+  }
+
+  public static TDateTimeFormatter ofLocalizedTime(TFormatStyle timeStyle) {
+
+    TObjects.requireNonNull(timeStyle, "timeStyle");
+    return new TDateTimeFormatterBuilder().appendLocalized(null, timeStyle).toFormatter(TResolverStyle.SMART,
+        TIsoChronology.INSTANCE);
+  }
+
+  public static TDateTimeFormatter ofLocalizedDateTime(TFormatStyle dateTimeStyle) {
+
+    TObjects.requireNonNull(dateTimeStyle, "dateTimeStyle");
+    return new TDateTimeFormatterBuilder().appendLocalized(dateTimeStyle, dateTimeStyle)
+        .toFormatter(TResolverStyle.SMART, TIsoChronology.INSTANCE);
+  }
+
+  public static TDateTimeFormatter ofLocalizedDateTime(TFormatStyle dateStyle, TFormatStyle timeStyle) {
+
+    TObjects.requireNonNull(dateStyle, "dateStyle");
+    TObjects.requireNonNull(timeStyle, "timeStyle");
+    return new TDateTimeFormatterBuilder().appendLocalized(dateStyle, timeStyle).toFormatter(TResolverStyle.SMART,
+        TIsoChronology.INSTANCE);
+  }
+
+  public static final TDateTimeFormatter ISO_LOCAL_DATE;
+  static {
+    ISO_LOCAL_DATE = new TDateTimeFormatterBuilder().appendValue(YEAR, 4, 10, TSignStyle.EXCEEDS_PAD).appendLiteral('-')
+        .appendValue(MONTH_OF_YEAR, 2).appendLiteral('-').appendValue(DAY_OF_MONTH, 2)
+        .toFormatter(TResolverStyle.STRICT, TIsoChronology.INSTANCE);
+  }
+
+  public static final TDateTimeFormatter ISO_OFFSET_DATE;
+  static {
+    ISO_OFFSET_DATE = new TDateTimeFormatterBuilder().parseCaseInsensitive().append(ISO_LOCAL_DATE).appendOffsetId()
+        .toFormatter(TResolverStyle.STRICT, TIsoChronology.INSTANCE);
+  }
+
+  public static final TDateTimeFormatter ISO_DATE;
+  static {
+    ISO_DATE = new TDateTimeFormatterBuilder().parseCaseInsensitive().append(ISO_LOCAL_DATE).optionalStart()
+        .appendOffsetId().toFormatter(TResolverStyle.STRICT, TIsoChronology.INSTANCE);
+  }
+
+  public static final TDateTimeFormatter ISO_LOCAL_TIME;
+  static {
+    ISO_LOCAL_TIME = new TDateTimeFormatterBuilder().appendValue(HOUR_OF_DAY, 2).appendLiteral(':')
+        .appendValue(MINUTE_OF_HOUR, 2).optionalStart().appendLiteral(':').appendValue(SECOND_OF_MINUTE, 2)
+        .optionalStart().appendFraction(NANO_OF_SECOND, 0, 9, true).toFormatter(TResolverStyle.STRICT, null);
+  }
+
+  public static final TDateTimeFormatter ISO_OFFSET_TIME;
+  static {
+    ISO_OFFSET_TIME = new TDateTimeFormatterBuilder().parseCaseInsensitive().append(ISO_LOCAL_TIME).appendOffsetId()
+        .toFormatter(TResolverStyle.STRICT, null);
+  }
+
+  public static final TDateTimeFormatter ISO_TIME;
+  static {
+    ISO_TIME = new TDateTimeFormatterBuilder().parseCaseInsensitive().append(ISO_LOCAL_TIME).optionalStart()
+        .appendOffsetId().toFormatter(TResolverStyle.STRICT, null);
+  }
+
+  public static final TDateTimeFormatter ISO_LOCAL_DATE_TIME;
+  static {
+    ISO_LOCAL_DATE_TIME = new TDateTimeFormatterBuilder().parseCaseInsensitive().append(ISO_LOCAL_DATE)
+        .appendLiteral('T').append(ISO_LOCAL_TIME).toFormatter(TResolverStyle.STRICT, TIsoChronology.INSTANCE);
+  }
+
+  public static final TDateTimeFormatter ISO_OFFSET_DATE_TIME;
+  static {
+    ISO_OFFSET_DATE_TIME = new TDateTimeFormatterBuilder().parseCaseInsensitive().append(ISO_LOCAL_DATE_TIME)
+        .parseLenient().appendOffsetId().parseStrict().toFormatter(TResolverStyle.STRICT, TIsoChronology.INSTANCE);
+  }
+
+  public static final TDateTimeFormatter ISO_ZONED_DATE_TIME;
+  static {
+    ISO_ZONED_DATE_TIME = new TDateTimeFormatterBuilder().append(ISO_OFFSET_DATE_TIME).optionalStart()
+        .appendLiteral('[').parseCaseSensitive().appendZoneRegionId().appendLiteral(']')
+        .toFormatter(TResolverStyle.STRICT, TIsoChronology.INSTANCE);
+  }
+
+  public static final TDateTimeFormatter ISO_DATE_TIME;
+  static {
+    ISO_DATE_TIME = new TDateTimeFormatterBuilder().append(ISO_LOCAL_DATE_TIME).optionalStart().appendOffsetId()
+        .optionalStart().appendLiteral('[').parseCaseSensitive().appendZoneRegionId().appendLiteral(']')
+        .toFormatter(TResolverStyle.STRICT, TIsoChronology.INSTANCE);
+  }
+
+  public static final TDateTimeFormatter ISO_ORDINAL_DATE;
+  static {
+    ISO_ORDINAL_DATE = new TDateTimeFormatterBuilder().parseCaseInsensitive()
+        .appendValue(YEAR, 4, 10, TSignStyle.EXCEEDS_PAD).appendLiteral('-').appendValue(DAY_OF_YEAR, 3).optionalStart()
+        .appendOffsetId().toFormatter(TResolverStyle.STRICT, TIsoChronology.INSTANCE);
+  }
+
+  // public static final TDateTimeFormatter ISO_WEEK_DATE;
+  // static {
+  // ISO_WEEK_DATE = new TDateTimeFormatterBuilder().parseCaseInsensitive()
+  // .appendValue(IsoFields.WEEK_BASED_YEAR, 4, 10, SignStyle.EXCEEDS_PAD).appendLiteral("-W")
+  // .appendValue(IsoFields.WEEK_OF_WEEK_BASED_YEAR, 2).appendLiteral('-').appendValue(DAY_OF_WEEK, 1)
+  // .optionalStart().appendOffsetId().toFormatter(TResolverStyle.STRICT, TIsoChronology.INSTANCE);
+  // }
+
+  public static final TDateTimeFormatter ISO_INSTANT;
+  static {
+    ISO_INSTANT = new TDateTimeFormatterBuilder().parseCaseInsensitive().appendInstant()
+        .toFormatter(TResolverStyle.STRICT, null);
+  }
+
+  public static final TDateTimeFormatter BASIC_ISO_DATE;
+  static {
+    BASIC_ISO_DATE = new TDateTimeFormatterBuilder().parseCaseInsensitive().appendValue(YEAR, 4)
+        .appendValue(MONTH_OF_YEAR, 2).appendValue(DAY_OF_MONTH, 2).optionalStart().parseLenient()
+        .appendOffset("+HHMMss", "Z").parseStrict().toFormatter(TResolverStyle.STRICT, TIsoChronology.INSTANCE);
+  }
+
+  public static final TDateTimeFormatter RFC_1123_DATE_TIME;
+  static {
+    Map<Long, String> dow = new HashMap<>();
+    dow.put(1L, "Mon");
+    dow.put(2L, "Tue");
+    dow.put(3L, "Wed");
+    dow.put(4L, "Thu");
+    dow.put(5L, "Fri");
+    dow.put(6L, "Sat");
+    dow.put(7L, "Sun");
+    Map<Long, String> moy = new HashMap<>();
+    moy.put(1L, "Jan");
+    moy.put(2L, "Feb");
+    moy.put(3L, "Mar");
+    moy.put(4L, "Apr");
+    moy.put(5L, "May");
+    moy.put(6L, "Jun");
+    moy.put(7L, "Jul");
+    moy.put(8L, "Aug");
+    moy.put(9L, "Sep");
+    moy.put(10L, "Oct");
+    moy.put(11L, "Nov");
+    moy.put(12L, "Dec");
+    RFC_1123_DATE_TIME = new TDateTimeFormatterBuilder().parseCaseInsensitive().parseLenient().optionalStart()
+        .appendText(DAY_OF_WEEK, dow).appendLiteral(", ").optionalEnd()
+        .appendValue(DAY_OF_MONTH, 1, 2, TSignStyle.NOT_NEGATIVE).appendLiteral(' ').appendText(MONTH_OF_YEAR, moy)
+        .appendLiteral(' ').appendValue(YEAR, 4).appendLiteral(' ').appendValue(HOUR_OF_DAY, 2).appendLiteral(':')
+        .appendValue(MINUTE_OF_HOUR, 2).optionalStart().appendLiteral(':').appendValue(SECOND_OF_MINUTE, 2)
+        .optionalEnd().appendLiteral(' ').appendOffset("+HHMM", "GMT")
+        .toFormatter(TResolverStyle.SMART, TIsoChronology.INSTANCE);
+  }
+
+  public static final TTemporalQuery<TPeriod> parsedExcessDays() {
+
+    return PARSED_EXCESS_DAYS;
+  }
+
+  private static final TTemporalQuery<TPeriod> PARSED_EXCESS_DAYS = t -> {
+    if (t instanceof TParsed) {
+      return ((TParsed) t).excessDays;
+    } else {
+      return TPeriod.ZERO;
+    }
+  };
+
+  public static final TTemporalQuery<Boolean> parsedLeapSecond() {
+
+    return PARSED_LEAP_SECOND;
+  }
+
+  private static final TTemporalQuery<Boolean> PARSED_LEAP_SECOND = t -> {
+    if (t instanceof TParsed) {
+      return ((TParsed) t).leapSecond;
+    } else {
+      return Boolean.FALSE;
+    }
+  };
+
+  TDateTimeFormatter(TCompositePrinterParser printerParser, TLocale locale, TDecimalStyle decimalStyle,
+      TResolverStyle resolverStyle, Set<TTemporalField> resolverFields, TChronology chrono, TZoneId zone) {
+
+    this.printerParser = TObjects.requireNonNull(printerParser, "printerParser");
+    this.resolverFields = resolverFields;
+    this.locale = TObjects.requireNonNull(locale, "locale");
+    this.decimalStyle = TObjects.requireNonNull(decimalStyle, "decimalStyle");
+    this.resolverStyle = TObjects.requireNonNull(resolverStyle, "resolverStyle");
+    this.chrono = chrono;
+    this.zone = zone;
+  }
+
+  public TLocale getLocale() {
+
+    return this.locale;
+  }
+
+  public TDateTimeFormatter withLocale(TLocale locale) {
+
+    if (this.locale.equals(locale)) {
+      return this;
+    }
+    return new TDateTimeFormatter(this.printerParser, locale, this.decimalStyle, this.resolverStyle,
+        this.resolverFields, this.chrono, this.zone);
+  }
+
+  public TDateTimeFormatter localizedBy(TLocale locale) {
+
+    if (this.locale.equals(locale)) {
+      return this;
+    }
+
+    TChronology c = this.chrono;
+    TDecimalStyle ds = this.decimalStyle;
+    TZoneId z = this.zone;
+    return new TDateTimeFormatter(this.printerParser, locale, ds, this.resolverStyle, this.resolverFields, c, z);
+  }
+
+  public TDecimalStyle getDecimalStyle() {
+
+    return this.decimalStyle;
+  }
+
+  public TDateTimeFormatter withDecimalStyle(TDecimalStyle decimalStyle) {
+
+    if (this.decimalStyle.equals(decimalStyle)) {
+      return this;
+    }
+    return new TDateTimeFormatter(this.printerParser, this.locale, decimalStyle, this.resolverStyle,
+        this.resolverFields, this.chrono, this.zone);
+  }
+
+  public TChronology getChronology() {
+
+    return this.chrono;
+  }
+
+  public TDateTimeFormatter withChronology(TChronology chrono) {
+
+    if (TObjects.equals(this.chrono, chrono)) {
+      return this;
+    }
+    return new TDateTimeFormatter(this.printerParser, this.locale, this.decimalStyle, this.resolverStyle,
+        this.resolverFields, chrono, this.zone);
+  }
+
+  public TZoneId getZone() {
+
+    return this.zone;
+  }
+
+  public TDateTimeFormatter withZone(TZoneId zone) {
+
+    if (TObjects.equals(this.zone, zone)) {
+      return this;
+    }
+    return new TDateTimeFormatter(this.printerParser, this.locale, this.decimalStyle, this.resolverStyle,
+        this.resolverFields, this.chrono, zone);
+  }
+
+  public TResolverStyle getResolverStyle() {
+
+    return this.resolverStyle;
+  }
+
+  public TDateTimeFormatter withResolverStyle(TResolverStyle resolverStyle) {
+
+    TObjects.requireNonNull(resolverStyle, "resolverStyle");
+    if (TObjects.equals(this.resolverStyle, resolverStyle)) {
+      return this;
+    }
+    return new TDateTimeFormatter(this.printerParser, this.locale, this.decimalStyle, resolverStyle,
+        this.resolverFields, this.chrono, this.zone);
+  }
+
+  public Set<TTemporalField> getResolverFields() {
+
+    return this.resolverFields;
+  }
+
+  public TDateTimeFormatter withResolverFields(TTemporalField... resolverFields) {
+
+    Set<TTemporalField> fields = null;
+    if (resolverFields != null) {
+      // Set.of cannot be used because it is hostile to nulls and duplicate elements
+      fields = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(resolverFields)));
+    }
+    if (TObjects.equals(this.resolverFields, fields)) {
+      return this;
+    }
+    return new TDateTimeFormatter(this.printerParser, this.locale, this.decimalStyle, this.resolverStyle, fields,
+        this.chrono, this.zone);
+  }
+
+  public TDateTimeFormatter withResolverFields(Set<TTemporalField> resolverFields) {
+
+    if (TObjects.equals(this.resolverFields, resolverFields)) {
+      return this;
+    }
+    if (resolverFields != null) {
+      resolverFields = Collections.unmodifiableSet(new HashSet<>(resolverFields));
+    }
+    return new TDateTimeFormatter(this.printerParser, this.locale, this.decimalStyle, this.resolverStyle,
+        resolverFields, this.chrono, this.zone);
+  }
+
+  public String format(TTemporalAccessor temporal) {
+
+    StringBuilder buf = new StringBuilder(32);
+    formatTo(temporal, buf);
+    return buf.toString();
+  }
+
+  public void formatTo(TTemporalAccessor temporal, Appendable appendable) {
+
+    TObjects.requireNonNull(temporal, "temporal");
+    TObjects.requireNonNull(appendable, "appendable");
+    try {
+      TDateTimePrintContext context = new TDateTimePrintContext(temporal, this);
+      if (appendable instanceof StringBuilder) {
+        this.printerParser.format(context, (StringBuilder) appendable);
+      } else {
+        StringBuilder buf = new StringBuilder(32);
+        this.printerParser.format(context, buf);
+        appendable.append(buf);
+      }
+    } catch (IOException ex) {
+      throw new TDateTimeException(ex.getMessage(), ex);
+    }
+  }
+
+  public TTemporalAccessor parse(CharSequence text) {
+
+    TObjects.requireNonNull(text, "text");
+    try {
+      return parseResolved0(text, null);
+    } catch (TDateTimeParseException ex) {
+      throw ex;
+    } catch (RuntimeException ex) {
+      throw createError(text, ex);
+    }
+  }
+
+  public TTemporalAccessor parse(CharSequence text, TParsePosition position) {
+
+    TObjects.requireNonNull(text, "text");
+    TObjects.requireNonNull(position, "position");
+    try {
+      return parseResolved0(text, position);
+    } catch (TDateTimeParseException | IndexOutOfBoundsException ex) {
+      throw ex;
+    } catch (RuntimeException ex) {
+      throw createError(text, ex);
+    }
+  }
+
+  public <T> T parse(CharSequence text, TTemporalQuery<T> query) {
+
+    Objects.requireNonNull(text, "text");
+    Objects.requireNonNull(query, "query");
+    try {
+      return parseResolved0(text, null).query(query);
+    } catch (TDateTimeParseException ex) {
+      throw ex;
+    } catch (RuntimeException ex) {
+      throw createError(text, ex);
+    }
+  }
+
+  public TTemporalAccessor parseBest(CharSequence text, TTemporalQuery<?>... queries) {
+
+    TObjects.requireNonNull(text, "text");
+    TObjects.requireNonNull(queries, "queries");
+    if (queries.length < 2) {
+      throw new IllegalArgumentException("At least two queries must be specified");
+    }
+    try {
+      TTemporalAccessor resolved = parseResolved0(text, null);
+      for (TTemporalQuery<?> query : queries) {
+        try {
+          return (TTemporalAccessor) resolved.query(query);
+        } catch (RuntimeException ex) {
+        }
+      }
+      throw new TDateTimeException("Unable to convert parsed text using any of the specified queries");
+    } catch (TDateTimeParseException ex) {
+      throw ex;
+    } catch (RuntimeException ex) {
+      throw createError(text, ex);
+    }
+  }
+
+  private TDateTimeParseException createError(CharSequence text, RuntimeException ex) {
+
+    String abbr;
+    if (text.length() > 64) {
+      abbr = text.subSequence(0, 64).toString() + "...";
+    } else {
+      abbr = text.toString();
+    }
+    return new TDateTimeParseException("Text '" + abbr + "' could not be parsed: " + ex.getMessage(), text, 0, ex);
+  }
+
+  private TTemporalAccessor parseResolved0(final CharSequence text, final TParsePosition position) {
+
+    TParsePosition pos = (position != null ? position : new TParsePosition(0));
+    TDateTimeParseContext context = parseUnresolved0(text, pos);
+    if (context == null || pos.getErrorIndex() >= 0 || (position == null && pos.getIndex() < text.length())) {
+      String abbr;
+      if (text.length() > 64) {
+        abbr = text.subSequence(0, 64).toString() + "...";
+      } else {
+        abbr = text.toString();
+      }
+      if (pos.getErrorIndex() >= 0) {
+        throw new TDateTimeParseException("Text '" + abbr + "' could not be parsed at index " + pos.getErrorIndex(),
+            text, pos.getErrorIndex());
+      } else {
+        throw new TDateTimeParseException(
+            "Text '" + abbr + "' could not be parsed, unparsed text found at index " + pos.getIndex(), text,
+            pos.getIndex());
+      }
+    }
+    return context.toResolved(this.resolverStyle, this.resolverFields);
+  }
+
+  public TTemporalAccessor parseUnresolved(CharSequence text, TParsePosition position) {
+
+    TDateTimeParseContext context = parseUnresolved0(text, position);
+    if (context == null) {
+      return null;
+    }
+    return context.toUnresolved();
+  }
+
+  private TDateTimeParseContext parseUnresolved0(CharSequence text, TParsePosition position) {
+
+    TObjects.requireNonNull(text, "text");
+    TObjects.requireNonNull(position, "position");
+    TDateTimeParseContext context = new TDateTimeParseContext(this);
+    int pos = position.getIndex();
+    pos = this.printerParser.parse(context, text, pos);
+    if (pos < 0) {
+      position.setErrorIndex(~pos);
+      return null;
+    }
+    position.setIndex(pos);
+    return context;
+  }
+
+  TCompositePrinterParser toPrinterParser(boolean optional) {
+
+    return this.printerParser.withOptional(optional);
+  }
+
+  public TFormat toFormat() {
+
+    return new TClassicFormat(this, null);
+  }
+
+  public TFormat toFormat(TTemporalQuery<?> parseQuery) {
+
+    TObjects.requireNonNull(parseQuery, "parseQuery");
+    return new TClassicFormat(this, parseQuery);
+  }
+
+  @Override
+  public String toString() {
+
+    String pattern = this.printerParser.toString();
+    pattern = pattern.startsWith("[") ? pattern : pattern.substring(1, pattern.length() - 1);
+    return pattern;
+  }
+
+  static class TClassicFormat extends TFormat {
+    private final TDateTimeFormatter formatter;
+
+    private final TTemporalQuery<?> parseType;
+
+    public TClassicFormat(TDateTimeFormatter formatter, TTemporalQuery<?> parseType) {
+
+      this.formatter = formatter;
+      this.parseType = parseType;
+    }
+
+    @Override
+    public StringBuffer format(Object obj, StringBuffer toAppendTo, TFieldPosition pos) {
+
+      TObjects.requireNonNull(obj, "obj");
+      TObjects.requireNonNull(toAppendTo, "toAppendTo");
+      TObjects.requireNonNull(pos, "pos");
+      if (obj instanceof TTemporalAccessor == false) {
+        throw new IllegalArgumentException("Format target must implement TemporalAccessor");
+      }
+      pos.setBeginIndex(0);
+      pos.setEndIndex(0);
+      try {
+        this.formatter.formatTo((TTemporalAccessor) obj, toAppendTo);
+      } catch (RuntimeException ex) {
+        throw new IllegalArgumentException(ex.getMessage(), ex);
+      }
+      return toAppendTo;
+    }
+
+    @Override
+    public Object parseObject(String text) throws TParseException {
+
+      Objects.requireNonNull(text, "text");
+      try {
+        if (this.parseType == null) {
+          return this.formatter.parseResolved0(text, null);
+        }
+        return this.formatter.parse(text, this.parseType);
+      } catch (TDateTimeParseException ex) {
+        throw new TParseException(ex.getMessage(), ex.getErrorIndex());
+      } catch (RuntimeException ex) {
+        throw (TParseException) new TParseException(ex.getMessage(), 0).initCause(ex);
+      }
+    }
+
+    @Override
+    public Object parseObject(String text, TParsePosition pos) {
+
+      Objects.requireNonNull(text, "text");
+      TDateTimeParseContext context;
+      try {
+        context = this.formatter.parseUnresolved0(text, pos);
+      } catch (IndexOutOfBoundsException ex) {
+        if (pos.getErrorIndex() < 0) {
+          pos.setErrorIndex(0);
+        }
+        return null;
+      }
+      if (context == null) {
+        if (pos.getErrorIndex() < 0) {
+          pos.setErrorIndex(0);
+        }
+        return null;
+      }
+      try {
+        TTemporalAccessor resolved = context.toResolved(this.formatter.resolverStyle, this.formatter.resolverFields);
+        if (this.parseType == null) {
+          return resolved;
+        }
+        return resolved.query(this.parseType);
+      } catch (RuntimeException ex) {
+        pos.setErrorIndex(0);
+        return null;
+      }
+    }
+  }
+
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/time/format/TDateTimeFormatterBuilder.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/time/format/TDateTimeFormatterBuilder.java
@@ -1,0 +1,2652 @@
+package org.teavm.classlib.java.time.format;
+
+import static org.teavm.classlib.java.time.temporal.TChronoField.DAY_OF_MONTH;
+import static org.teavm.classlib.java.time.temporal.TChronoField.HOUR_OF_DAY;
+import static org.teavm.classlib.java.time.temporal.TChronoField.INSTANT_SECONDS;
+import static org.teavm.classlib.java.time.temporal.TChronoField.MINUTE_OF_HOUR;
+import static org.teavm.classlib.java.time.temporal.TChronoField.MONTH_OF_YEAR;
+import static org.teavm.classlib.java.time.temporal.TChronoField.NANO_OF_SECOND;
+import static org.teavm.classlib.java.time.temporal.TChronoField.OFFSET_SECONDS;
+import static org.teavm.classlib.java.time.temporal.TChronoField.SECOND_OF_MINUTE;
+import static org.teavm.classlib.java.time.temporal.TChronoField.YEAR;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.math.RoundingMode;
+import java.text.ParsePosition;
+import java.time.DateTimeException;
+import java.time.format.SignStyle;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import org.teavm.classlib.java.time.TDateTimeException;
+import org.teavm.classlib.java.time.TInstant;
+import org.teavm.classlib.java.time.TLocalDate;
+import org.teavm.classlib.java.time.TLocalDateTime;
+import org.teavm.classlib.java.time.TLocalTime;
+import org.teavm.classlib.java.time.TZoneId;
+import org.teavm.classlib.java.time.TZoneOffset;
+import org.teavm.classlib.java.time.chrono.TChronoLocalDate;
+import org.teavm.classlib.java.time.chrono.TChronology;
+import org.teavm.classlib.java.time.temporal.TChronoField;
+import org.teavm.classlib.java.time.temporal.TTemporalAccessor;
+import org.teavm.classlib.java.time.temporal.TTemporalField;
+import org.teavm.classlib.java.time.temporal.TTemporalQueries;
+import org.teavm.classlib.java.time.temporal.TTemporalQuery;
+import org.teavm.classlib.java.time.temporal.TValueRange;
+import org.teavm.classlib.java.util.TLocale;
+import org.teavm.classlib.java.util.TObjects;
+
+public final class TDateTimeFormatterBuilder {
+
+  private static final TTemporalQuery<TZoneId> QUERY_REGION_ONLY = (temporal) -> {
+    TZoneId zone = temporal.query(TTemporalQueries.zoneId());
+    return (zone != null && zone instanceof TZoneOffset == false ? zone : null);
+  };
+
+  private static final String[] LOCALIZED_PATTERN_DATE = { "y MMMM d, EEEE ", "y MMMM d ", "y MMM d ", "y-MM-dd " };
+
+  private static final String[] LOCALIZED_PATTERN_TIME = { "HH:mm:ss zzzz", "HH:mm:ss", "HH:mm:ss", "HH:mm" };
+
+  private TDateTimeFormatterBuilder active = this;
+
+  private final TDateTimeFormatterBuilder parent;
+
+  private final List<TDateTimePrinterParser> printerParsers = new ArrayList<>();
+
+  private final boolean optional;
+
+  private int padNextWidth;
+
+  private char padNextChar;
+
+  private int valueParserIndex = -1;
+
+  public static String getLocalizedDateTimePattern(TFormatStyle dateStyle, TFormatStyle timeStyle, TChronology chrono,
+      TLocale locale) {
+
+    TObjects.requireNonNull(locale, "locale");
+    TObjects.requireNonNull(chrono, "chrono");
+
+    if (dateStyle == null && timeStyle == null) {
+      throw new IllegalArgumentException("Either dateStyle or timeStyle must be non-null");
+    }
+    String datePattern = "";
+    if (dateStyle != null) {
+      datePattern = LOCALIZED_PATTERN_DATE[dateStyle.ordinal()];
+    }
+    String timePattern = "";
+    if (timeStyle != null) {
+      timePattern = LOCALIZED_PATTERN_TIME[timeStyle.ordinal()];
+    }
+    String infix = "";
+    if (!datePattern.isEmpty() && timePattern.isEmpty()) {
+      // TODO consider adding localized 'at' if date style is full or long
+      infix = " ";
+    }
+    return datePattern + infix + timePattern;
+  }
+
+  private static int convertStyle(TFormatStyle style) {
+
+    if (style == null) {
+      return -1;
+    }
+    return style.ordinal();
+  }
+
+  public TDateTimeFormatterBuilder() {
+
+    super();
+    this.parent = null;
+    this.optional = false;
+  }
+
+  private TDateTimeFormatterBuilder(TDateTimeFormatterBuilder parent, boolean optional) {
+
+    super();
+    this.parent = parent;
+    this.optional = optional;
+  }
+
+  public TDateTimeFormatterBuilder parseCaseSensitive() {
+
+    appendInternal(TSettingsParser.SENSITIVE);
+    return this;
+  }
+
+  public TDateTimeFormatterBuilder parseCaseInsensitive() {
+
+    appendInternal(TSettingsParser.INSENSITIVE);
+    return this;
+  }
+
+  public TDateTimeFormatterBuilder parseStrict() {
+
+    appendInternal(TSettingsParser.STRICT);
+    return this;
+  }
+
+  public TDateTimeFormatterBuilder parseLenient() {
+
+    appendInternal(TSettingsParser.LENIENT);
+    return this;
+  }
+
+  public TDateTimeFormatterBuilder parseDefaulting(TTemporalField field, long value) {
+
+    Objects.requireNonNull(field, "field");
+    appendInternal(new TDefaultValueParser(field, value));
+    return this;
+  }
+
+  public TDateTimeFormatterBuilder appendValue(TTemporalField field) {
+
+    TObjects.requireNonNull(field, "field");
+    appendValue(new TNumberPrinterParser(field, 1, 19, TSignStyle.NORMAL));
+    return this;
+  }
+
+  public TDateTimeFormatterBuilder appendValue(TTemporalField field, int width) {
+
+    TObjects.requireNonNull(field, "field");
+    if (width < 1 || width > 19) {
+      throw new IllegalArgumentException("The width must be from 1 to 19 inclusive but was " + width);
+    }
+    TNumberPrinterParser pp = new TNumberPrinterParser(field, width, width, TSignStyle.NOT_NEGATIVE);
+    appendValue(pp);
+    return this;
+  }
+
+  public TDateTimeFormatterBuilder appendValue(TTemporalField field, int minWidth, int maxWidth, TSignStyle signStyle) {
+
+    if (minWidth == maxWidth && signStyle == TSignStyle.NOT_NEGATIVE) {
+      return appendValue(field, maxWidth);
+    }
+    Objects.requireNonNull(field, "field");
+    Objects.requireNonNull(signStyle, "signStyle");
+    if (minWidth < 1 || minWidth > 19) {
+      throw new IllegalArgumentException("The minimum width must be from 1 to 19 inclusive but was " + minWidth);
+    }
+    if (maxWidth < 1 || maxWidth > 19) {
+      throw new IllegalArgumentException("The maximum width must be from 1 to 19 inclusive but was " + maxWidth);
+    }
+    if (maxWidth < minWidth) {
+      throw new IllegalArgumentException(
+          "The maximum width must exceed or equal the minimum width but " + maxWidth + " < " + minWidth);
+    }
+    TNumberPrinterParser pp = new TNumberPrinterParser(field, minWidth, maxWidth, signStyle);
+    appendValue(pp);
+    return this;
+  }
+
+  public TDateTimeFormatterBuilder appendValueReduced(TTemporalField field, int width, int maxWidth, int baseValue) {
+
+    TObjects.requireNonNull(field, "field");
+    TReducedPrinterParser pp = new TReducedPrinterParser(field, width, maxWidth, baseValue, null);
+    appendValue(pp);
+    return this;
+  }
+
+  public TDateTimeFormatterBuilder appendValueReduced(TTemporalField field, int width, int maxWidth,
+      TChronoLocalDate baseDate) {
+
+    TObjects.requireNonNull(field, "field");
+    TObjects.requireNonNull(baseDate, "baseDate");
+    TReducedPrinterParser pp = new TReducedPrinterParser(field, width, maxWidth, 0, baseDate);
+    appendValue(pp);
+    return this;
+  }
+
+  private TDateTimeFormatterBuilder appendValue(TNumberPrinterParser pp) {
+
+    if (this.active.valueParserIndex >= 0) {
+      final int activeValueParser = this.active.valueParserIndex;
+
+      TNumberPrinterParser basePP = (TNumberPrinterParser) this.active.printerParsers.get(activeValueParser);
+      if (pp.minWidth == pp.maxWidth && pp.signStyle == TSignStyle.NOT_NEGATIVE) {
+        basePP = basePP.withSubsequentWidth(pp.maxWidth);
+        appendInternal(pp.withFixedWidth());
+        this.active.valueParserIndex = activeValueParser;
+      } else {
+        basePP = basePP.withFixedWidth();
+        this.active.valueParserIndex = appendInternal(pp);
+      }
+      this.active.printerParsers.set(activeValueParser, basePP);
+    } else {
+      this.active.valueParserIndex = appendInternal(pp);
+    }
+    return this;
+  }
+
+  public TDateTimeFormatterBuilder appendFraction(TTemporalField field, int minWidth, int maxWidth,
+      boolean decimalPoint) {
+
+    if (minWidth == maxWidth && decimalPoint == false) {
+      // adjacent parsing
+      appendValue(new TFractionPrinterParser(field, minWidth, maxWidth, decimalPoint));
+    } else {
+      appendInternal(new TFractionPrinterParser(field, minWidth, maxWidth, decimalPoint));
+    }
+    return this;
+  }
+
+  public TDateTimeFormatterBuilder appendText(TTemporalField field) {
+
+    return appendText(field, TTextStyle.FULL);
+  }
+
+  public TDateTimeFormatterBuilder appendText(TTemporalField field, TTextStyle textStyle) {
+
+    TObjects.requireNonNull(field, "field");
+    TObjects.requireNonNull(textStyle, "textStyle");
+    appendInternal(new TTextPrinterParser(field, textStyle));
+    return this;
+  }
+
+  public TDateTimeFormatterBuilder appendText(TTemporalField field, Map<Long, String> textLookup) {
+
+    TObjects.requireNonNull(field, "field");
+    TObjects.requireNonNull(textLookup, "textLookup");
+    appendInternal(new TTextPrinterParser(field, TTextStyle.FULL));
+    return this;
+  }
+
+  public TDateTimeFormatterBuilder appendInstant() {
+
+    appendInternal(new TInstantPrinterParser(-2));
+    return this;
+  }
+
+  public TDateTimeFormatterBuilder appendInstant(int fractionalDigits) {
+
+    if (fractionalDigits < -1 || fractionalDigits > 9) {
+      throw new IllegalArgumentException(
+          "The fractional digits must be from -1 to 9 inclusive but was " + fractionalDigits);
+    }
+    appendInternal(new TInstantPrinterParser(fractionalDigits));
+    return this;
+  }
+
+  public TDateTimeFormatterBuilder appendOffsetId() {
+
+    appendInternal(TOffsetIdPrinterParser.INSTANCE_ID_Z);
+    return this;
+  }
+
+  public TDateTimeFormatterBuilder appendOffset(String pattern, String noOffsetText) {
+
+    appendInternal(new TOffsetIdPrinterParser(pattern, noOffsetText));
+    return this;
+  }
+
+  public TDateTimeFormatterBuilder appendLocalizedOffset(TTextStyle style) {
+
+    Objects.requireNonNull(style, "style");
+    if (style != TTextStyle.FULL && style != TTextStyle.SHORT) {
+      throw new IllegalArgumentException("Style must be either full or short");
+    }
+    appendInternal(new TLocalizedOffsetIdPrinterParser(style));
+    return this;
+  }
+
+  public TDateTimeFormatterBuilder appendZoneId() {
+
+    appendInternal(new TZoneIdPrinterParser(TTemporalQueries.zoneId(), "ZoneId()"));
+    return this;
+  }
+
+  public TDateTimeFormatterBuilder appendZoneRegionId() {
+
+    appendInternal(new TZoneIdPrinterParser(QUERY_REGION_ONLY, "ZoneRegionId()"));
+    return this;
+  }
+
+  public TDateTimeFormatterBuilder appendZoneOrOffsetId() {
+
+    appendInternal(new TZoneIdPrinterParser(TTemporalQueries.zone(), "ZoneOrOffsetId()"));
+    return this;
+  }
+
+  public TDateTimeFormatterBuilder appendZoneText(TTextStyle textStyle) {
+
+    appendInternal(new TZoneTextPrinterParser(textStyle, false));
+    return this;
+  }
+
+  public TDateTimeFormatterBuilder appendGenericZoneText(TTextStyle textStyle) {
+
+    appendInternal(new TZoneTextPrinterParser(textStyle, true));
+    return this;
+  }
+
+  public TDateTimeFormatterBuilder appendChronologyId() {
+
+    appendInternal(new TChronoPrinterParser(null));
+    return this;
+  }
+
+  public TDateTimeFormatterBuilder appendChronologyText(TTextStyle textStyle) {
+
+    TObjects.requireNonNull(textStyle, "textStyle");
+    appendInternal(new TChronoPrinterParser(textStyle));
+    return this;
+  }
+
+  public TDateTimeFormatterBuilder appendLocalized(TFormatStyle dateStyle, TFormatStyle timeStyle) {
+
+    if (dateStyle == null && timeStyle == null) {
+      throw new IllegalArgumentException("Either the date or time style must be non-null");
+    }
+    appendInternal(new TLocalizedPrinterParser(dateStyle, timeStyle));
+    return this;
+  }
+
+  public TDateTimeFormatterBuilder appendLiteral(char literal) {
+
+    appendInternal(new TCharLiteralPrinterParser(literal));
+    return this;
+  }
+
+  public TDateTimeFormatterBuilder appendLiteral(String literal) {
+
+    TObjects.requireNonNull(literal, "literal");
+    if (!literal.isEmpty()) {
+      if (literal.length() == 1) {
+        appendInternal(new TCharLiteralPrinterParser(literal.charAt(0)));
+      } else {
+        appendInternal(new TStringLiteralPrinterParser(literal));
+      }
+    }
+    return this;
+  }
+
+  public TDateTimeFormatterBuilder append(TDateTimeFormatter formatter) {
+
+    TObjects.requireNonNull(formatter, "formatter");
+    appendInternal(formatter.toPrinterParser(false));
+    return this;
+  }
+
+  public TDateTimeFormatterBuilder appendOptional(TDateTimeFormatter formatter) {
+
+    TObjects.requireNonNull(formatter, "formatter");
+    appendInternal(formatter.toPrinterParser(true));
+    return this;
+  }
+
+  public TDateTimeFormatterBuilder appendPattern(String pattern) {
+
+    TObjects.requireNonNull(pattern, "pattern");
+    parsePattern(pattern);
+    return this;
+  }
+
+  private void parsePattern(String pattern) {
+
+    for (int pos = 0; pos < pattern.length(); pos++) {
+      char cur = pattern.charAt(pos);
+      if ((cur >= 'A' && cur <= 'Z') || (cur >= 'a' && cur <= 'z')) {
+        int start = pos++;
+        for (; pos < pattern.length() && pattern.charAt(pos) == cur; pos++)
+          ;
+        int count = pos - start;
+        if (cur == 'p') {
+          int pad = 0;
+          if (pos < pattern.length()) {
+            cur = pattern.charAt(pos);
+            if ((cur >= 'A' && cur <= 'Z') || (cur >= 'a' && cur <= 'z')) {
+              pad = count;
+              start = pos++;
+              for (; pos < pattern.length() && pattern.charAt(pos) == cur; pos++)
+                ;
+              count = pos - start;
+            }
+          }
+          if (pad == 0) {
+            throw new IllegalArgumentException("Pad letter 'p' must be followed by valid pad pattern: " + pattern);
+          }
+          padNext(pad);
+        }
+        TTemporalField field = FIELD_MAP.get(cur);
+        if (field != null) {
+          parseField(cur, count, field);
+        } else if (cur == 'z') {
+          if (count > 4) {
+            throw new IllegalArgumentException("Too many pattern letters: " + cur);
+          } else if (count == 4) {
+            appendZoneText(TTextStyle.FULL);
+          } else {
+            appendZoneText(TTextStyle.SHORT);
+          }
+        } else if (cur == 'V') {
+          if (count != 2) {
+            throw new IllegalArgumentException("Pattern letter count must be 2: " + cur);
+          }
+          appendZoneId();
+        } else if (cur == 'v') {
+          if (count == 1) {
+            appendGenericZoneText(TTextStyle.SHORT);
+          } else if (count == 4) {
+            appendGenericZoneText(TTextStyle.FULL);
+          } else {
+            throw new IllegalArgumentException("Wrong number of  pattern letters: " + cur);
+          }
+        } else if (cur == 'Z') {
+          if (count < 4) {
+            appendOffset("+HHMM", "+0000");
+          } else if (count == 4) {
+            appendLocalizedOffset(TTextStyle.FULL);
+          } else if (count == 5) {
+            appendOffset("+HH:MM:ss", "Z");
+          } else {
+            throw new IllegalArgumentException("Too many pattern letters: " + cur);
+          }
+        } else if (cur == 'O') {
+          if (count == 1) {
+            appendLocalizedOffset(TTextStyle.SHORT);
+          } else if (count == 4) {
+            appendLocalizedOffset(TTextStyle.FULL);
+          } else {
+            throw new IllegalArgumentException("Pattern letter count must be 1 or 4: " + cur);
+          }
+        } else if (cur == 'X') {
+          if (count > 5) {
+            throw new IllegalArgumentException("Too many pattern letters: " + cur);
+          }
+          appendOffset(TOffsetIdPrinterParser.PATTERNS[count + (count == 1 ? 0 : 1)], "Z");
+        } else if (cur == 'x') {
+          if (count > 5) {
+            throw new IllegalArgumentException("Too many pattern letters: " + cur);
+          }
+          String zero = (count == 1 ? "+00" : (count % 2 == 0 ? "+0000" : "+00:00"));
+          appendOffset(TOffsetIdPrinterParser.PATTERNS[count + (count == 1 ? 0 : 1)], zero);
+        } else if (cur == 'W') {
+          if (count > 1) {
+            throw new IllegalArgumentException("Too many pattern letters: " + cur);
+          }
+          appendValue(new TWeekBasedFieldPrinterParser(cur, count, count, count));
+        } else if (cur == 'w') {
+          if (count > 2) {
+            throw new IllegalArgumentException("Too many pattern letters: " + cur);
+          }
+          appendValue(new TWeekBasedFieldPrinterParser(cur, count, count, 2));
+        } else if (cur == 'Y') {
+          if (count == 2) {
+            appendValue(new TWeekBasedFieldPrinterParser(cur, count, count, 2));
+          } else {
+            appendValue(new TWeekBasedFieldPrinterParser(cur, count, count, 19));
+          }
+        } else {
+          throw new IllegalArgumentException("Unknown pattern letter: " + cur);
+        }
+        pos--;
+
+      } else if (cur == '\'') {
+        int start = pos++;
+        for (; pos < pattern.length(); pos++) {
+          if (pattern.charAt(pos) == '\'') {
+            if (pos + 1 < pattern.length() && pattern.charAt(pos + 1) == '\'') {
+              pos++;
+            } else {
+              break;
+            }
+          }
+        }
+        if (pos >= pattern.length()) {
+          throw new IllegalArgumentException("Pattern ends with an incomplete string literal: " + pattern);
+        }
+        String str = pattern.substring(start + 1, pos);
+        if (str.isEmpty()) {
+          appendLiteral('\'');
+        } else {
+          appendLiteral(str.replace("''", "'"));
+        }
+
+      } else if (cur == '[') {
+        optionalStart();
+
+      } else if (cur == ']') {
+        if (this.active.parent == null) {
+          throw new IllegalArgumentException("Pattern invalid as it contains ] without previous [");
+        }
+        optionalEnd();
+
+      } else if (cur == '{' || cur == '}' || cur == '#') {
+        throw new IllegalArgumentException("Pattern includes reserved character: '" + cur + "'");
+      } else {
+        appendLiteral(cur);
+      }
+    }
+  }
+
+  @SuppressWarnings("fallthrough")
+  private void parseField(char cur, int count, TTemporalField field) {
+
+    boolean standalone = false;
+    switch (cur) {
+      case 'u':
+      case 'y':
+        if (count == 2) {
+          appendValueReduced(field, 2, 2, TReducedPrinterParser.BASE_DATE);
+        } else if (count < 4) {
+          appendValue(field, count, 19, TSignStyle.NORMAL);
+        } else {
+          appendValue(field, count, 19, TSignStyle.EXCEEDS_PAD);
+        }
+        break;
+      case 'c':
+        if (count == 1) {
+          appendValue(new TWeekBasedFieldPrinterParser(cur, count, count, count));
+          break;
+        } else if (count == 2) {
+          throw new IllegalArgumentException("Invalid pattern \"cc\"");
+        }
+      case 'L':
+      case 'q':
+        standalone = true;
+      case 'M':
+      case 'Q':
+      case 'E':
+      case 'e':
+        switch (count) {
+          case 1:
+          case 2:
+            if (cur == 'e') {
+              appendValue(new TWeekBasedFieldPrinterParser(cur, count, count, count));
+            } else if (cur == 'E') {
+              appendText(field, TTextStyle.SHORT);
+            } else {
+              if (count == 1) {
+                appendValue(field);
+              } else {
+                appendValue(field, 2);
+              }
+            }
+            break;
+          case 3:
+            appendText(field, standalone ? TTextStyle.SHORT_STANDALONE : TTextStyle.SHORT);
+            break;
+          case 4:
+            appendText(field, standalone ? TTextStyle.FULL_STANDALONE : TTextStyle.FULL);
+            break;
+          case 5:
+            appendText(field, standalone ? TTextStyle.NARROW_STANDALONE : TTextStyle.NARROW);
+            break;
+          default:
+            throw new IllegalArgumentException("Too many pattern letters: " + cur);
+        }
+        break;
+      case 'a':
+        if (count == 1) {
+          appendText(field, TTextStyle.SHORT);
+        } else {
+          throw new IllegalArgumentException("Too many pattern letters: " + cur);
+        }
+        break;
+      case 'G':
+        switch (count) {
+          case 1:
+          case 2:
+          case 3:
+            appendText(field, TTextStyle.SHORT);
+            break;
+          case 4:
+            appendText(field, TTextStyle.FULL);
+            break;
+          case 5:
+            appendText(field, TTextStyle.NARROW);
+            break;
+          default:
+            throw new IllegalArgumentException("Too many pattern letters: " + cur);
+        }
+        break;
+      case 'S':
+        appendFraction(NANO_OF_SECOND, count, count, false);
+        break;
+      case 'F':
+        if (count == 1) {
+          appendValue(field);
+        } else {
+          throw new IllegalArgumentException("Too many pattern letters: " + cur);
+        }
+        break;
+      case 'd':
+      case 'h':
+      case 'H':
+      case 'k':
+      case 'K':
+      case 'm':
+      case 's':
+        if (count == 1) {
+          appendValue(field);
+        } else if (count == 2) {
+          appendValue(field, count);
+        } else {
+          throw new IllegalArgumentException("Too many pattern letters: " + cur);
+        }
+        break;
+      case 'D':
+        if (count == 1) {
+          appendValue(field);
+        } else if (count == 2 || count == 3) {
+          appendValue(field, count, 3, TSignStyle.NOT_NEGATIVE);
+        } else {
+          throw new IllegalArgumentException("Too many pattern letters: " + cur);
+        }
+        break;
+      case 'g':
+        appendValue(field, count, 19, TSignStyle.NORMAL);
+        break;
+      case 'A':
+      case 'n':
+      case 'N':
+        appendValue(field, count, 19, TSignStyle.NOT_NEGATIVE);
+        break;
+      default:
+        if (count == 1) {
+          appendValue(field);
+        } else {
+          appendValue(field, count);
+        }
+        break;
+    }
+  }
+
+  private static final Map<Character, TTemporalField> FIELD_MAP = new HashMap<>();
+  static {
+    // SDF = SimpleDateFormat
+    FIELD_MAP.put('G', TChronoField.ERA);
+    FIELD_MAP.put('y', TChronoField.YEAR_OF_ERA);
+    FIELD_MAP.put('u', TChronoField.YEAR);
+    // FIELD_MAP.put('Q', IsoFields.QUARTER_OF_YEAR);
+    // FIELD_MAP.put('q', IsoFields.QUARTER_OF_YEAR);
+    FIELD_MAP.put('M', TChronoField.MONTH_OF_YEAR);
+    FIELD_MAP.put('L', TChronoField.MONTH_OF_YEAR);
+    FIELD_MAP.put('D', TChronoField.DAY_OF_YEAR);
+    FIELD_MAP.put('d', TChronoField.DAY_OF_MONTH);
+    FIELD_MAP.put('F', TChronoField.ALIGNED_DAY_OF_WEEK_IN_MONTH);
+    FIELD_MAP.put('E', TChronoField.DAY_OF_WEEK);
+    FIELD_MAP.put('c', TChronoField.DAY_OF_WEEK);
+    FIELD_MAP.put('e', TChronoField.DAY_OF_WEEK);
+    FIELD_MAP.put('a', TChronoField.AMPM_OF_DAY);
+    FIELD_MAP.put('H', TChronoField.HOUR_OF_DAY);
+    FIELD_MAP.put('k', TChronoField.CLOCK_HOUR_OF_DAY);
+    FIELD_MAP.put('K', TChronoField.HOUR_OF_AMPM);
+    FIELD_MAP.put('h', TChronoField.CLOCK_HOUR_OF_AMPM);
+    FIELD_MAP.put('m', TChronoField.MINUTE_OF_HOUR);
+    FIELD_MAP.put('s', TChronoField.SECOND_OF_MINUTE);
+    FIELD_MAP.put('S', TChronoField.NANO_OF_SECOND);
+    FIELD_MAP.put('A', TChronoField.MILLI_OF_DAY);
+    FIELD_MAP.put('n', TChronoField.NANO_OF_SECOND);
+    FIELD_MAP.put('N', TChronoField.NANO_OF_DAY);
+    // FIELD_MAP.put('g', JulianFields.MODIFIED_JULIAN_DAY);
+  }
+
+  public TDateTimeFormatterBuilder padNext(int padWidth) {
+
+    return padNext(padWidth, ' ');
+  }
+
+  public TDateTimeFormatterBuilder padNext(int padWidth, char padChar) {
+
+    if (padWidth < 1) {
+      throw new IllegalArgumentException("The pad width must be at least one but was " + padWidth);
+    }
+    this.active.padNextWidth = padWidth;
+    this.active.padNextChar = padChar;
+    this.active.valueParserIndex = -1;
+    return this;
+  }
+
+  public TDateTimeFormatterBuilder optionalStart() {
+
+    this.active.valueParserIndex = -1;
+    this.active = new TDateTimeFormatterBuilder(this.active, true);
+    return this;
+  }
+
+  public TDateTimeFormatterBuilder optionalEnd() {
+
+    if (this.active.parent == null) {
+      throw new IllegalStateException("Cannot call optionalEnd() as there was no previous call to optionalStart()");
+    }
+    if (this.active.printerParsers.size() > 0) {
+      TCompositePrinterParser cpp = new TCompositePrinterParser(this.active.printerParsers, this.active.optional);
+      this.active = this.active.parent;
+      appendInternal(cpp);
+    } else {
+      this.active = this.active.parent;
+    }
+    return this;
+  }
+
+  private int appendInternal(TDateTimePrinterParser pp) {
+
+    TObjects.requireNonNull(pp, "pp");
+    if (this.active.padNextWidth > 0) {
+      if (pp != null) {
+        pp = new TPadPrinterParserDecorator(pp, this.active.padNextWidth, this.active.padNextChar);
+      }
+      this.active.padNextWidth = 0;
+      this.active.padNextChar = 0;
+    }
+    this.active.printerParsers.add(pp);
+    this.active.valueParserIndex = -1;
+    return this.active.printerParsers.size() - 1;
+  }
+
+  public TDateTimeFormatter toFormatter() {
+
+    return toFormatter(TLocale.getDefault());
+  }
+
+  public TDateTimeFormatter toFormatter(TLocale locale) {
+
+    return toFormatter(locale, TResolverStyle.SMART, null);
+  }
+
+  TDateTimeFormatter toFormatter(TResolverStyle resolverStyle, TChronology chrono) {
+
+    return toFormatter(TLocale.getDefault(), resolverStyle, chrono);
+  }
+
+  private TDateTimeFormatter toFormatter(TLocale locale, TResolverStyle resolverStyle, TChronology chrono) {
+
+    TObjects.requireNonNull(locale, "locale");
+    while (this.active.parent != null) {
+      optionalEnd();
+    }
+    TCompositePrinterParser pp = new TCompositePrinterParser(this.printerParsers, false);
+    return new TDateTimeFormatter(pp, locale, TDecimalStyle.STANDARD, resolverStyle, null, chrono, null);
+  }
+
+  interface TDateTimePrinterParser {
+
+    boolean format(TDateTimePrintContext context, StringBuilder buf);
+
+    int parse(TDateTimeParseContext context, CharSequence text, int position);
+  }
+
+  static final class TCompositePrinterParser implements TDateTimePrinterParser {
+    private final TDateTimePrinterParser[] printerParsers;
+
+    private final boolean optional;
+
+    TCompositePrinterParser(List<TDateTimePrinterParser> printerParsers, boolean optional) {
+
+      this(printerParsers.toArray(new TDateTimePrinterParser[printerParsers.size()]), optional);
+    }
+
+    TCompositePrinterParser(TDateTimePrinterParser[] printerParsers, boolean optional) {
+
+      this.printerParsers = printerParsers;
+      this.optional = optional;
+    }
+
+    public TCompositePrinterParser withOptional(boolean optional) {
+
+      if (optional == this.optional) {
+        return this;
+      }
+      return new TCompositePrinterParser(this.printerParsers, optional);
+    }
+
+    @Override
+    public boolean format(TDateTimePrintContext context, StringBuilder buf) {
+
+      int length = buf.length();
+      if (this.optional) {
+        context.startOptional();
+      }
+      try {
+        for (TDateTimePrinterParser pp : this.printerParsers) {
+          if (pp.format(context, buf) == false) {
+            buf.setLength(length);
+            return true;
+          }
+        }
+      } finally {
+        if (this.optional) {
+          context.endOptional();
+        }
+      }
+      return true;
+    }
+
+    @Override
+    public int parse(TDateTimeParseContext context, CharSequence text, int position) {
+
+      if (this.optional) {
+        context.startOptional();
+        int pos = position;
+        for (TDateTimePrinterParser pp : this.printerParsers) {
+          pos = pp.parse(context, text, pos);
+          if (pos < 0) {
+            context.endOptional(false);
+            return position;
+          }
+        }
+        context.endOptional(true);
+        return pos;
+      } else {
+        for (TDateTimePrinterParser pp : this.printerParsers) {
+          position = pp.parse(context, text, position);
+          if (position < 0) {
+            break;
+          }
+        }
+        return position;
+      }
+    }
+
+    @Override
+    public String toString() {
+
+      StringBuilder buf = new StringBuilder();
+      if (this.printerParsers != null) {
+        buf.append(this.optional ? "[" : "(");
+        for (TDateTimePrinterParser pp : this.printerParsers) {
+          buf.append(pp);
+        }
+        buf.append(this.optional ? "]" : ")");
+      }
+      return buf.toString();
+    }
+  }
+
+  static final class TPadPrinterParserDecorator implements TDateTimePrinterParser {
+    private final TDateTimePrinterParser printerParser;
+
+    private final int padWidth;
+
+    private final char padChar;
+
+    TPadPrinterParserDecorator(TDateTimePrinterParser printerParser, int padWidth, char padChar) {
+
+      this.printerParser = printerParser;
+      this.padWidth = padWidth;
+      this.padChar = padChar;
+    }
+
+    @Override
+    public boolean format(TDateTimePrintContext context, StringBuilder buf) {
+
+      int preLen = buf.length();
+      if (this.printerParser.format(context, buf) == false) {
+        return false;
+      }
+      int len = buf.length() - preLen;
+      if (len > this.padWidth) {
+        throw new TDateTimeException(
+            "Cannot print as output of " + len + " characters exceeds pad width of " + this.padWidth);
+      }
+      for (int i = 0; i < this.padWidth - len; i++) {
+        buf.insert(preLen, this.padChar);
+      }
+      return true;
+    }
+
+    @Override
+    public int parse(TDateTimeParseContext context, CharSequence text, int position) {
+
+      final boolean strict = context.isStrict();
+      if (position > text.length()) {
+        throw new IndexOutOfBoundsException();
+      }
+      if (position == text.length()) {
+        return ~position;
+      }
+      int endPos = position + this.padWidth;
+      if (endPos > text.length()) {
+        if (strict) {
+          return ~position;
+        }
+        endPos = text.length();
+      }
+      int pos = position;
+      while (pos < endPos && context.charEquals(text.charAt(pos), this.padChar)) {
+        pos++;
+      }
+      text = text.subSequence(0, endPos);
+      int resultPos = this.printerParser.parse(context, text, pos);
+      if (resultPos != endPos && strict) {
+        return ~(position + pos);
+      }
+      return resultPos;
+    }
+
+    @Override
+    public String toString() {
+
+      return "Pad(" + this.printerParser + "," + this.padWidth
+          + (this.padChar == ' ' ? ")" : ",'" + this.padChar + "')");
+    }
+  }
+
+  static enum TSettingsParser implements TDateTimePrinterParser {
+    SENSITIVE, INSENSITIVE, STRICT, LENIENT;
+
+    @Override
+    public boolean format(TDateTimePrintContext context, StringBuilder buf) {
+
+      return true;
+    }
+
+    @Override
+    public int parse(TDateTimeParseContext context, CharSequence text, int position) {
+
+      switch (ordinal()) {
+        case 0:
+          context.setCaseSensitive(true);
+          break;
+        case 1:
+          context.setCaseSensitive(false);
+          break;
+        case 2:
+          context.setStrict(true);
+          break;
+        case 3:
+          context.setStrict(false);
+          break;
+      }
+      return position;
+    }
+
+    @Override
+    public String toString() {
+
+      switch (ordinal()) {
+        case 0:
+          return "ParseCaseSensitive(true)";
+        case 1:
+          return "ParseCaseSensitive(false)";
+        case 2:
+          return "ParseStrict(true)";
+        case 3:
+          return "ParseStrict(false)";
+      }
+      throw new IllegalStateException("Unreachable");
+    }
+  }
+
+  static class TDefaultValueParser implements TDateTimePrinterParser {
+    private final TTemporalField field;
+
+    private final long value;
+
+    TDefaultValueParser(TTemporalField field, long value) {
+
+      this.field = field;
+      this.value = value;
+    }
+
+    @Override
+    public boolean format(TDateTimePrintContext context, StringBuilder buf) {
+
+      return true;
+    }
+
+    @Override
+    public int parse(TDateTimeParseContext context, CharSequence text, int position) {
+
+      if (context.getParsed(this.field) == null) {
+        context.setParsedField(this.field, this.value, position, position);
+      }
+      return position;
+    }
+  }
+
+  static final class TCharLiteralPrinterParser implements TDateTimePrinterParser {
+    private final char literal;
+
+    TCharLiteralPrinterParser(char literal) {
+
+      this.literal = literal;
+    }
+
+    @Override
+    public boolean format(TDateTimePrintContext context, StringBuilder buf) {
+
+      buf.append(this.literal);
+      return true;
+    }
+
+    @Override
+    public int parse(TDateTimeParseContext context, CharSequence text, int position) {
+
+      int length = text.length();
+      if (position == length) {
+        return ~position;
+      }
+      char ch = text.charAt(position);
+      if (ch != this.literal) {
+        if (context.isCaseSensitive() || (Character.toUpperCase(ch) != Character.toUpperCase(this.literal)
+            && Character.toLowerCase(ch) != Character.toLowerCase(this.literal))) {
+          return ~position;
+        }
+      }
+      return position + 1;
+    }
+
+    @Override
+    public String toString() {
+
+      if (this.literal == '\'') {
+        return "''";
+      }
+      return "'" + this.literal + "'";
+    }
+  }
+
+  static final class TStringLiteralPrinterParser implements TDateTimePrinterParser {
+    private final String literal;
+
+    TStringLiteralPrinterParser(String literal) {
+
+      this.literal = literal;
+    }
+
+    @Override
+    public boolean format(TDateTimePrintContext context, StringBuilder buf) {
+
+      buf.append(this.literal);
+      return true;
+    }
+
+    @Override
+    public int parse(TDateTimeParseContext context, CharSequence text, int position) {
+
+      int length = text.length();
+      if (position > length || position < 0) {
+        throw new IndexOutOfBoundsException();
+      }
+      if (context.subSequenceEquals(text, position, this.literal, 0, this.literal.length()) == false) {
+        return ~position;
+      }
+      return position + this.literal.length();
+    }
+
+    @Override
+    public String toString() {
+
+      String converted = this.literal.replace("'", "''");
+      return "'" + converted + "'";
+    }
+  }
+
+  static class TNumberPrinterParser implements TDateTimePrinterParser {
+
+    static final long[] EXCEED_POINTS = new long[] { 0L, 10L, 100L, 1000L, 10000L, 100000L, 1000000L, 10000000L,
+    100000000L, 1000000000L, 10000000000L, };
+
+    final TTemporalField field;
+
+    final int minWidth;
+
+    final int maxWidth;
+
+    private final TSignStyle signStyle;
+
+    final int subsequentWidth;
+
+    TNumberPrinterParser(TTemporalField field, int minWidth, int maxWidth, TSignStyle signStyle) {
+
+      this.field = field;
+      this.minWidth = minWidth;
+      this.maxWidth = maxWidth;
+      this.signStyle = signStyle;
+      this.subsequentWidth = 0;
+    }
+
+    protected TNumberPrinterParser(TTemporalField field, int minWidth, int maxWidth, TSignStyle signStyle,
+        int subsequentWidth) {
+
+      this.field = field;
+      this.minWidth = minWidth;
+      this.maxWidth = maxWidth;
+      this.signStyle = signStyle;
+      this.subsequentWidth = subsequentWidth;
+    }
+
+    TNumberPrinterParser withFixedWidth() {
+
+      if (this.subsequentWidth == -1) {
+        return this;
+      }
+      return new TNumberPrinterParser(this.field, this.minWidth, this.maxWidth, this.signStyle, -1);
+    }
+
+    TNumberPrinterParser withSubsequentWidth(int subsequentWidth) {
+
+      return new TNumberPrinterParser(this.field, this.minWidth, this.maxWidth, this.signStyle,
+          this.subsequentWidth + subsequentWidth);
+    }
+
+    @Override
+    public boolean format(TDateTimePrintContext context, StringBuilder buf) {
+
+      Long valueLong = context.getValue(this.field);
+      if (valueLong == null) {
+        return false;
+      }
+      long value = getValue(context, valueLong);
+      TDecimalStyle decimalStyle = context.getDecimalStyle();
+      String str = (value == Long.MIN_VALUE ? "9223372036854775808" : Long.toString(Math.abs(value)));
+      if (str.length() > this.maxWidth) {
+        throw new TDateTimeException("Field " + this.field + " cannot be printed as the value " + value
+            + " exceeds the maximum print width of " + this.maxWidth);
+      }
+      // str = decimalStyle.convertNumberToI18N(str);
+
+      if (value >= 0) {
+        switch (this.signStyle) {
+          case EXCEEDS_PAD:
+            if (this.minWidth < 19 && value >= EXCEED_POINTS[this.minWidth]) {
+              buf.append(decimalStyle.getPositiveSign());
+            }
+            break;
+          case ALWAYS:
+            buf.append(decimalStyle.getPositiveSign());
+            break;
+        }
+      } else {
+        switch (this.signStyle) {
+          case NORMAL:
+          case EXCEEDS_PAD:
+          case ALWAYS:
+            buf.append(decimalStyle.getNegativeSign());
+            break;
+          case NOT_NEGATIVE:
+            throw new TDateTimeException("Field " + this.field + " cannot be printed as the value " + value
+                + " cannot be negative according to the SignStyle");
+        }
+      }
+      for (int i = 0; i < this.minWidth - str.length(); i++) {
+        buf.append(decimalStyle.getZeroDigit());
+      }
+      buf.append(str);
+      return true;
+    }
+
+    long getValue(TDateTimePrintContext context, long value) {
+
+      return value;
+    }
+
+    boolean isFixedWidth(TDateTimeParseContext context) {
+
+      return this.subsequentWidth == -1
+          || (this.subsequentWidth > 0 && this.minWidth == this.maxWidth && this.signStyle == TSignStyle.NOT_NEGATIVE);
+    }
+
+    @Override
+    public int parse(TDateTimeParseContext context, CharSequence text, int position) {
+
+      int length = text.length();
+      if (position == length) {
+        return ~position;
+      }
+      char sign = text.charAt(position);
+      boolean negative = false;
+      boolean positive = false;
+      if (sign == context.getDecimalStyle().getPositiveSign()) {
+        if (this.signStyle.parse(true, context.isStrict(), this.minWidth == this.maxWidth) == false) {
+          return ~position;
+        }
+        positive = true;
+        position++;
+      } else if (sign == context.getDecimalStyle().getNegativeSign()) {
+        if (this.signStyle.parse(false, context.isStrict(), this.minWidth == this.maxWidth) == false) {
+          return ~position;
+        }
+        negative = true;
+        position++;
+      } else {
+        if (this.signStyle == TSignStyle.ALWAYS && context.isStrict()) {
+          return ~position;
+        }
+      }
+      int effMinWidth = (context.isStrict() || isFixedWidth(context) ? this.minWidth : 1);
+      int minEndPos = position + effMinWidth;
+      if (minEndPos > length) {
+        return ~position;
+      }
+      int effMaxWidth = (context.isStrict() || isFixedWidth(context) ? this.maxWidth : 9)
+          + Math.max(this.subsequentWidth, 0);
+      long total = 0;
+      BigInteger totalBig = null;
+      int pos = position;
+      for (int pass = 0; pass < 2; pass++) {
+        int maxEndPos = Math.min(pos + effMaxWidth, length);
+        while (pos < maxEndPos) {
+          char ch = text.charAt(pos++);
+          int digit = ch - '0';
+          if ((digit < 0) || (digit > 9)) {
+            pos--;
+            if (pos < minEndPos) {
+              return ~position;
+            }
+            break;
+          }
+          if ((pos - position) > 18) {
+            if (totalBig == null) {
+              totalBig = BigInteger.valueOf(total);
+            }
+            totalBig = totalBig.multiply(BigInteger.TEN).add(BigInteger.valueOf(digit));
+          } else {
+            total = total * 10 + digit;
+          }
+        }
+        if (this.subsequentWidth > 0 && pass == 0) {
+          int parseLen = pos - position;
+          effMaxWidth = Math.max(effMinWidth, parseLen - this.subsequentWidth);
+          pos = position;
+          total = 0;
+          totalBig = null;
+        } else {
+          break;
+        }
+      }
+      if (negative) {
+        if (totalBig != null) {
+          if (totalBig.equals(BigInteger.ZERO) && context.isStrict()) {
+            return ~(position - 1);
+          }
+          totalBig = totalBig.negate();
+        } else {
+          if (total == 0 && context.isStrict()) {
+            return ~(position - 1);
+          }
+          total = -total;
+        }
+      } else if (this.signStyle == TSignStyle.EXCEEDS_PAD && context.isStrict()) {
+        int parseLen = pos - position;
+        if (positive) {
+          if (parseLen <= this.minWidth) {
+            return ~(position - 1);
+          }
+        } else {
+          if (parseLen > this.minWidth) {
+            return ~position;
+          }
+        }
+      }
+      if (totalBig != null) {
+        if (totalBig.bitLength() > 63) {
+          totalBig = totalBig.divide(BigInteger.TEN);
+          pos--;
+        }
+        return setValue(context, totalBig.longValue(), position, pos);
+      }
+      return setValue(context, total, position, pos);
+    }
+
+    int setValue(TDateTimeParseContext context, long value, int errorPos, int successPos) {
+
+      return context.setParsedField(this.field, value, errorPos, successPos);
+    }
+
+    @Override
+    public String toString() {
+
+      if (this.minWidth == 1 && this.maxWidth == 19 && this.signStyle == TSignStyle.NORMAL) {
+        return "Value(" + this.field + ")";
+      }
+      if (this.minWidth == this.maxWidth && this.signStyle == TSignStyle.NOT_NEGATIVE) {
+        return "Value(" + this.field + "," + this.minWidth + ")";
+      }
+      return "Value(" + this.field + "," + this.minWidth + "," + this.maxWidth + "," + this.signStyle + ")";
+    }
+  }
+
+  static final class TReducedPrinterParser extends TNumberPrinterParser {
+
+    static final TLocalDate BASE_DATE = TLocalDate.of(2000, 1, 1);
+
+    private final int baseValue;
+
+    private final TChronoLocalDate baseDate;
+
+    TReducedPrinterParser(TTemporalField field, int minWidth, int maxWidth, int baseValue, TChronoLocalDate baseDate) {
+
+      this(field, minWidth, maxWidth, baseValue, baseDate, 0);
+      if (minWidth < 1 || minWidth > 10) {
+        throw new IllegalArgumentException("The minWidth must be from 1 to 10 inclusive but was " + minWidth);
+      }
+      if (maxWidth < 1 || maxWidth > 10) {
+        throw new IllegalArgumentException("The maxWidth must be from 1 to 10 inclusive but was " + minWidth);
+      }
+      if (maxWidth < minWidth) {
+        throw new IllegalArgumentException(
+            "Maximum width must exceed or equal the minimum width but " + maxWidth + " < " + minWidth);
+      }
+      if (baseDate == null) {
+        if (field.range().isValidValue(baseValue) == false) {
+          throw new IllegalArgumentException("The base value must be within the range of the field");
+        }
+        if (((baseValue) + EXCEED_POINTS[maxWidth]) > Integer.MAX_VALUE) {
+          throw new DateTimeException("Unable to add printer-parser as the range exceeds the capacity of an int");
+        }
+      }
+    }
+
+    private TReducedPrinterParser(TTemporalField field, int minWidth, int maxWidth, int baseValue,
+        TChronoLocalDate baseDate, int subsequentWidth) {
+
+      super(field, minWidth, maxWidth, TSignStyle.NOT_NEGATIVE, subsequentWidth);
+      this.baseValue = baseValue;
+      this.baseDate = baseDate;
+    }
+
+    @Override
+    long getValue(TDateTimePrintContext context, long value) {
+
+      long absValue = Math.abs(value);
+      int baseValue = this.baseValue;
+      if (this.baseDate != null) {
+        TChronology chrono = TChronology.from(context.getTemporal());
+        baseValue = chrono.date(this.baseDate).get(this.field);
+      }
+      if (value >= baseValue && value < baseValue + EXCEED_POINTS[this.minWidth]) {
+        return absValue % EXCEED_POINTS[this.minWidth];
+      }
+      return absValue % EXCEED_POINTS[this.maxWidth];
+    }
+
+    @Override
+    int setValue(TDateTimeParseContext context, long value, int errorPos, int successPos) {
+
+      int baseValue = this.baseValue;
+      if (this.baseDate != null) {
+        TChronology chrono = context.getEffectiveChronology();
+        baseValue = chrono.date(this.baseDate).get(this.field);
+
+        final long initialValue = value;
+        context.addChronoChangedListener((_unused) -> {
+          setValue(context, initialValue, errorPos, successPos);
+        });
+      }
+      int parseLen = successPos - errorPos;
+      if (parseLen == this.minWidth && value >= 0) {
+        long range = EXCEED_POINTS[this.minWidth];
+        long lastPart = baseValue % range;
+        long basePart = baseValue - lastPart;
+        if (baseValue > 0) {
+          value = basePart + value;
+        } else {
+          value = basePart - value;
+        }
+        if (value < baseValue) {
+          value += range;
+        }
+      }
+      return context.setParsedField(this.field, value, errorPos, successPos);
+    }
+
+    @Override
+    TReducedPrinterParser withFixedWidth() {
+
+      if (this.subsequentWidth == -1) {
+        return this;
+      }
+      return new TReducedPrinterParser(this.field, this.minWidth, this.maxWidth, this.baseValue, this.baseDate, -1);
+    }
+
+    @Override
+    TReducedPrinterParser withSubsequentWidth(int subsequentWidth) {
+
+      return new TReducedPrinterParser(this.field, this.minWidth, this.maxWidth, this.baseValue, this.baseDate,
+          this.subsequentWidth + subsequentWidth);
+    }
+
+    @Override
+    boolean isFixedWidth(TDateTimeParseContext context) {
+
+      if (context.isStrict() == false) {
+        return false;
+      }
+      return super.isFixedWidth(context);
+    }
+
+    @Override
+    public String toString() {
+
+      return "ReducedValue(" + this.field + "," + this.minWidth + "," + this.maxWidth + ","
+          + Objects.requireNonNullElse(this.baseDate, this.baseValue) + ")";
+    }
+  }
+
+  static final class TFractionPrinterParser extends TNumberPrinterParser {
+    private final boolean decimalPoint;
+
+    TFractionPrinterParser(TTemporalField field, int minWidth, int maxWidth, boolean decimalPoint) {
+
+      this(field, minWidth, maxWidth, decimalPoint, 0);
+      TObjects.requireNonNull(field, "field");
+      if (field.range().isFixed() == false) {
+        throw new IllegalArgumentException("Field must have a fixed set of values: " + field);
+      }
+      if (minWidth < 0 || minWidth > 9) {
+        throw new IllegalArgumentException("Minimum width must be from 0 to 9 inclusive but was " + minWidth);
+      }
+      if (maxWidth < 1 || maxWidth > 9) {
+        throw new IllegalArgumentException("Maximum width must be from 1 to 9 inclusive but was " + maxWidth);
+      }
+      if (maxWidth < minWidth) {
+        throw new IllegalArgumentException(
+            "Maximum width must exceed or equal the minimum width but " + maxWidth + " < " + minWidth);
+      }
+    }
+
+    TFractionPrinterParser(TTemporalField field, int minWidth, int maxWidth, boolean decimalPoint, int subsequentWidth) {
+
+      super(field, minWidth, maxWidth, TSignStyle.NOT_NEGATIVE, subsequentWidth);
+      this.decimalPoint = decimalPoint;
+    }
+
+    @Override
+    TFractionPrinterParser withFixedWidth() {
+
+      if (this.subsequentWidth == -1) {
+        return this;
+      }
+      return new TFractionPrinterParser(this.field, this.minWidth, this.maxWidth, this.decimalPoint, -1);
+    }
+
+    @Override
+    TFractionPrinterParser withSubsequentWidth(int subsequentWidth) {
+
+      return new TFractionPrinterParser(this.field, this.minWidth, this.maxWidth, this.decimalPoint,
+          this.subsequentWidth + subsequentWidth);
+    }
+
+    @Override
+    boolean isFixedWidth(TDateTimeParseContext context) {
+
+      if (context.isStrict() && this.minWidth == this.maxWidth && this.decimalPoint == false) {
+        return true;
+      }
+      return false;
+    }
+
+    @Override
+    public boolean format(TDateTimePrintContext context, StringBuilder buf) {
+
+      Long value = context.getValue(this.field);
+      if (value == null) {
+        return false;
+      }
+      TDecimalStyle decimalStyle = context.getDecimalStyle();
+      BigDecimal fraction = convertToFraction(value);
+      if (fraction.scale() == 0) {
+        if (this.minWidth > 0) {
+          if (this.decimalPoint) {
+            buf.append(decimalStyle.getDecimalSeparator());
+          }
+          for (int i = 0; i < this.minWidth; i++) {
+            buf.append(decimalStyle.getZeroDigit());
+          }
+        }
+      } else {
+        int outputScale = Math.min(Math.max(fraction.scale(), this.minWidth), this.maxWidth);
+        fraction = fraction.setScale(outputScale, RoundingMode.FLOOR);
+        String str = fraction.toPlainString().substring(2);
+        str = decimalStyle.convertNumberToI18N(str);
+        if (this.decimalPoint) {
+          buf.append(decimalStyle.getDecimalSeparator());
+        }
+        buf.append(str);
+      }
+      return true;
+    }
+
+    @Override
+    public int parse(TDateTimeParseContext context, CharSequence text, int position) {
+
+      int effectiveMin = (context.isStrict() || isFixedWidth(context) ? this.minWidth : 0);
+      int effectiveMax = (context.isStrict() || isFixedWidth(context) ? this.maxWidth : 9);
+      int length = text.length();
+      if (position == length) {
+        return (effectiveMin > 0 ? ~position : position);
+      }
+      if (this.decimalPoint) {
+        if (text.charAt(position) != context.getDecimalStyle().getDecimalSeparator()) {
+          return (effectiveMin > 0 ? ~position : position);
+        }
+        position++;
+      }
+      int minEndPos = position + effectiveMin;
+      if (minEndPos > length) {
+        return ~position;
+      }
+      int maxEndPos = Math.min(position + effectiveMax, length);
+      int total = 0;
+      int pos = position;
+      while (pos < maxEndPos) {
+        char ch = text.charAt(pos++);
+        int digit = ch - '0';
+        if ((digit < 0) || (digit > 9)) {
+          if (pos < minEndPos) {
+            return ~position;
+          }
+          pos--;
+          break;
+        }
+        total = total * 10 + digit;
+      }
+      BigDecimal fraction = new BigDecimal(total).movePointLeft(pos - position);
+      long value = convertFromFraction(fraction);
+      return context.setParsedField(this.field, value, position, pos);
+    }
+
+    private BigDecimal convertToFraction(long value) {
+
+      TValueRange range = this.field.range();
+      range.checkValidValue(value, this.field);
+      BigDecimal minBD = BigDecimal.valueOf(range.getMinimum());
+      BigDecimal rangeBD = BigDecimal.valueOf(range.getMaximum()).subtract(minBD).add(BigDecimal.ONE);
+      BigDecimal valueBD = BigDecimal.valueOf(value).subtract(minBD);
+      BigDecimal fraction = valueBD.divide(rangeBD, 9, RoundingMode.FLOOR);
+      return fraction.compareTo(BigDecimal.ZERO) == 0 ? BigDecimal.ZERO : fraction.stripTrailingZeros();
+    }
+
+    private long convertFromFraction(BigDecimal fraction) {
+
+      TValueRange range = this.field.range();
+      BigDecimal minBD = BigDecimal.valueOf(range.getMinimum());
+      BigDecimal rangeBD = BigDecimal.valueOf(range.getMaximum()).subtract(minBD).add(BigDecimal.ONE);
+      BigDecimal valueBD = fraction.multiply(rangeBD).setScale(0, RoundingMode.FLOOR).add(minBD);
+      return valueBD.longValueExact();
+    }
+
+    @Override
+    public String toString() {
+
+      String decimal = (this.decimalPoint ? ",DecimalPoint" : "");
+      return "Fraction(" + this.field + "," + this.minWidth + "," + this.maxWidth + decimal + ")";
+    }
+  }
+
+  static final class TTextPrinterParser implements TDateTimePrinterParser {
+
+    private final TTemporalField field;
+
+    private final TTextStyle textStyle;
+
+    private volatile TNumberPrinterParser numberPrinterParser;
+
+    TTextPrinterParser(TTemporalField field, TTextStyle textStyle) {
+
+      this.field = field;
+      this.textStyle = textStyle;
+    }
+
+    @Override
+    public boolean format(TDateTimePrintContext context, StringBuilder buf) {
+
+      Long value = context.getValue(this.field);
+      if (value == null) {
+        return false;
+      }
+      String text;
+      text = this.field.getDisplayName(context.getLocale());
+      if (text == null) {
+        return numberPrinterParser().format(context, buf);
+      }
+      buf.append(text);
+      return true;
+    }
+
+    @Override
+    public int parse(TDateTimeParseContext context, CharSequence parseText, int position) {
+
+      int length = parseText.length();
+      if (position < 0 || position > length) {
+        throw new IndexOutOfBoundsException();
+      }
+      TTextStyle style = (context.isStrict() ? this.textStyle : null);
+      // Iterator<Entry<String, Long>> it;
+      // it = this.provider.getTextIterator(this.field, style, context.getLocale());
+      // if (it != null) {
+      // while (it.hasNext()) {
+      // Entry<String, Long> entry = it.next();
+      // String itText = entry.getKey();
+      // if (context.subSequenceEquals(itText, 0, parseText, position, itText.length())) {
+      // return context.setParsedField(this.field, entry.getValue(), position, position + itText.length());
+      // }
+      // }
+      // if (this.field == ERA && !context.isStrict()) {
+      // for (TEra era : TIsoEra.values()) {
+      // String name = era.toString();
+      // if (context.subSequenceEquals(name, 0, parseText, position, name.length())) {
+      // return context.setParsedField(this.field, era.getValue(), position, position + name.length());
+      // }
+      // }
+      // }
+      // if (context.isStrict()) {
+      // return ~position;
+      // }
+      // }
+      return numberPrinterParser().parse(context, parseText, position);
+    }
+
+    private TNumberPrinterParser numberPrinterParser() {
+
+      if (this.numberPrinterParser == null) {
+        this.numberPrinterParser = new TNumberPrinterParser(this.field, 1, 19, TSignStyle.NORMAL);
+      }
+      return this.numberPrinterParser;
+    }
+
+    @Override
+    public String toString() {
+
+      if (this.textStyle == TTextStyle.FULL) {
+        return "Text(" + this.field + ")";
+      }
+      return "Text(" + this.field + "," + this.textStyle + ")";
+    }
+  }
+
+  static final class TInstantPrinterParser implements TDateTimePrinterParser {
+
+    private static final long SECONDS_PER_10000_YEARS = 146097L * 25L * 86400L;
+
+    private static final long SECONDS_0000_TO_1970 = ((146097L * 5L) - (30L * 365L + 7L)) * 86400L;
+
+    private final int fractionalDigits;
+
+    TInstantPrinterParser(int fractionalDigits) {
+
+      this.fractionalDigits = fractionalDigits;
+    }
+
+    @Override
+    public boolean format(TDateTimePrintContext context, StringBuilder buf) {
+
+      Long inSecs = context.getValue(INSTANT_SECONDS);
+      Long inNanos = null;
+      if (context.getTemporal().isSupported(NANO_OF_SECOND)) {
+        inNanos = context.getTemporal().getLong(NANO_OF_SECOND);
+      }
+      if (inSecs == null) {
+        return false;
+      }
+      long inSec = inSecs;
+      int inNano = NANO_OF_SECOND.checkValidIntValue(inNanos != null ? inNanos : 0);
+      if (inSec >= -SECONDS_0000_TO_1970) {
+        long zeroSecs = inSec - SECONDS_PER_10000_YEARS + SECONDS_0000_TO_1970;
+        long hi = Math.floorDiv(zeroSecs, SECONDS_PER_10000_YEARS) + 1;
+        long lo = Math.floorMod(zeroSecs, SECONDS_PER_10000_YEARS);
+        TLocalDateTime ldt = TLocalDateTime.ofEpochSecond(lo - SECONDS_0000_TO_1970, 0, TZoneOffset.UTC);
+        if (hi > 0) {
+          buf.append('+').append(hi);
+        }
+        buf.append(ldt);
+        if (ldt.getSecond() == 0) {
+          buf.append(":00");
+        }
+      } else {
+        long zeroSecs = inSec + SECONDS_0000_TO_1970;
+        long hi = zeroSecs / SECONDS_PER_10000_YEARS;
+        long lo = zeroSecs % SECONDS_PER_10000_YEARS;
+        TLocalDateTime ldt = TLocalDateTime.ofEpochSecond(lo - SECONDS_0000_TO_1970, 0, TZoneOffset.UTC);
+        int pos = buf.length();
+        buf.append(ldt);
+        if (ldt.getSecond() == 0) {
+          buf.append(":00");
+        }
+        if (hi < 0) {
+          if (ldt.getYear() == -10_000) {
+            buf.replace(pos, pos + 2, Long.toString(hi - 1));
+          } else if (lo == 0) {
+            buf.insert(pos, hi);
+          } else {
+            buf.insert(pos + 1, Math.abs(hi));
+          }
+        }
+      }
+      if ((this.fractionalDigits < 0 && inNano > 0) || this.fractionalDigits > 0) {
+        buf.append('.');
+        int div = 100_000_000;
+        for (int i = 0; ((this.fractionalDigits == -1 && inNano > 0)
+            || (this.fractionalDigits == -2 && (inNano > 0 || (i % 3) != 0)) || i < this.fractionalDigits); i++) {
+          int digit = inNano / div;
+          buf.append((char) (digit + '0'));
+          inNano = inNano - (digit * div);
+          div = div / 10;
+        }
+      }
+      buf.append('Z');
+      return true;
+    }
+
+    @Override
+    public int parse(TDateTimeParseContext context, CharSequence text, int position) {
+
+      int minDigits = (this.fractionalDigits < 0 ? 0 : this.fractionalDigits);
+      int maxDigits = (this.fractionalDigits < 0 ? 9 : this.fractionalDigits);
+      TCompositePrinterParser parser = new TDateTimeFormatterBuilder().append(TDateTimeFormatter.ISO_LOCAL_DATE)
+          .appendLiteral('T').appendValue(HOUR_OF_DAY, 2).appendLiteral(':').appendValue(MINUTE_OF_HOUR, 2)
+          .appendLiteral(':').appendValue(SECOND_OF_MINUTE, 2)
+          .appendFraction(NANO_OF_SECOND, minDigits, maxDigits, true).appendLiteral('Z').toFormatter()
+          .toPrinterParser(false);
+      TDateTimeParseContext newContext = context.copy();
+      int pos = parser.parse(newContext, text, position);
+      if (pos < 0) {
+        return pos;
+      }
+      // parser restricts most fields to 2 digits, so definitely int
+      // correctly parsed nano is also guaranteed to be valid
+      long yearParsed = newContext.getParsed(YEAR);
+      int month = newContext.getParsed(MONTH_OF_YEAR).intValue();
+      int day = newContext.getParsed(DAY_OF_MONTH).intValue();
+      int hour = newContext.getParsed(HOUR_OF_DAY).intValue();
+      int min = newContext.getParsed(MINUTE_OF_HOUR).intValue();
+      Long secVal = newContext.getParsed(SECOND_OF_MINUTE);
+      Long nanoVal = newContext.getParsed(NANO_OF_SECOND);
+      int sec = (secVal != null ? secVal.intValue() : 0);
+      int nano = (nanoVal != null ? nanoVal.intValue() : 0);
+      int days = 0;
+      if (hour == 24 && min == 0 && sec == 0 && nano == 0) {
+        hour = 0;
+        days = 1;
+      } else if (hour == 23 && min == 59 && sec == 60) {
+        context.setParsedLeapSecond();
+        sec = 59;
+      }
+      int year = (int) yearParsed % 10_000;
+      long instantSecs;
+      try {
+        TLocalDateTime ldt = TLocalDateTime.of(year, month, day, hour, min, sec, 0).plusDays(days);
+        instantSecs = ldt.toEpochSecond(TZoneOffset.UTC);
+        instantSecs += Math.multiplyExact(yearParsed / 10_000L, SECONDS_PER_10000_YEARS);
+      } catch (RuntimeException ex) {
+        return ~position;
+      }
+      int successPos = pos;
+      successPos = context.setParsedField(INSTANT_SECONDS, instantSecs, position, successPos);
+      return context.setParsedField(NANO_OF_SECOND, nano, position, successPos);
+    }
+
+    @Override
+    public String toString() {
+
+      return "Instant()";
+    }
+  }
+
+  static final class TOffsetIdPrinterParser implements TDateTimePrinterParser {
+
+    static final String[] PATTERNS = new String[] { "+HH", "+HHmm", "+HH:mm", "+HHMM", "+HH:MM", "+HHMMss", "+HH:MM:ss",
+    "+HHMMSS", "+HH:MM:SS", "+HHmmss", "+HH:mm:ss", "+H", "+Hmm", "+H:mm", "+HMM", "+H:MM", "+HMMss", "+H:MM:ss",
+    "+HMMSS", "+H:MM:SS", "+Hmmss", "+H:mm:ss", };
+
+    static final TOffsetIdPrinterParser INSTANCE_ID_Z = new TOffsetIdPrinterParser("+HH:MM:ss", "Z");
+
+    static final TOffsetIdPrinterParser INSTANCE_ID_ZERO = new TOffsetIdPrinterParser("+HH:MM:ss", "0");
+
+    private final String noOffsetText;
+
+    private final int type;
+
+    private final int style;
+
+    TOffsetIdPrinterParser(String pattern, String noOffsetText) {
+
+      Objects.requireNonNull(pattern, "pattern");
+      Objects.requireNonNull(noOffsetText, "noOffsetText");
+      this.type = checkPattern(pattern);
+      this.style = this.type % 11;
+      this.noOffsetText = noOffsetText;
+    }
+
+    private int checkPattern(String pattern) {
+
+      for (int i = 0; i < PATTERNS.length; i++) {
+        if (PATTERNS[i].equals(pattern)) {
+          return i;
+        }
+      }
+      throw new IllegalArgumentException("Invalid zone offset pattern: " + pattern);
+    }
+
+    private boolean isPaddedHour() {
+
+      return this.type < 11;
+    }
+
+    private boolean isColon() {
+
+      return this.style > 0 && (this.style % 2) == 0;
+    }
+
+    @Override
+    public boolean format(TDateTimePrintContext context, StringBuilder buf) {
+
+      Long offsetSecs = context.getValue(OFFSET_SECONDS);
+      if (offsetSecs == null) {
+        return false;
+      }
+      int totalSecs = Math.toIntExact(offsetSecs);
+      if (totalSecs == 0) {
+        buf.append(this.noOffsetText);
+      } else {
+        int absHours = Math.abs((totalSecs / 3600) % 100);
+        int absMinutes = Math.abs((totalSecs / 60) % 60);
+        int absSeconds = Math.abs(totalSecs % 60);
+        int bufPos = buf.length();
+        int output = absHours;
+        buf.append(totalSecs < 0 ? "-" : "+");
+        if (isPaddedHour() || absHours >= 10) {
+          formatZeroPad(false, absHours, buf);
+        } else {
+          buf.append((char) (absHours + '0'));
+        }
+        if ((this.style >= 3 && this.style <= 8) || (this.style >= 9 && absSeconds > 0)
+            || (this.style >= 1 && absMinutes > 0)) {
+          formatZeroPad(isColon(), absMinutes, buf);
+          output += absMinutes;
+          if (this.style == 7 || this.style == 8 || (this.style >= 5 && absSeconds > 0)) {
+            formatZeroPad(isColon(), absSeconds, buf);
+            output += absSeconds;
+          }
+        }
+        if (output == 0) {
+          buf.setLength(bufPos);
+          buf.append(this.noOffsetText);
+        }
+      }
+      return true;
+    }
+
+    private void formatZeroPad(boolean colon, int value, StringBuilder buf) {
+
+      buf.append(colon ? ":" : "").append((char) (value / 10 + '0')).append((char) (value % 10 + '0'));
+    }
+
+    @Override
+    public int parse(TDateTimeParseContext context, CharSequence text, int position) {
+
+      int length = text.length();
+      int noOffsetLen = this.noOffsetText.length();
+      if (noOffsetLen == 0) {
+        if (position == length) {
+          return context.setParsedField(OFFSET_SECONDS, 0, position, position);
+        }
+      } else {
+        if (position == length) {
+          return ~position;
+        }
+        if (context.subSequenceEquals(text, position, this.noOffsetText, 0, noOffsetLen)) {
+          return context.setParsedField(OFFSET_SECONDS, 0, position, position + noOffsetLen);
+        }
+      }
+
+      char sign = text.charAt(position);
+      if (sign == '+' || sign == '-') {
+        int negative = (sign == '-' ? -1 : 1);
+        boolean isColon = isColon();
+        boolean paddedHour = isPaddedHour();
+        int[] array = new int[4];
+        array[0] = position + 1;
+        int parseType = this.type;
+        if (!context.isStrict()) {
+          if (paddedHour) {
+            if (isColon || (parseType == 0 && length > position + 3 && text.charAt(position + 3) == ':')) {
+              isColon = true;
+              parseType = 10;
+            } else {
+              parseType = 9;
+            }
+          } else {
+            if (isColon || (parseType == 11 && length > position + 3
+                && (text.charAt(position + 2) == ':' || text.charAt(position + 3) == ':'))) {
+              isColon = true;
+              parseType = 21;
+            } else {
+              parseType = 20;
+            }
+          }
+        }
+        switch (parseType) {
+          case 0:
+          case 11:
+            parseHour(text, paddedHour, array);
+            break;
+          case 1:
+          case 2:
+          case 13:
+            parseHour(text, paddedHour, array);
+            parseMinute(text, isColon, false, array);
+            break;
+          case 3:
+          case 4:
+          case 15:
+            parseHour(text, paddedHour, array);
+            parseMinute(text, isColon, true, array);
+            break;
+          case 5:
+          case 6:
+          case 17:
+            parseHour(text, paddedHour, array);
+            parseMinute(text, isColon, true, array);
+            parseSecond(text, isColon, false, array);
+            break;
+          case 7:
+          case 8:
+          case 19:
+            parseHour(text, paddedHour, array);
+            parseMinute(text, isColon, true, array);
+            parseSecond(text, isColon, true, array);
+            break;
+          case 9:
+          case 10:
+          case 21:
+            parseHour(text, paddedHour, array);
+            parseOptionalMinuteSecond(text, isColon, array);
+            break;
+          case 12:
+            parseVariableWidthDigits(text, 1, 4, array);
+            break;
+          case 14:
+            parseVariableWidthDigits(text, 3, 4, array);
+            break;
+          case 16:
+            parseVariableWidthDigits(text, 3, 6, array);
+            break;
+          case 18:
+            parseVariableWidthDigits(text, 5, 6, array);
+            break;
+          case 20:
+            parseVariableWidthDigits(text, 1, 6, array);
+            break;
+        }
+        if (array[0] > 0) {
+          if (array[1] > 23 || array[2] > 59 || array[3] > 59) {
+            throw new DateTimeException("Value out of range: Hour[0-23], Minute[0-59], Second[0-59]");
+          }
+          long offsetSecs = negative * (array[1] * 3600L + array[2] * 60L + array[3]);
+          return context.setParsedField(OFFSET_SECONDS, offsetSecs, position, array[0]);
+        }
+      }
+      if (noOffsetLen == 0) {
+        return context.setParsedField(OFFSET_SECONDS, 0, position, position);
+      }
+      return ~position;
+    }
+
+    private void parseHour(CharSequence parseText, boolean paddedHour, int[] array) {
+
+      if (paddedHour) {
+        if (!parseDigits(parseText, false, 1, array)) {
+          array[0] = ~array[0];
+        }
+      } else {
+        parseVariableWidthDigits(parseText, 1, 2, array);
+      }
+    }
+
+    private void parseMinute(CharSequence parseText, boolean isColon, boolean mandatory, int[] array) {
+
+      if (!parseDigits(parseText, isColon, 2, array)) {
+        if (mandatory) {
+          array[0] = ~array[0];
+        }
+      }
+    }
+
+    private void parseSecond(CharSequence parseText, boolean isColon, boolean mandatory, int[] array) {
+
+      if (!parseDigits(parseText, isColon, 3, array)) {
+        if (mandatory) {
+          array[0] = ~array[0];
+        }
+      }
+    }
+
+    private void parseOptionalMinuteSecond(CharSequence parseText, boolean isColon, int[] array) {
+
+      if (parseDigits(parseText, isColon, 2, array)) {
+        parseDigits(parseText, isColon, 3, array);
+      }
+    }
+
+    private boolean parseDigits(CharSequence parseText, boolean isColon, int arrayIndex, int[] array) {
+
+      int pos = array[0];
+      if (pos < 0) {
+        return true;
+      }
+      if (isColon && arrayIndex != 1) {
+        if (pos + 1 > parseText.length() || parseText.charAt(pos) != ':') {
+          return false;
+        }
+        pos++;
+      }
+      if (pos + 2 > parseText.length()) {
+        return false;
+      }
+      char ch1 = parseText.charAt(pos++);
+      char ch2 = parseText.charAt(pos++);
+      if (ch1 < '0' || ch1 > '9' || ch2 < '0' || ch2 > '9') {
+        return false;
+      }
+      int value = (ch1 - 48) * 10 + (ch2 - 48);
+      if (value < 0 || value > 59) {
+        return false;
+      }
+      array[arrayIndex] = value;
+      array[0] = pos;
+      return true;
+    }
+
+    private void parseVariableWidthDigits(CharSequence parseText, int minDigits, int maxDigits, int[] array) {
+
+      int pos = array[0];
+      int available = 0;
+      char[] chars = new char[maxDigits];
+      for (int i = 0; i < maxDigits; i++) {
+        if (pos + 1 > parseText.length()) {
+          break;
+        }
+        char ch = parseText.charAt(pos++);
+        if (ch < '0' || ch > '9') {
+          pos--;
+          break;
+        }
+        chars[i] = ch;
+        available++;
+      }
+      if (available < minDigits) {
+        array[0] = ~array[0];
+        return;
+      }
+      switch (available) {
+        case 1:
+          array[1] = (chars[0] - 48);
+          break;
+        case 2:
+          array[1] = ((chars[0] - 48) * 10 + (chars[1] - 48));
+          break;
+        case 3:
+          array[1] = (chars[0] - 48);
+          array[2] = ((chars[1] - 48) * 10 + (chars[2] - 48));
+          break;
+        case 4:
+          array[1] = ((chars[0] - 48) * 10 + (chars[1] - 48));
+          array[2] = ((chars[2] - 48) * 10 + (chars[3] - 48));
+          break;
+        case 5:
+          array[1] = (chars[0] - 48);
+          array[2] = ((chars[1] - 48) * 10 + (chars[2] - 48));
+          array[3] = ((chars[3] - 48) * 10 + (chars[4] - 48));
+          break;
+        case 6:
+          array[1] = ((chars[0] - 48) * 10 + (chars[1] - 48));
+          array[2] = ((chars[2] - 48) * 10 + (chars[3] - 48));
+          array[3] = ((chars[4] - 48) * 10 + (chars[5] - 48));
+          break;
+      }
+      array[0] = pos;
+    }
+
+    @Override
+    public String toString() {
+
+      String converted = this.noOffsetText.replace("'", "''");
+      return "Offset(" + PATTERNS[this.type] + ",'" + converted + "')";
+    }
+  }
+
+  static final class TLocalizedOffsetIdPrinterParser implements TDateTimePrinterParser {
+    private final TTextStyle style;
+
+    TLocalizedOffsetIdPrinterParser(TTextStyle style) {
+
+      this.style = style;
+    }
+
+    private static StringBuilder appendHMS(StringBuilder buf, int t) {
+
+      return buf.append((char) (t / 10 + '0')).append((char) (t % 10 + '0'));
+    }
+
+    @Override
+    public boolean format(TDateTimePrintContext context, StringBuilder buf) {
+
+      Long offsetSecs = context.getValue(OFFSET_SECONDS);
+      if (offsetSecs == null) {
+        return false;
+      }
+      String gmtText = "GMT";
+      buf.append(gmtText);
+      int totalSecs = Math.toIntExact(offsetSecs);
+      if (totalSecs != 0) {
+        int absHours = Math.abs((totalSecs / 3600) % 100);
+        int absMinutes = Math.abs((totalSecs / 60) % 60);
+        int absSeconds = Math.abs(totalSecs % 60);
+        buf.append(totalSecs < 0 ? "-" : "+");
+        if (this.style == TTextStyle.FULL) {
+          appendHMS(buf, absHours);
+          buf.append(':');
+          appendHMS(buf, absMinutes);
+          if (absSeconds != 0) {
+            buf.append(':');
+            appendHMS(buf, absSeconds);
+          }
+        } else {
+          if (absHours >= 10) {
+            buf.append((char) (absHours / 10 + '0'));
+          }
+          buf.append((char) (absHours % 10 + '0'));
+          if (absMinutes != 0 || absSeconds != 0) {
+            buf.append(':');
+            appendHMS(buf, absMinutes);
+            if (absSeconds != 0) {
+              buf.append(':');
+              appendHMS(buf, absSeconds);
+            }
+          }
+        }
+      }
+      return true;
+    }
+
+    int getDigit(CharSequence text, int position) {
+
+      char c = text.charAt(position);
+      if (c < '0' || c > '9') {
+        return -1;
+      }
+      return c - '0';
+    }
+
+    @Override
+    public int parse(TDateTimeParseContext context, CharSequence text, int position) {
+
+      int pos = position;
+      int end = text.length();
+      String gmtText = "GMT";
+      if (!context.subSequenceEquals(text, pos, gmtText, 0, gmtText.length())) {
+        return ~position;
+      }
+      pos += gmtText.length();
+      int negative = 0;
+      if (pos == end) {
+        return context.setParsedField(OFFSET_SECONDS, 0, position, pos);
+      }
+      char sign = text.charAt(pos);
+      if (sign == '+') {
+        negative = 1;
+      } else if (sign == '-') {
+        negative = -1;
+      } else {
+        return context.setParsedField(OFFSET_SECONDS, 0, position, pos);
+      }
+      pos++;
+      int h = 0;
+      int m = 0;
+      int s = 0;
+      if (this.style == TTextStyle.FULL) {
+        int h1 = getDigit(text, pos++);
+        int h2 = getDigit(text, pos++);
+        if (h1 < 0 || h2 < 0 || text.charAt(pos++) != ':') {
+          return ~position;
+        }
+        h = h1 * 10 + h2;
+        int m1 = getDigit(text, pos++);
+        int m2 = getDigit(text, pos++);
+        if (m1 < 0 || m2 < 0) {
+          return ~position;
+        }
+        m = m1 * 10 + m2;
+        if (pos + 2 < end && text.charAt(pos) == ':') {
+          int s1 = getDigit(text, pos + 1);
+          int s2 = getDigit(text, pos + 2);
+          if (s1 >= 0 && s2 >= 0) {
+            s = s1 * 10 + s2;
+            pos += 3;
+          }
+        }
+      } else {
+        h = getDigit(text, pos++);
+        if (h < 0) {
+          return ~position;
+        }
+        if (pos < end) {
+          int h2 = getDigit(text, pos);
+          if (h2 >= 0) {
+            h = h * 10 + h2;
+            pos++;
+          }
+          if (pos + 2 < end && text.charAt(pos) == ':') {
+            if (pos + 2 < end && text.charAt(pos) == ':') {
+              int m1 = getDigit(text, pos + 1);
+              int m2 = getDigit(text, pos + 2);
+              if (m1 >= 0 && m2 >= 0) {
+                m = m1 * 10 + m2;
+                pos += 3;
+                if (pos + 2 < end && text.charAt(pos) == ':') {
+                  int s1 = getDigit(text, pos + 1);
+                  int s2 = getDigit(text, pos + 2);
+                  if (s1 >= 0 && s2 >= 0) {
+                    s = s1 * 10 + s2;
+                    pos += 3;
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+      long offsetSecs = negative * (h * 3600L + m * 60L + s);
+      return context.setParsedField(OFFSET_SECONDS, offsetSecs, position, pos);
+    }
+
+    @Override
+    public String toString() {
+
+      return "LocalizedOffset(" + this.style + ")";
+    }
+  }
+
+  static final class TZoneTextPrinterParser extends TZoneIdPrinterParser {
+
+    private final TTextStyle textStyle;
+
+    private final boolean isGeneric;
+
+    TZoneTextPrinterParser(TTextStyle textStyle, boolean isGeneric) {
+
+      super(TTemporalQueries.zone(), "ZoneText(" + textStyle + ")");
+      this.textStyle = TObjects.requireNonNull(textStyle, "textStyle");
+      this.isGeneric = isGeneric;
+    }
+
+    private static final int STD = 0;
+
+    private static final int DST = 1;
+
+    private static final int GENERIC = 2;
+
+    private String getDisplayName(String id, int type, TLocale locale) {
+
+      if (this.textStyle == TTextStyle.NARROW) {
+        return null;
+      }
+      // TODO use i18n
+      return id;
+    }
+
+    @Override
+    public boolean format(TDateTimePrintContext context, StringBuilder buf) {
+
+      TZoneId zone = context.getValue(TTemporalQueries.zoneId());
+      if (zone == null) {
+        return false;
+      }
+      String zname = zone.getId();
+      if (!(zone instanceof TZoneOffset)) {
+        TTemporalAccessor dt = context.getTemporal();
+        int type = GENERIC;
+        if (!this.isGeneric) {
+          if (dt.isSupported(TChronoField.INSTANT_SECONDS)) {
+            type = zone.getRules().isDaylightSavings(TInstant.from(dt)) ? DST : STD;
+          } else if (dt.isSupported(TChronoField.EPOCH_DAY) && dt.isSupported(TChronoField.NANO_OF_DAY)) {
+            TLocalDate date = TLocalDate.ofEpochDay(dt.getLong(TChronoField.EPOCH_DAY));
+            TLocalTime time = TLocalTime.ofNanoOfDay(dt.getLong(TChronoField.NANO_OF_DAY));
+            TLocalDateTime ldt = date.atTime(time);
+            if (zone.getRules().getTransition(ldt) == null) {
+              type = zone.getRules().isDaylightSavings(ldt.atZone(zone).toInstant()) ? DST : STD;
+            }
+          }
+        }
+        String name = getDisplayName(zname, type, context.getLocale());
+        if (name != null) {
+          zname = name;
+        }
+      }
+      buf.append(zname);
+      return true;
+    }
+
+  }
+
+  static class TZoneIdPrinterParser implements TDateTimePrinterParser {
+    private final TTemporalQuery<TZoneId> query;
+
+    private final String description;
+
+    TZoneIdPrinterParser(TTemporalQuery<TZoneId> query, String description) {
+
+      this.query = query;
+      this.description = description;
+    }
+
+    @Override
+    public boolean format(TDateTimePrintContext context, StringBuilder buf) {
+
+      TZoneId zone = context.getValue(this.query);
+      if (zone == null) {
+        return false;
+      }
+      buf.append(zone.getId());
+      return true;
+    }
+
+    @Override
+    public int parse(TDateTimeParseContext context, CharSequence text, int position) {
+
+      int length = text.length();
+      if (position > length) {
+        throw new IndexOutOfBoundsException();
+      }
+      if (position == length) {
+        return ~position;
+      }
+
+      char nextChar = text.charAt(position);
+      if (nextChar == '+' || nextChar == '-') {
+        return parseOffsetBased(context, text, position, position, TOffsetIdPrinterParser.INSTANCE_ID_Z);
+      } else if (length >= position + 2) {
+        char nextNextChar = text.charAt(position + 1);
+        if (context.charEquals(nextChar, 'U') && context.charEquals(nextNextChar, 'T')) {
+          if (length >= position + 3 && context.charEquals(text.charAt(position + 2), 'C')) {
+            return parseOffsetBased(context, text, position, position + 3, TOffsetIdPrinterParser.INSTANCE_ID_ZERO);
+          }
+          return parseOffsetBased(context, text, position, position + 2, TOffsetIdPrinterParser.INSTANCE_ID_ZERO);
+        } else if (context.charEquals(nextChar, 'G') && length >= position + 3 && context.charEquals(nextNextChar, 'M')
+            && context.charEquals(text.charAt(position + 2), 'T')) {
+          if (length >= position + 4 && context.charEquals(text.charAt(position + 3), '0')) {
+            context.setParsed(TZoneId.of("GMT0"));
+            return position + 4;
+          }
+          return parseOffsetBased(context, text, position, position + 3, TOffsetIdPrinterParser.INSTANCE_ID_ZERO);
+        }
+      }
+
+      ParsePosition ppos = new ParsePosition(position);
+      String parsedZoneId = null; // tree.match(text, ppos);
+      if (parsedZoneId == null) {
+        if (context.charEquals(nextChar, 'Z')) {
+          context.setParsed(TZoneOffset.UTC);
+          return position + 1;
+        }
+        return ~position;
+      }
+      context.setParsed(TZoneId.of(parsedZoneId));
+      return ppos.getIndex();
+    }
+
+    private int parseOffsetBased(TDateTimeParseContext context, CharSequence text, int prefixPos, int position,
+        TOffsetIdPrinterParser parser) {
+
+      String prefix = text.subSequence(prefixPos, position).toString().toUpperCase();
+      if (position >= text.length()) {
+        context.setParsed(TZoneId.of(prefix));
+        return position;
+      }
+
+      // '0' or 'Z' after prefix is not part of a valid ZoneId; use bare prefix
+      if (text.charAt(position) == '0' || context.charEquals(text.charAt(position), 'Z')) {
+        context.setParsed(TZoneId.of(prefix));
+        return position;
+      }
+
+      TDateTimeParseContext newContext = context.copy();
+      int endPos = parser.parse(newContext, text, position);
+      try {
+        if (endPos < 0) {
+          if (parser == TOffsetIdPrinterParser.INSTANCE_ID_Z) {
+            return ~prefixPos;
+          }
+          context.setParsed(TZoneId.of(prefix));
+          return position;
+        }
+        int offset = (int) newContext.getParsed(OFFSET_SECONDS).longValue();
+        TZoneOffset zoneOffset = TZoneOffset.ofTotalSeconds(offset);
+        context.setParsed(TZoneId.ofOffset(prefix, zoneOffset));
+        return endPos;
+      } catch (TDateTimeException dte) {
+        return ~prefixPos;
+      }
+    }
+
+    @Override
+    public String toString() {
+
+      return this.description;
+    }
+  }
+
+  static final class TChronoPrinterParser implements TDateTimePrinterParser {
+    private final TTextStyle textStyle;
+
+    TChronoPrinterParser(TTextStyle textStyle) {
+
+      this.textStyle = textStyle;
+    }
+
+    @Override
+    public boolean format(TDateTimePrintContext context, StringBuilder buf) {
+
+      TChronology chrono = context.getValue(TTemporalQueries.chronology());
+      if (chrono == null) {
+        return false;
+      }
+      if (this.textStyle == null) {
+        buf.append(chrono.getId());
+      } else {
+        buf.append(getChronologyName(chrono, context.getLocale()));
+      }
+      return true;
+    }
+
+    @Override
+    public int parse(TDateTimeParseContext context, CharSequence text, int position) {
+
+      if (position < 0 || position > text.length()) {
+        throw new IndexOutOfBoundsException();
+      }
+      Set<TChronology> chronos = TChronology.getAvailableChronologies();
+      TChronology bestMatch = null;
+      int matchLen = -1;
+      for (TChronology chrono : chronos) {
+        String name;
+        if (this.textStyle == null) {
+          name = chrono.getId();
+        } else {
+          name = getChronologyName(chrono, context.getLocale());
+        }
+        int nameLen = name.length();
+        if (nameLen > matchLen && context.subSequenceEquals(text, position, name, 0, nameLen)) {
+          bestMatch = chrono;
+          matchLen = nameLen;
+        }
+      }
+      if (bestMatch == null) {
+        return ~position;
+      }
+      context.setParsed(bestMatch);
+      return position + matchLen;
+    }
+
+    private String getChronologyName(TChronology chrono, TLocale locale) {
+
+      return chrono.getDisplayName(TTextStyle.FULL, locale);
+    }
+  }
+
+  static final class TLocalizedPrinterParser implements TDateTimePrinterParser {
+    private static final Map<String, TDateTimeFormatter> FORMATTER_CACHE = new HashMap<>(16, 0.75f);
+
+    private final TFormatStyle dateStyle;
+
+    private final TFormatStyle timeStyle;
+
+    TLocalizedPrinterParser(TFormatStyle dateStyle, TFormatStyle timeStyle) {
+
+      this.dateStyle = dateStyle;
+      this.timeStyle = timeStyle;
+    }
+
+    @Override
+    public boolean format(TDateTimePrintContext context, StringBuilder buf) {
+
+      TChronology chrono = TChronology.from(context.getTemporal());
+      return formatter(context.getLocale(), chrono).toPrinterParser(false).format(context, buf);
+    }
+
+    @Override
+    public int parse(TDateTimeParseContext context, CharSequence text, int position) {
+
+      TChronology chrono = context.getEffectiveChronology();
+      return formatter(context.getLocale(), chrono).toPrinterParser(false).parse(context, text, position);
+    }
+
+    private TDateTimeFormatter formatter(TLocale locale, TChronology chrono) {
+
+      TDateTimeFormatter formatter = null;
+      if (formatter == null) {
+        String pattern = getLocalizedDateTimePattern(this.dateStyle, this.timeStyle, chrono, locale);
+        formatter = new TDateTimeFormatterBuilder().appendPattern(pattern).toFormatter(locale);
+      }
+      return formatter;
+    }
+
+    @Override
+    public String toString() {
+
+      return "Localized(" + (this.dateStyle != null ? this.dateStyle : "") + ","
+          + (this.timeStyle != null ? this.timeStyle : "") + ")";
+    }
+  }
+
+  static final class TWeekBasedFieldPrinterParser extends TNumberPrinterParser {
+    private char chr;
+
+    private int count;
+
+    TWeekBasedFieldPrinterParser(char chr, int count, int minWidth, int maxWidth) {
+
+      this(chr, count, minWidth, maxWidth, 0);
+    }
+
+    TWeekBasedFieldPrinterParser(char chr, int count, int minWidth, int maxWidth, int subsequentWidth) {
+
+      super(null, minWidth, maxWidth, TSignStyle.NOT_NEGATIVE, subsequentWidth);
+      this.chr = chr;
+      this.count = count;
+    }
+
+    @Override
+    TWeekBasedFieldPrinterParser withFixedWidth() {
+
+      if (this.subsequentWidth == -1) {
+        return this;
+      }
+      return new TWeekBasedFieldPrinterParser(this.chr, this.count, this.minWidth, this.maxWidth, -1);
+    }
+
+    @Override
+    TWeekBasedFieldPrinterParser withSubsequentWidth(int subsequentWidth) {
+
+      return new TWeekBasedFieldPrinterParser(this.chr, this.count, this.minWidth, this.maxWidth,
+          this.subsequentWidth + subsequentWidth);
+    }
+
+    @Override
+    public boolean format(TDateTimePrintContext context, StringBuilder buf) {
+
+      return printerParser(context.getLocale()).format(context, buf);
+    }
+
+    @Override
+    public int parse(TDateTimeParseContext context, CharSequence text, int position) {
+
+      return printerParser(context.getLocale()).parse(context, text, position);
+    }
+
+    private TDateTimePrinterParser printerParser(TLocale locale) {
+
+      // WeekFields weekDef = WeekFields.of(locale);
+      // TTemporalField field = null;
+      // switch (this.chr) {
+      // case 'Y':
+      // field = weekDef.weekBasedYear();
+      // if (this.count == 2) {
+      // return new ReducedPrinterParser(field, 2, 2, 0, ReducedPrinterParser.BASE_DATE, this.subsequentWidth);
+      // } else {
+      // return new NumberPrinterParser(field, this.count, 19,
+      // (this.count < 4) ? SignStyle.NORMAL : SignStyle.EXCEEDS_PAD, this.subsequentWidth);
+      // }
+      // case 'e':
+      // case 'c':
+      // field = weekDef.dayOfWeek();
+      // break;
+      // case 'w':
+      // field = weekDef.weekOfWeekBasedYear();
+      // break;
+      // case 'W':
+      // field = weekDef.weekOfMonth();
+      // break;
+      // default:
+      // throw new IllegalStateException("unreachable");
+      // }
+      // TODO Currently unsupported / totally broken
+      return new TNumberPrinterParser(this.field, this.minWidth, this.maxWidth, TSignStyle.NOT_NEGATIVE,
+          this.subsequentWidth);
+    }
+
+    @Override
+    public String toString() {
+
+      StringBuilder sb = new StringBuilder(30);
+      sb.append("Localized(");
+      if (this.chr == 'Y') {
+        if (this.count == 1) {
+          sb.append("WeekBasedYear");
+        } else if (this.count == 2) {
+          sb.append("ReducedValue(WeekBasedYear,2,2,2000-01-01)");
+        } else {
+          sb.append("WeekBasedYear,").append(this.count).append(",").append(19).append(",")
+              .append((this.count < 4) ? SignStyle.NORMAL : SignStyle.EXCEEDS_PAD);
+        }
+      } else {
+        switch (this.chr) {
+          case 'c':
+          case 'e':
+            sb.append("DayOfWeek");
+            break;
+          case 'w':
+            sb.append("WeekOfWeekBasedYear");
+            break;
+          case 'W':
+            sb.append("WeekOfMonth");
+            break;
+          default:
+            break;
+        }
+        sb.append(",");
+        sb.append(this.count);
+      }
+      sb.append(")");
+      return sb.toString();
+    }
+  }
+
+  static final Comparator<String> LENGTH_SORT = new Comparator<String>() {
+    @Override
+    public int compare(String str1, String str2) {
+
+      return str1.length() == str2.length() ? str1.compareTo(str2) : str1.length() - str2.length();
+    }
+  };
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/time/format/TDateTimeParseContext.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/time/format/TDateTimeParseContext.java
@@ -1,0 +1,208 @@
+package org.teavm.classlib.java.time.format;
+
+import java.util.ArrayList;
+import java.util.Set;
+import java.util.function.Consumer;
+
+import org.teavm.classlib.java.time.TZoneId;
+import org.teavm.classlib.java.time.chrono.TChronology;
+import org.teavm.classlib.java.time.chrono.TIsoChronology;
+import org.teavm.classlib.java.time.temporal.TTemporalAccessor;
+import org.teavm.classlib.java.time.temporal.TTemporalField;
+import org.teavm.classlib.java.util.TLocale;
+import org.teavm.classlib.java.util.TObjects;
+
+public class TDateTimeParseContext {
+
+  private TDateTimeFormatter formatter;
+
+  private boolean caseSensitive = true;
+
+  private boolean strict = true;
+
+  private final ArrayList<TParsed> parsed = new ArrayList<>();
+
+  private ArrayList<Consumer<TChronology>> chronoListeners = null;
+
+  TDateTimeParseContext(TDateTimeFormatter formatter) {
+
+    super();
+    this.formatter = formatter;
+    this.parsed.add(new TParsed());
+  }
+
+  TDateTimeParseContext copy() {
+
+    TDateTimeParseContext newContext = new TDateTimeParseContext(this.formatter);
+    newContext.caseSensitive = this.caseSensitive;
+    newContext.strict = this.strict;
+    return newContext;
+  }
+
+  TLocale getLocale() {
+
+    return this.formatter.getLocale();
+  }
+
+  TDecimalStyle getDecimalStyle() {
+
+    return this.formatter.getDecimalStyle();
+  }
+
+  TChronology getEffectiveChronology() {
+
+    TChronology chrono = currentParsed().chrono;
+    if (chrono == null) {
+      chrono = this.formatter.getChronology();
+      if (chrono == null) {
+        chrono = TIsoChronology.INSTANCE;
+      }
+    }
+    return chrono;
+  }
+
+  boolean isCaseSensitive() {
+
+    return this.caseSensitive;
+  }
+
+  void setCaseSensitive(boolean caseSensitive) {
+
+    this.caseSensitive = caseSensitive;
+  }
+
+  boolean subSequenceEquals(CharSequence cs1, int offset1, CharSequence cs2, int offset2, int length) {
+
+    if (offset1 + length > cs1.length() || offset2 + length > cs2.length()) {
+      return false;
+    }
+    if (isCaseSensitive()) {
+      for (int i = 0; i < length; i++) {
+        char ch1 = cs1.charAt(offset1 + i);
+        char ch2 = cs2.charAt(offset2 + i);
+        if (ch1 != ch2) {
+          return false;
+        }
+      }
+    } else {
+      for (int i = 0; i < length; i++) {
+        char ch1 = cs1.charAt(offset1 + i);
+        char ch2 = cs2.charAt(offset2 + i);
+        if (ch1 != ch2 && Character.toUpperCase(ch1) != Character.toUpperCase(ch2)
+            && Character.toLowerCase(ch1) != Character.toLowerCase(ch2)) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  boolean charEquals(char ch1, char ch2) {
+
+    if (isCaseSensitive()) {
+      return ch1 == ch2;
+    }
+    return charEqualsIgnoreCase(ch1, ch2);
+  }
+
+  static boolean charEqualsIgnoreCase(char c1, char c2) {
+
+    return c1 == c2 || Character.toUpperCase(c1) == Character.toUpperCase(c2)
+        || Character.toLowerCase(c1) == Character.toLowerCase(c2);
+  }
+
+  boolean isStrict() {
+
+    return this.strict;
+  }
+
+  void setStrict(boolean strict) {
+
+    this.strict = strict;
+  }
+
+  void startOptional() {
+
+    this.parsed.add(currentParsed().copy());
+  }
+
+  void endOptional(boolean successful) {
+
+    if (successful) {
+      this.parsed.remove(this.parsed.size() - 2);
+    } else {
+      this.parsed.remove(this.parsed.size() - 1);
+    }
+  }
+
+  private TParsed currentParsed() {
+
+    return this.parsed.get(this.parsed.size() - 1);
+  }
+
+  TParsed toUnresolved() {
+
+    return currentParsed();
+  }
+
+  TTemporalAccessor toResolved(TResolverStyle resolverStyle, Set<TTemporalField> resolverFields) {
+
+    TParsed parsed = currentParsed();
+    parsed.chrono = getEffectiveChronology();
+    parsed.zone = (parsed.zone != null ? parsed.zone : this.formatter.getZone());
+    return parsed.resolve(resolverStyle, resolverFields);
+  }
+
+  Long getParsed(TTemporalField field) {
+
+    return currentParsed().fieldValues.get(field);
+  }
+
+  int setParsedField(TTemporalField field, long value, int errorPos, int successPos) {
+
+    TObjects.requireNonNull(field, "field");
+    Long old = currentParsed().fieldValues.put(field, value);
+    return (old != null && old.longValue() != value) ? ~errorPos : successPos;
+  }
+
+  void setParsed(TChronology chrono) {
+
+    TObjects.requireNonNull(chrono, "chrono");
+    currentParsed().chrono = chrono;
+    if (this.chronoListeners != null && !this.chronoListeners.isEmpty()) {
+      @SuppressWarnings({ "rawtypes", "unchecked" })
+      Consumer<TChronology>[] tmp = new Consumer[1];
+      Consumer<TChronology>[] listeners = this.chronoListeners.toArray(tmp);
+      this.chronoListeners.clear();
+      for (Consumer<TChronology> l : listeners) {
+        l.accept(chrono);
+      }
+    }
+  }
+
+  void addChronoChangedListener(Consumer<TChronology> listener) {
+
+    if (this.chronoListeners == null) {
+      this.chronoListeners = new ArrayList<>();
+    }
+    this.chronoListeners.add(listener);
+  }
+
+  void setParsed(TZoneId zone) {
+
+    TObjects.requireNonNull(zone, "zone");
+    currentParsed().zone = zone;
+  }
+
+  void setParsedLeapSecond() {
+
+    currentParsed().leapSecond = true;
+  }
+
+  @Override
+  public String toString() {
+
+    return currentParsed().toString();
+  }
+
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/time/format/TDateTimeParseException.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/time/format/TDateTimeParseException.java
@@ -1,0 +1,35 @@
+package org.teavm.classlib.java.time.format;
+
+import org.teavm.classlib.java.time.TDateTimeException;
+
+public class TDateTimeParseException extends TDateTimeException {
+
+  private final String parsedString;
+
+  private final int errorIndex;
+
+  public TDateTimeParseException(String message, CharSequence parsedData, int errorIndex) {
+
+    super(message);
+    this.parsedString = parsedData.toString();
+    this.errorIndex = errorIndex;
+  }
+
+  public TDateTimeParseException(String message, CharSequence parsedData, int errorIndex, Throwable cause) {
+
+    super(message, cause);
+    this.parsedString = parsedData.toString();
+    this.errorIndex = errorIndex;
+  }
+
+  public String getParsedString() {
+
+    return this.parsedString;
+  }
+
+  public int getErrorIndex() {
+
+    return this.errorIndex;
+  }
+
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/time/format/TDateTimePrintContext.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/time/format/TDateTimePrintContext.java
@@ -1,0 +1,193 @@
+package org.teavm.classlib.java.time.format;
+
+import static org.teavm.classlib.java.time.temporal.TChronoField.EPOCH_DAY;
+import static org.teavm.classlib.java.time.temporal.TChronoField.INSTANT_SECONDS;
+import static org.teavm.classlib.java.time.temporal.TChronoField.OFFSET_SECONDS;
+
+import org.teavm.classlib.java.time.TDateTimeException;
+import org.teavm.classlib.java.time.TInstant;
+import org.teavm.classlib.java.time.TZoneId;
+import org.teavm.classlib.java.time.TZoneOffset;
+import org.teavm.classlib.java.time.chrono.TChronoLocalDate;
+import org.teavm.classlib.java.time.chrono.TChronology;
+import org.teavm.classlib.java.time.chrono.TIsoChronology;
+import org.teavm.classlib.java.time.temporal.TChronoField;
+import org.teavm.classlib.java.time.temporal.TTemporalAccessor;
+import org.teavm.classlib.java.time.temporal.TTemporalField;
+import org.teavm.classlib.java.time.temporal.TTemporalQueries;
+import org.teavm.classlib.java.time.temporal.TTemporalQuery;
+import org.teavm.classlib.java.time.temporal.TValueRange;
+import org.teavm.classlib.java.util.TLocale;
+import org.teavm.classlib.java.util.TObjects;
+
+final class TDateTimePrintContext {
+
+  private TTemporalAccessor temporal;
+
+  private TDateTimeFormatter formatter;
+
+  private int optional;
+
+  TDateTimePrintContext(TTemporalAccessor temporal, TDateTimeFormatter formatter) {
+
+    super();
+    this.temporal = adjust(temporal, formatter);
+    this.formatter = formatter;
+  }
+
+  private static TTemporalAccessor adjust(final TTemporalAccessor temporal, TDateTimeFormatter formatter) {
+
+    TChronology overrideChrono = formatter.getChronology();
+    TZoneId overrideZone = formatter.getZone();
+    if (overrideChrono == null && overrideZone == null) {
+      return temporal;
+    }
+
+    TChronology temporalChrono = temporal.query(TTemporalQueries.chronology());
+    TZoneId temporalZone = temporal.query(TTemporalQueries.zoneId());
+    if (TObjects.equals(overrideChrono, temporalChrono)) {
+      overrideChrono = null;
+    }
+    if (TObjects.equals(overrideZone, temporalZone)) {
+      overrideZone = null;
+    }
+    if (overrideChrono == null && overrideZone == null) {
+      return temporal;
+    }
+
+    final TChronology effectiveChrono = (overrideChrono != null ? overrideChrono : temporalChrono);
+    if (overrideZone != null) {
+      if (temporal.isSupported(INSTANT_SECONDS)) {
+        TChronology chrono = (effectiveChrono != null) ? effectiveChrono : TIsoChronology.INSTANCE;
+        return chrono.zonedDateTime(TInstant.from(temporal), overrideZone);
+      }
+      if (overrideZone.normalized() instanceof TZoneOffset && temporal.isSupported(OFFSET_SECONDS)
+          && temporal.get(OFFSET_SECONDS) != overrideZone.getRules().getOffset(TInstant.EPOCH).getTotalSeconds()) {
+        throw new TDateTimeException("Unable to apply override zone '" + overrideZone
+            + "' because the temporal object being formatted has a different offset but"
+            + " does not represent an instant: " + temporal);
+      }
+    }
+    final TZoneId effectiveZone = (overrideZone != null ? overrideZone : temporalZone);
+    final TChronoLocalDate effectiveDate;
+    if (overrideChrono != null) {
+      if (temporal.isSupported(EPOCH_DAY)) {
+        effectiveDate = effectiveChrono.date(temporal);
+      } else {
+        if (!(overrideChrono == TIsoChronology.INSTANCE && temporalChrono == null)) {
+          for (TChronoField f : TChronoField.values()) {
+            if (f.isDateBased() && temporal.isSupported(f)) {
+              throw new TDateTimeException("Unable to apply override chronology '" + overrideChrono
+                  + "' because the temporal object being formatted contains date fields but"
+                  + " does not represent a whole date: " + temporal);
+            }
+          }
+        }
+        effectiveDate = null;
+      }
+    } else {
+      effectiveDate = null;
+    }
+
+    return new TTemporalAccessor() {
+      @Override
+      public boolean isSupported(TTemporalField field) {
+
+        if (effectiveDate != null && field.isDateBased()) {
+          return effectiveDate.isSupported(field);
+        }
+        return temporal.isSupported(field);
+      }
+
+      @Override
+      public TValueRange range(TTemporalField field) {
+
+        if (effectiveDate != null && field.isDateBased()) {
+          return effectiveDate.range(field);
+        }
+        return temporal.range(field);
+      }
+
+      @Override
+      public long getLong(TTemporalField field) {
+
+        if (effectiveDate != null && field.isDateBased()) {
+          return effectiveDate.getLong(field);
+        }
+        return temporal.getLong(field);
+      }
+
+      @SuppressWarnings("unchecked")
+      @Override
+      public <R> R query(TTemporalQuery<R> query) {
+
+        if (query == TTemporalQueries.chronology()) {
+          return (R) effectiveChrono;
+        }
+        if (query == TTemporalQueries.zoneId()) {
+          return (R) effectiveZone;
+        }
+        if (query == TTemporalQueries.precision()) {
+          return temporal.query(query);
+        }
+        return query.queryFrom(this);
+      }
+
+      @Override
+      public String toString() {
+
+        return temporal + (effectiveChrono != null ? " with chronology " + effectiveChrono : "")
+            + (effectiveZone != null ? " with zone " + effectiveZone : "");
+      }
+    };
+  }
+
+  TTemporalAccessor getTemporal() {
+
+    return this.temporal;
+  }
+
+  TLocale getLocale() {
+
+    return this.formatter.getLocale();
+  }
+
+  TDecimalStyle getDecimalStyle() {
+
+    return this.formatter.getDecimalStyle();
+  }
+
+  void startOptional() {
+
+    this.optional++;
+  }
+
+  void endOptional() {
+
+    this.optional--;
+  }
+
+  <R> R getValue(TTemporalQuery<R> query) {
+
+    R result = this.temporal.query(query);
+    if (result == null && this.optional == 0) {
+      throw new TDateTimeException("Unable to extract " + query + " from temporal " + this.temporal);
+    }
+    return result;
+  }
+
+  Long getValue(TTemporalField field) {
+
+    if (this.optional > 0 && !this.temporal.isSupported(field)) {
+      return null;
+    }
+    return this.temporal.getLong(field);
+  }
+
+  @Override
+  public String toString() {
+
+    return this.temporal.toString();
+  }
+
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/time/format/TDecimalStyle.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/time/format/TDecimalStyle.java
@@ -1,0 +1,169 @@
+package org.teavm.classlib.java.time.format;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.teavm.classlib.java.text.TDecimalFormatSymbols;
+import org.teavm.classlib.java.util.TLocale;
+import org.teavm.classlib.java.util.TObjects;
+
+public final class TDecimalStyle {
+  public static final TDecimalStyle STANDARD = new TDecimalStyle('0', '+', '-', '.');
+
+  private static final Map<TLocale, TDecimalStyle> CACHE = new HashMap<>(16, 0.75f);
+
+  private final char zeroDigit;
+
+  private final char positiveSign;
+
+  private final char negativeSign;
+
+  private final char decimalSeparator;
+
+  public static Set<TLocale> getAvailableLocales() {
+
+    TLocale[] l = TDecimalFormatSymbols.getAvailableLocales();
+    Set<TLocale> locales = new HashSet<>(l.length);
+    Collections.addAll(locales, l);
+    return locales;
+  }
+
+  private TDecimalStyle(char zeroChar, char positiveSignChar, char negativeSignChar, char decimalPointChar) {
+
+    this.zeroDigit = zeroChar;
+    this.positiveSign = positiveSignChar;
+    this.negativeSign = negativeSignChar;
+    this.decimalSeparator = decimalPointChar;
+  }
+
+  public char getZeroDigit() {
+
+    return this.zeroDigit;
+  }
+
+  public TDecimalStyle withZeroDigit(char zeroDigit) {
+
+    if (zeroDigit == this.zeroDigit) {
+      return this;
+    }
+    return new TDecimalStyle(zeroDigit, this.positiveSign, this.negativeSign, this.decimalSeparator);
+  }
+
+  public char getPositiveSign() {
+
+    return this.positiveSign;
+  }
+
+  public TDecimalStyle withPositiveSign(char positiveSign) {
+
+    if (positiveSign == this.positiveSign) {
+      return this;
+    }
+    return new TDecimalStyle(this.zeroDigit, positiveSign, this.negativeSign, this.decimalSeparator);
+  }
+
+  public char getNegativeSign() {
+
+    return this.negativeSign;
+  }
+
+  public TDecimalStyle withNegativeSign(char negativeSign) {
+
+    if (negativeSign == this.negativeSign) {
+      return this;
+    }
+    return new TDecimalStyle(this.zeroDigit, this.positiveSign, negativeSign, this.decimalSeparator);
+  }
+
+  public char getDecimalSeparator() {
+
+    return this.decimalSeparator;
+  }
+
+  public TDecimalStyle withDecimalSeparator(char decimalSeparator) {
+
+    if (decimalSeparator == this.decimalSeparator) {
+      return this;
+    }
+    return new TDecimalStyle(this.zeroDigit, this.positiveSign, this.negativeSign, decimalSeparator);
+  }
+
+  int convertToDigit(char ch) {
+
+    int val = ch - this.zeroDigit;
+    return (val >= 0 && val <= 9) ? val : -1;
+  }
+
+  String convertNumberToI18N(String numericText) {
+
+    if (this.zeroDigit == '0') {
+      return numericText;
+    }
+    int diff = this.zeroDigit - '0';
+    char[] array = numericText.toCharArray();
+    for (int i = 0; i < array.length; i++) {
+      array[i] = (char) (array[i] + diff);
+    }
+    return new String(array);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+
+    if (this == obj) {
+      return true;
+    }
+    if (obj instanceof TDecimalStyle) {
+      TDecimalStyle other = (TDecimalStyle) obj;
+      return (this.zeroDigit == other.zeroDigit && this.positiveSign == other.positiveSign
+          && this.negativeSign == other.negativeSign && this.decimalSeparator == other.decimalSeparator);
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+
+    return this.zeroDigit + this.positiveSign + this.negativeSign + this.decimalSeparator;
+  }
+
+  @Override
+  public String toString() {
+
+    return "DecimalStyle[" + this.zeroDigit + this.positiveSign + this.negativeSign + this.decimalSeparator + "]";
+  }
+
+  public static TDecimalStyle ofDefaultLocale() {
+
+    return of(TLocale.getDefault());
+  }
+
+  public static TDecimalStyle of(TLocale locale) {
+
+    TObjects.requireNonNull(locale, "locale");
+    TDecimalStyle info = CACHE.get(locale);
+    if (info == null) {
+      info = create(locale);
+      CACHE.putIfAbsent(locale, info);
+      info = CACHE.get(locale);
+    }
+    return info;
+  }
+
+  private static TDecimalStyle create(TLocale locale) {
+
+    TDecimalFormatSymbols oldSymbols = TDecimalFormatSymbols.getInstance(locale);
+    char zeroDigit = oldSymbols.getZeroDigit();
+    char positiveSign = '+';
+    char negativeSign = oldSymbols.getMinusSign();
+    char decimalSeparator = oldSymbols.getDecimalSeparator();
+    if (zeroDigit == '0' && negativeSign == '-' && decimalSeparator == '.') {
+      return STANDARD;
+    }
+    return new TDecimalStyle(zeroDigit, positiveSign, negativeSign, decimalSeparator);
+  }
+
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/time/format/TFormatStyle.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/time/format/TFormatStyle.java
@@ -1,0 +1,5 @@
+package org.teavm.classlib.java.time.format;
+
+public enum TFormatStyle {
+  FULL, LONG, MEDIUM, SHORT;
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/time/format/TParsed.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/time/format/TParsed.java
@@ -1,0 +1,563 @@
+package org.teavm.classlib.java.time.format;
+
+import static org.teavm.classlib.java.time.temporal.TChronoField.AMPM_OF_DAY;
+import static org.teavm.classlib.java.time.temporal.TChronoField.CLOCK_HOUR_OF_AMPM;
+import static org.teavm.classlib.java.time.temporal.TChronoField.CLOCK_HOUR_OF_DAY;
+import static org.teavm.classlib.java.time.temporal.TChronoField.HOUR_OF_AMPM;
+import static org.teavm.classlib.java.time.temporal.TChronoField.HOUR_OF_DAY;
+import static org.teavm.classlib.java.time.temporal.TChronoField.INSTANT_SECONDS;
+import static org.teavm.classlib.java.time.temporal.TChronoField.MICRO_OF_DAY;
+import static org.teavm.classlib.java.time.temporal.TChronoField.MICRO_OF_SECOND;
+import static org.teavm.classlib.java.time.temporal.TChronoField.MILLI_OF_DAY;
+import static org.teavm.classlib.java.time.temporal.TChronoField.MILLI_OF_SECOND;
+import static org.teavm.classlib.java.time.temporal.TChronoField.MINUTE_OF_DAY;
+import static org.teavm.classlib.java.time.temporal.TChronoField.MINUTE_OF_HOUR;
+import static org.teavm.classlib.java.time.temporal.TChronoField.NANO_OF_DAY;
+import static org.teavm.classlib.java.time.temporal.TChronoField.NANO_OF_SECOND;
+import static org.teavm.classlib.java.time.temporal.TChronoField.OFFSET_SECONDS;
+import static org.teavm.classlib.java.time.temporal.TChronoField.SECOND_OF_DAY;
+import static org.teavm.classlib.java.time.temporal.TChronoField.SECOND_OF_MINUTE;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import org.teavm.classlib.java.time.TDateTimeException;
+import org.teavm.classlib.java.time.TInstant;
+import org.teavm.classlib.java.time.TLocalDate;
+import org.teavm.classlib.java.time.TLocalTime;
+import org.teavm.classlib.java.time.TPeriod;
+import org.teavm.classlib.java.time.TZoneId;
+import org.teavm.classlib.java.time.TZoneOffset;
+import org.teavm.classlib.java.time.chrono.TChronoLocalDate;
+import org.teavm.classlib.java.time.chrono.TChronoLocalDateTime;
+import org.teavm.classlib.java.time.chrono.TChronoZonedDateTime;
+import org.teavm.classlib.java.time.chrono.TChronology;
+import org.teavm.classlib.java.time.temporal.TChronoField;
+import org.teavm.classlib.java.time.temporal.TTemporalAccessor;
+import org.teavm.classlib.java.time.temporal.TTemporalField;
+import org.teavm.classlib.java.time.temporal.TTemporalQueries;
+import org.teavm.classlib.java.time.temporal.TTemporalQuery;
+import org.teavm.classlib.java.time.temporal.TUnsupportedTemporalTypeException;
+import org.teavm.classlib.java.util.TObjects;
+
+public final class TParsed implements TTemporalAccessor {
+  final Map<TTemporalField, Long> fieldValues = new HashMap<>();
+
+  TZoneId zone;
+
+  TChronology chrono;
+
+  boolean leapSecond;
+
+  private TResolverStyle resolverStyle;
+
+  private TChronoLocalDate date;
+
+  private TLocalTime time;
+
+  TPeriod excessDays = TPeriod.ZERO;
+
+  TParsed() {
+
+  }
+
+  TParsed copy() {
+
+    TParsed cloned = new TParsed();
+    cloned.fieldValues.putAll(this.fieldValues);
+    cloned.zone = this.zone;
+    cloned.chrono = this.chrono;
+    cloned.leapSecond = this.leapSecond;
+    return cloned;
+  }
+
+  @Override
+  public boolean isSupported(TTemporalField field) {
+
+    if (this.fieldValues.containsKey(field) || (this.date != null && this.date.isSupported(field))
+        || (this.time != null && this.time.isSupported(field))) {
+      return true;
+    }
+    return field != null && (field instanceof TChronoField == false) && field.isSupportedBy(this);
+  }
+
+  @Override
+  public long getLong(TTemporalField field) {
+
+    TObjects.requireNonNull(field, "field");
+    Long value = this.fieldValues.get(field);
+    if (value != null) {
+      return value.longValue();
+    }
+    if (this.date != null && this.date.isSupported(field)) {
+      return this.date.getLong(field);
+    }
+    if (this.time != null && this.time.isSupported(field)) {
+      return this.time.getLong(field);
+    }
+    if (field instanceof TChronoField) {
+      throw new TUnsupportedTemporalTypeException("Unsupported field: " + field);
+    }
+    return field.getFrom(this);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public <R> R query(TTemporalQuery<R> query) {
+
+    if (query == TTemporalQueries.zoneId()) {
+      return (R) this.zone;
+    } else if (query == TTemporalQueries.chronology()) {
+      return (R) this.chrono;
+    } else if (query == TTemporalQueries.localDate()) {
+      return (R) (this.date != null ? TLocalDate.from(this.date) : null);
+    } else if (query == TTemporalQueries.localTime()) {
+      return (R) this.time;
+    } else if (query == TTemporalQueries.offset()) {
+      Long offsetSecs = this.fieldValues.get(OFFSET_SECONDS);
+      if (offsetSecs != null) {
+        return (R) TZoneOffset.ofTotalSeconds(offsetSecs.intValue());
+      }
+      if (this.zone instanceof TZoneOffset) {
+        return (R) this.zone;
+      }
+      return query.queryFrom(this);
+    } else if (query == TTemporalQueries.zone()) {
+      return query.queryFrom(this);
+    } else if (query == TTemporalQueries.precision()) {
+      return null;
+    }
+    return query.queryFrom(this);
+  }
+
+  TTemporalAccessor resolve(TResolverStyle resolverStyle, Set<TTemporalField> resolverFields) {
+
+    if (resolverFields != null) {
+      this.fieldValues.keySet().retainAll(resolverFields);
+    }
+    this.resolverStyle = resolverStyle;
+    resolveFields();
+    resolveTimeLenient();
+    crossCheck();
+    resolvePeriod();
+    resolveFractional();
+    resolveInstant();
+    return this;
+  }
+
+  private void resolveFields() {
+
+    resolveInstantFields();
+    resolveDateFields();
+    resolveTimeFields();
+
+    if (this.fieldValues.size() > 0) {
+      int changedCount = 0;
+      outer: while (changedCount < 50) {
+        for (Map.Entry<TTemporalField, Long> entry : this.fieldValues.entrySet()) {
+          TTemporalField targetField = entry.getKey();
+          TTemporalAccessor resolvedObject = targetField.resolve(this.fieldValues, this, this.resolverStyle);
+          if (resolvedObject != null) {
+            if (resolvedObject instanceof TChronoZonedDateTime) {
+              TChronoZonedDateTime<?> czdt = (TChronoZonedDateTime<?>) resolvedObject;
+              if (this.zone == null) {
+                this.zone = czdt.getZone();
+              } else if (this.zone.equals(czdt.getZone()) == false) {
+                throw new TDateTimeException("ChronoZonedDateTime must use the effective parsed zone: " + this.zone);
+              }
+              resolvedObject = czdt.toLocalDateTime();
+            }
+            if (resolvedObject instanceof TChronoLocalDateTime) {
+              TChronoLocalDateTime<?> cldt = (TChronoLocalDateTime<?>) resolvedObject;
+              updateCheckConflict(cldt.toLocalTime(), TPeriod.ZERO);
+              updateCheckConflict(cldt.toLocalDate());
+              changedCount++;
+              continue outer;
+            }
+            if (resolvedObject instanceof TChronoLocalDate) {
+              updateCheckConflict((TChronoLocalDate) resolvedObject);
+              changedCount++;
+              continue outer;
+            }
+            if (resolvedObject instanceof TLocalTime) {
+              updateCheckConflict((TLocalTime) resolvedObject, TPeriod.ZERO);
+              changedCount++;
+              continue outer;
+            }
+            throw new TDateTimeException("Method resolve() can only return ChronoZonedDateTime, "
+                + "ChronoLocalDateTime, ChronoLocalDate or LocalTime");
+          } else if (this.fieldValues.containsKey(targetField) == false) {
+            changedCount++;
+            continue outer;
+          }
+        }
+        break;
+      }
+      if (changedCount == 50) {
+        throw new TDateTimeException("One of the parsed fields has an incorrectly implemented resolve method");
+      }
+      if (changedCount > 0) {
+        resolveInstantFields();
+        resolveDateFields();
+        resolveTimeFields();
+      }
+    }
+  }
+
+  private void updateCheckConflict(TTemporalField targetField, TTemporalField changeField, Long changeValue) {
+
+    Long old = this.fieldValues.put(changeField, changeValue);
+    if (old != null && old.longValue() != changeValue.longValue()) {
+      throw new TDateTimeException("Conflict found: " + changeField + " " + old + " differs from " + changeField + " "
+          + changeValue + " while resolving  " + targetField);
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  private void resolveInstantFields() {
+
+    // resolve parsed instant seconds to date and time if zone available
+    if (this.fieldValues.containsKey(INSTANT_SECONDS)) {
+      if (this.zone != null) {
+        resolveInstantFields0(this.zone);
+      } else {
+        Long offsetSecs = this.fieldValues.get(OFFSET_SECONDS);
+        if (offsetSecs != null) {
+          TZoneOffset offset = TZoneOffset.ofTotalSeconds(offsetSecs.intValue());
+          resolveInstantFields0(offset);
+        }
+      }
+    }
+  }
+
+  private void resolveInstantFields0(TZoneId selectedZone) {
+
+    TInstant instant = TInstant.ofEpochSecond(this.fieldValues.remove(INSTANT_SECONDS));
+    TChronoZonedDateTime<?> zdt = this.chrono.zonedDateTime(instant, selectedZone);
+    updateCheckConflict(zdt.toLocalDate());
+    updateCheckConflict(INSTANT_SECONDS, SECOND_OF_DAY, (long) zdt.toLocalTime().toSecondOfDay());
+  }
+
+  private void resolveDateFields() {
+
+    updateCheckConflict(this.chrono.resolveDate(this.fieldValues, this.resolverStyle));
+  }
+
+  private void updateCheckConflict(TChronoLocalDate cld) {
+
+    if (this.date != null) {
+      if (cld != null && this.date.equals(cld) == false) {
+        throw new TDateTimeException(
+            "Conflict found: Fields resolved to two different dates: " + this.date + " " + cld);
+      }
+    } else if (cld != null) {
+      if (this.chrono.equals(cld.getChronology()) == false) {
+        throw new TDateTimeException("ChronoLocalDate must use the effective parsed chronology: " + this.chrono);
+      }
+      this.date = cld;
+    }
+  }
+
+  private void resolveTimeFields() {
+
+    // simplify fields
+    if (this.fieldValues.containsKey(CLOCK_HOUR_OF_DAY)) {
+      // lenient allows anything, smart allows 0-24, strict allows 1-24
+      long ch = this.fieldValues.remove(CLOCK_HOUR_OF_DAY);
+      if (this.resolverStyle == TResolverStyle.STRICT || (this.resolverStyle == TResolverStyle.SMART && ch != 0)) {
+        CLOCK_HOUR_OF_DAY.checkValidValue(ch);
+      }
+      updateCheckConflict(CLOCK_HOUR_OF_DAY, HOUR_OF_DAY, ch == 24 ? 0 : ch);
+    }
+    if (this.fieldValues.containsKey(CLOCK_HOUR_OF_AMPM)) {
+      // lenient allows anything, smart allows 0-12, strict allows 1-12
+      long ch = this.fieldValues.remove(CLOCK_HOUR_OF_AMPM);
+      if (this.resolverStyle == TResolverStyle.STRICT || (this.resolverStyle == TResolverStyle.SMART && ch != 0)) {
+        CLOCK_HOUR_OF_AMPM.checkValidValue(ch);
+      }
+      updateCheckConflict(CLOCK_HOUR_OF_AMPM, HOUR_OF_AMPM, ch == 12 ? 0 : ch);
+    }
+    if (this.fieldValues.containsKey(AMPM_OF_DAY) && this.fieldValues.containsKey(HOUR_OF_AMPM)) {
+      long ap = this.fieldValues.remove(AMPM_OF_DAY);
+      long hap = this.fieldValues.remove(HOUR_OF_AMPM);
+      if (this.resolverStyle == TResolverStyle.LENIENT) {
+        updateCheckConflict(AMPM_OF_DAY, HOUR_OF_DAY, Math.addExact(Math.multiplyExact(ap, 12), hap));
+      } else {
+        AMPM_OF_DAY.checkValidValue(ap);
+        HOUR_OF_AMPM.checkValidValue(ap);
+        updateCheckConflict(AMPM_OF_DAY, HOUR_OF_DAY, ap * 12 + hap);
+      }
+    }
+    if (this.fieldValues.containsKey(NANO_OF_DAY)) {
+      long nod = this.fieldValues.remove(NANO_OF_DAY);
+      if (this.resolverStyle != TResolverStyle.LENIENT) {
+        NANO_OF_DAY.checkValidValue(nod);
+      }
+      updateCheckConflict(NANO_OF_DAY, HOUR_OF_DAY, nod / 3600_000_000_000L);
+      updateCheckConflict(NANO_OF_DAY, MINUTE_OF_HOUR, (nod / 60_000_000_000L) % 60);
+      updateCheckConflict(NANO_OF_DAY, SECOND_OF_MINUTE, (nod / 1_000_000_000L) % 60);
+      updateCheckConflict(NANO_OF_DAY, NANO_OF_SECOND, nod % 1_000_000_000L);
+    }
+    if (this.fieldValues.containsKey(MICRO_OF_DAY)) {
+      long cod = this.fieldValues.remove(MICRO_OF_DAY);
+      if (this.resolverStyle != TResolverStyle.LENIENT) {
+        MICRO_OF_DAY.checkValidValue(cod);
+      }
+      updateCheckConflict(MICRO_OF_DAY, SECOND_OF_DAY, cod / 1_000_000L);
+      updateCheckConflict(MICRO_OF_DAY, MICRO_OF_SECOND, cod % 1_000_000L);
+    }
+    if (this.fieldValues.containsKey(MILLI_OF_DAY)) {
+      long lod = this.fieldValues.remove(MILLI_OF_DAY);
+      if (this.resolverStyle != TResolverStyle.LENIENT) {
+        MILLI_OF_DAY.checkValidValue(lod);
+      }
+      updateCheckConflict(MILLI_OF_DAY, SECOND_OF_DAY, lod / 1_000);
+      updateCheckConflict(MILLI_OF_DAY, MILLI_OF_SECOND, lod % 1_000);
+    }
+    if (this.fieldValues.containsKey(SECOND_OF_DAY)) {
+      long sod = this.fieldValues.remove(SECOND_OF_DAY);
+      if (this.resolverStyle != TResolverStyle.LENIENT) {
+        SECOND_OF_DAY.checkValidValue(sod);
+      }
+      updateCheckConflict(SECOND_OF_DAY, HOUR_OF_DAY, sod / 3600);
+      updateCheckConflict(SECOND_OF_DAY, MINUTE_OF_HOUR, (sod / 60) % 60);
+      updateCheckConflict(SECOND_OF_DAY, SECOND_OF_MINUTE, sod % 60);
+    }
+    if (this.fieldValues.containsKey(MINUTE_OF_DAY)) {
+      long mod = this.fieldValues.remove(MINUTE_OF_DAY);
+      if (this.resolverStyle != TResolverStyle.LENIENT) {
+        MINUTE_OF_DAY.checkValidValue(mod);
+      }
+      updateCheckConflict(MINUTE_OF_DAY, HOUR_OF_DAY, mod / 60);
+      updateCheckConflict(MINUTE_OF_DAY, MINUTE_OF_HOUR, mod % 60);
+    }
+
+    // combine partial second fields strictly, leaving lenient expansion to later
+    if (this.fieldValues.containsKey(NANO_OF_SECOND)) {
+      long nos = this.fieldValues.get(NANO_OF_SECOND);
+      if (this.resolverStyle != TResolverStyle.LENIENT) {
+        NANO_OF_SECOND.checkValidValue(nos);
+      }
+      if (this.fieldValues.containsKey(MICRO_OF_SECOND)) {
+        long cos = this.fieldValues.remove(MICRO_OF_SECOND);
+        if (this.resolverStyle != TResolverStyle.LENIENT) {
+          MICRO_OF_SECOND.checkValidValue(cos);
+        }
+        nos = cos * 1000 + (nos % 1000);
+        updateCheckConflict(MICRO_OF_SECOND, NANO_OF_SECOND, nos);
+      }
+      if (this.fieldValues.containsKey(MILLI_OF_SECOND)) {
+        long los = this.fieldValues.remove(MILLI_OF_SECOND);
+        if (this.resolverStyle != TResolverStyle.LENIENT) {
+          MILLI_OF_SECOND.checkValidValue(los);
+        }
+        updateCheckConflict(MILLI_OF_SECOND, NANO_OF_SECOND, los * 1_000_000L + (nos % 1_000_000L));
+      }
+    }
+
+    // convert to time if all four fields available (optimization)
+    if (this.fieldValues.containsKey(HOUR_OF_DAY) && this.fieldValues.containsKey(MINUTE_OF_HOUR)
+        && this.fieldValues.containsKey(SECOND_OF_MINUTE) && this.fieldValues.containsKey(NANO_OF_SECOND)) {
+      long hod = this.fieldValues.remove(HOUR_OF_DAY);
+      long moh = this.fieldValues.remove(MINUTE_OF_HOUR);
+      long som = this.fieldValues.remove(SECOND_OF_MINUTE);
+      long nos = this.fieldValues.remove(NANO_OF_SECOND);
+      resolveTime(hod, moh, som, nos);
+    }
+  }
+
+  private void resolveTimeLenient() {
+
+    if (this.time == null) {
+      if (this.fieldValues.containsKey(MILLI_OF_SECOND)) {
+        long los = this.fieldValues.remove(MILLI_OF_SECOND);
+        if (this.fieldValues.containsKey(MICRO_OF_SECOND)) {
+          long cos = los * 1_000 + (this.fieldValues.get(MICRO_OF_SECOND) % 1_000);
+          updateCheckConflict(MILLI_OF_SECOND, MICRO_OF_SECOND, cos);
+          this.fieldValues.remove(MICRO_OF_SECOND);
+          this.fieldValues.put(NANO_OF_SECOND, cos * 1_000L);
+        } else {
+          this.fieldValues.put(NANO_OF_SECOND, los * 1_000_000L);
+        }
+      } else if (this.fieldValues.containsKey(MICRO_OF_SECOND)) {
+        long cos = this.fieldValues.remove(MICRO_OF_SECOND);
+        this.fieldValues.put(NANO_OF_SECOND, cos * 1_000L);
+      }
+
+      Long hod = this.fieldValues.get(HOUR_OF_DAY);
+      if (hod != null) {
+        Long moh = this.fieldValues.get(MINUTE_OF_HOUR);
+        Long som = this.fieldValues.get(SECOND_OF_MINUTE);
+        Long nos = this.fieldValues.get(NANO_OF_SECOND);
+
+        if ((moh == null && (som != null || nos != null)) || (moh != null && som == null && nos != null)) {
+          return;
+        }
+
+        long mohVal = (moh != null ? moh : 0);
+        long somVal = (som != null ? som : 0);
+        long nosVal = (nos != null ? nos : 0);
+        resolveTime(hod, mohVal, somVal, nosVal);
+        this.fieldValues.remove(HOUR_OF_DAY);
+        this.fieldValues.remove(MINUTE_OF_HOUR);
+        this.fieldValues.remove(SECOND_OF_MINUTE);
+        this.fieldValues.remove(NANO_OF_SECOND);
+      }
+    }
+
+    if (this.resolverStyle != TResolverStyle.LENIENT && this.fieldValues.size() > 0) {
+      for (Entry<TTemporalField, Long> entry : this.fieldValues.entrySet()) {
+        TTemporalField field = entry.getKey();
+        if (field instanceof TChronoField && field.isTimeBased()) {
+          ((TChronoField) field).checkValidValue(entry.getValue());
+        }
+      }
+    }
+  }
+
+  private void resolveTime(long hod, long moh, long som, long nos) {
+
+    if (this.resolverStyle == TResolverStyle.LENIENT) {
+      long totalNanos = Math.multiplyExact(hod, 3600_000_000_000L);
+      totalNanos = Math.addExact(totalNanos, Math.multiplyExact(moh, 60_000_000_000L));
+      totalNanos = Math.addExact(totalNanos, Math.multiplyExact(som, 1_000_000_000L));
+      totalNanos = Math.addExact(totalNanos, nos);
+      int days = (int) Math.floorDiv(totalNanos, 86400_000_000_000L);
+      long nod = Math.floorMod(totalNanos, 86400_000_000_000L);
+      updateCheckConflict(TLocalTime.ofNanoOfDay(nod), TPeriod.ofDays(days));
+    } else {
+      int mohVal = MINUTE_OF_HOUR.checkValidIntValue(moh);
+      int nosVal = NANO_OF_SECOND.checkValidIntValue(nos);
+      if (this.resolverStyle == TResolverStyle.SMART && hod == 24 && mohVal == 0 && som == 0 && nosVal == 0) {
+        updateCheckConflict(TLocalTime.MIDNIGHT, TPeriod.ofDays(1));
+      } else {
+        int hodVal = HOUR_OF_DAY.checkValidIntValue(hod);
+        int somVal = SECOND_OF_MINUTE.checkValidIntValue(som);
+        updateCheckConflict(TLocalTime.of(hodVal, mohVal, somVal, nosVal), TPeriod.ZERO);
+      }
+    }
+  }
+
+  private void resolvePeriod() {
+
+    // add whole days if we have both date and time
+    if (this.date != null && this.time != null && this.excessDays.isZero() == false) {
+      this.date = this.date.plus(this.excessDays);
+      this.excessDays = TPeriod.ZERO;
+    }
+  }
+
+  private void resolveFractional() {
+
+    if (this.time == null && (this.fieldValues.containsKey(INSTANT_SECONDS)
+        || this.fieldValues.containsKey(SECOND_OF_DAY) || this.fieldValues.containsKey(SECOND_OF_MINUTE))) {
+      if (this.fieldValues.containsKey(NANO_OF_SECOND)) {
+        long nos = this.fieldValues.get(NANO_OF_SECOND);
+        this.fieldValues.put(MICRO_OF_SECOND, nos / 1000);
+        this.fieldValues.put(MILLI_OF_SECOND, nos / 1000000);
+      } else {
+        this.fieldValues.put(NANO_OF_SECOND, 0L);
+        this.fieldValues.put(MICRO_OF_SECOND, 0L);
+        this.fieldValues.put(MILLI_OF_SECOND, 0L);
+      }
+    }
+  }
+
+  private void resolveInstant() {
+
+    if (this.date != null && this.time != null) {
+      Long offsetSecs = this.fieldValues.get(OFFSET_SECONDS);
+      if (offsetSecs != null) {
+        TZoneOffset offset = TZoneOffset.ofTotalSeconds(offsetSecs.intValue());
+        long instant = this.date.atTime(this.time).atZone(offset).toEpochSecond();
+        this.fieldValues.put(INSTANT_SECONDS, instant);
+      } else {
+        if (this.zone != null) {
+          long instant = this.date.atTime(this.time).atZone(this.zone).toEpochSecond();
+          this.fieldValues.put(INSTANT_SECONDS, instant);
+        }
+      }
+    }
+  }
+
+  private void updateCheckConflict(TLocalTime timeToSet, TPeriod periodToSet) {
+
+    if (this.time != null) {
+      if (this.time.equals(timeToSet) == false) {
+        throw new TDateTimeException(
+            "Conflict found: Fields resolved to different times: " + this.time + " " + timeToSet);
+      }
+      if (this.excessDays.isZero() == false && periodToSet.isZero() == false
+          && this.excessDays.equals(periodToSet) == false) {
+        throw new TDateTimeException(
+            "Conflict found: Fields resolved to different excess periods: " + this.excessDays + " " + periodToSet);
+      } else {
+        this.excessDays = periodToSet;
+      }
+    } else {
+      this.time = timeToSet;
+      this.excessDays = periodToSet;
+    }
+  }
+
+  private void crossCheck() {
+
+    if (this.date != null) {
+      crossCheck(this.date);
+    }
+    if (this.time != null) {
+      crossCheck(this.time);
+      if (this.date != null && this.fieldValues.size() > 0) {
+        crossCheck(this.date.atTime(this.time));
+      }
+    }
+  }
+
+  private void crossCheck(TTemporalAccessor target) {
+
+    for (Iterator<Entry<TTemporalField, Long>> it = this.fieldValues.entrySet().iterator(); it.hasNext();) {
+      Entry<TTemporalField, Long> entry = it.next();
+      TTemporalField field = entry.getKey();
+      if (target.isSupported(field)) {
+        long val1;
+        try {
+          val1 = target.getLong(field);
+        } catch (RuntimeException ex) {
+          continue;
+        }
+        long val2 = entry.getValue();
+        if (val1 != val2) {
+          throw new TDateTimeException("Conflict found: Field " + field + " " + val1 + " differs from " + field + " "
+              + val2 + " derived from " + target);
+        }
+        it.remove();
+      }
+    }
+  }
+
+  @Override
+  public String toString() {
+
+    StringBuilder buf = new StringBuilder(64);
+    buf.append(this.fieldValues).append(',').append(this.chrono);
+    if (this.zone != null) {
+      buf.append(',').append(this.zone);
+    }
+    if (this.date != null || this.time != null) {
+      buf.append(" resolved to ");
+      if (this.date != null) {
+        buf.append(this.date);
+        if (this.time != null) {
+          buf.append('T').append(this.time);
+        }
+      } else {
+        buf.append(this.time);
+      }
+    }
+    return buf.toString();
+  }
+
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/time/format/TResolverStyle.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/time/format/TResolverStyle.java
@@ -1,0 +1,5 @@
+package org.teavm.classlib.java.time.format;
+
+public enum TResolverStyle {
+  STRICT, SMART, LENIENT;
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/time/format/TSignStyle.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/time/format/TSignStyle.java
@@ -1,0 +1,19 @@
+package org.teavm.classlib.java.time.format;
+
+public enum TSignStyle {
+  NORMAL, ALWAYS, NEVER, NOT_NEGATIVE, EXCEEDS_PAD;
+
+  boolean parse(boolean positive, boolean strict, boolean fixedWidth) {
+
+    switch (ordinal()) {
+      case 0:
+        return !positive || !strict;
+      case 1:
+      case 4:
+        return true;
+      default:
+        return !strict && !fixedWidth;
+    }
+  }
+
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/time/format/TTextStyle.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/time/format/TTextStyle.java
@@ -1,0 +1,46 @@
+package org.teavm.classlib.java.time.format;
+
+public enum TTextStyle {
+
+  FULL(2 /* Calendar.LONG_FORMAT */, 0), //
+  FULL_STANDALONE(32770 /* Calendar.LONG_STANDALONE */, 0), //
+  SHORT(1 /* Calendar.SHORT_FORMAT */, 1), //
+  SHORT_STANDALONE(32769 /* Calendar.SHORT_STANDALONE */, 1), //
+  NARROW(4 /* Calendar.NARROW_FORMAT */, 1), //
+  NARROW_STANDALONE(32772 /* Calendar.NARROW_STANDALONE */, 1);
+
+  private final int calendarStyle;
+
+  private final int zoneNameStyleIndex;
+
+  private TTextStyle(int calendarStyle, int zoneNameStyleIndex) {
+
+    this.calendarStyle = calendarStyle;
+    this.zoneNameStyleIndex = zoneNameStyleIndex;
+  }
+
+  public boolean isStandalone() {
+
+    return (ordinal() & 1) == 1;
+  }
+
+  public TTextStyle asStandalone() {
+
+    return TTextStyle.values()[ordinal() | 1];
+  }
+
+  public TTextStyle asNormal() {
+
+    return TTextStyle.values()[ordinal() & ~1];
+  }
+
+  int toCalendarStyle() {
+
+    return this.calendarStyle;
+  }
+
+  int zoneNameStyleIndex() {
+
+    return this.zoneNameStyleIndex;
+  }
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/time/temporal/TChronoField.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/time/temporal/TChronoField.java
@@ -1,0 +1,168 @@
+package org.teavm.classlib.java.time.temporal;
+
+import static org.teavm.classlib.java.time.temporal.TChronoUnit.DAYS;
+import static org.teavm.classlib.java.time.temporal.TChronoUnit.ERAS;
+import static org.teavm.classlib.java.time.temporal.TChronoUnit.FOREVER;
+import static org.teavm.classlib.java.time.temporal.TChronoUnit.HALF_DAYS;
+import static org.teavm.classlib.java.time.temporal.TChronoUnit.HOURS;
+import static org.teavm.classlib.java.time.temporal.TChronoUnit.MICROS;
+import static org.teavm.classlib.java.time.temporal.TChronoUnit.MILLIS;
+import static org.teavm.classlib.java.time.temporal.TChronoUnit.MINUTES;
+import static org.teavm.classlib.java.time.temporal.TChronoUnit.MONTHS;
+import static org.teavm.classlib.java.time.temporal.TChronoUnit.NANOS;
+import static org.teavm.classlib.java.time.temporal.TChronoUnit.SECONDS;
+import static org.teavm.classlib.java.time.temporal.TChronoUnit.WEEKS;
+import static org.teavm.classlib.java.time.temporal.TChronoUnit.YEARS;
+
+import org.teavm.classlib.java.time.TYear;
+import org.teavm.classlib.java.util.TLocale;
+import org.teavm.classlib.java.util.TObjects;
+
+public enum TChronoField implements TTemporalField {
+
+  NANO_OF_SECOND("NanoOfSecond", NANOS, SECONDS, TValueRange.of(0, 999_999_999)), //
+  NANO_OF_DAY("NanoOfDay", NANOS, DAYS, TValueRange.of(0, 86400L * 1000_000_000L - 1)), //
+  MICRO_OF_SECOND("MicroOfSecond", MICROS, SECONDS, TValueRange.of(0, 999_999)), //
+  MICRO_OF_DAY("MicroOfDay", MICROS, DAYS, TValueRange.of(0, 86400L * 1000_000L - 1)), //
+  MILLI_OF_SECOND("MilliOfSecond", MILLIS, SECONDS, TValueRange.of(0, 999)), //
+  MILLI_OF_DAY("MilliOfDay", MILLIS, DAYS, TValueRange.of(0, 86400L * 1000L - 1)), //
+  SECOND_OF_MINUTE("SecondOfMinute", SECONDS, MINUTES, TValueRange.of(0, 59), "second"), //
+  SECOND_OF_DAY("SecondOfDay", SECONDS, DAYS, TValueRange.of(0, 86400L - 1)), //
+  MINUTE_OF_HOUR("MinuteOfHour", MINUTES, HOURS, TValueRange.of(0, 59), "minute"), //
+  MINUTE_OF_DAY("MinuteOfDay", MINUTES, DAYS, TValueRange.of(0, (24 * 60) - 1)), //
+  HOUR_OF_AMPM("HourOfAmPm", HOURS, HALF_DAYS, TValueRange.of(0, 11)), //
+  CLOCK_HOUR_OF_AMPM("ClockHourOfAmPm", HOURS, HALF_DAYS, TValueRange.of(1, 12)), //
+  HOUR_OF_DAY("HourOfDay", HOURS, DAYS, TValueRange.of(0, 23), "hour"), //
+  CLOCK_HOUR_OF_DAY("ClockHourOfDay", HOURS, DAYS, TValueRange.of(1, 24)), //
+  AMPM_OF_DAY("AmPmOfDay", HALF_DAYS, DAYS, TValueRange.of(0, 1), "dayperiod"), //
+  DAY_OF_WEEK("DayOfWeek", DAYS, WEEKS, TValueRange.of(1, 7), "weekday"), //
+  ALIGNED_DAY_OF_WEEK_IN_MONTH("AlignedDayOfWeekInMonth", DAYS, WEEKS, TValueRange.of(1, 7)), //
+  ALIGNED_DAY_OF_WEEK_IN_YEAR("AlignedDayOfWeekInYear", DAYS, WEEKS, TValueRange.of(1, 7)), //
+  DAY_OF_MONTH("DayOfMonth", DAYS, MONTHS, TValueRange.of(1, 28, 31), "day"), //
+  DAY_OF_YEAR("DayOfYear", DAYS, YEARS, TValueRange.of(1, 365, 366)), //
+  EPOCH_DAY("EpochDay", DAYS, FOREVER, TValueRange.of(-365243219162L, 365241780471L)), //
+  ALIGNED_WEEK_OF_MONTH("AlignedWeekOfMonth", WEEKS, MONTHS, TValueRange.of(1, 4, 5)), //
+  ALIGNED_WEEK_OF_YEAR("AlignedWeekOfYear", WEEKS, YEARS, TValueRange.of(1, 53)), //
+  MONTH_OF_YEAR("MonthOfYear", MONTHS, YEARS, TValueRange.of(1, 12), "month"), //
+  PROLEPTIC_MONTH("ProlepticMonth", MONTHS, FOREVER, TValueRange.of(TYear.MIN_VALUE * 12L, TYear.MAX_VALUE * 12L + 11)), //
+  YEAR_OF_ERA("YearOfEra", YEARS, FOREVER, TValueRange.of(1, TYear.MAX_VALUE, TYear.MAX_VALUE + 1)), //
+  YEAR("Year", YEARS, FOREVER, TValueRange.of(TYear.MIN_VALUE, TYear.MAX_VALUE), "year"), //
+  ERA("Era", ERAS, FOREVER, TValueRange.of(0, 1), "era"), //
+  INSTANT_SECONDS("InstantSeconds", SECONDS, FOREVER, TValueRange.of(Long.MIN_VALUE, Long.MAX_VALUE)), //
+  OFFSET_SECONDS("OffsetSeconds", SECONDS, FOREVER, TValueRange.of(-18 * 3600, 18 * 3600));
+
+  private final String name;
+
+  private final TTemporalUnit baseUnit;
+
+  private final TTemporalUnit rangeUnit;
+
+  private final TValueRange range;
+
+  private final String displayNameKey;
+
+  private TChronoField(String name, TTemporalUnit baseUnit, TTemporalUnit rangeUnit, TValueRange range) {
+
+    this.name = name;
+    this.baseUnit = baseUnit;
+    this.rangeUnit = rangeUnit;
+    this.range = range;
+    this.displayNameKey = null;
+  }
+
+  private TChronoField(String name, TTemporalUnit baseUnit, TTemporalUnit rangeUnit, TValueRange range,
+      String displayNameKey) {
+
+    this.name = name;
+    this.baseUnit = baseUnit;
+    this.rangeUnit = rangeUnit;
+    this.range = range;
+    this.displayNameKey = displayNameKey;
+  }
+
+  @Override
+  public String getDisplayName(TLocale locale) {
+
+    TObjects.requireNonNull(locale, "locale");
+    if (this.displayNameKey == null) {
+      return this.name;
+    }
+    // TODO i18n will be tricky
+    // TResourceBundle rb = ...;
+    // String key = "field." + this.displayNameKey;
+    // return rb.containsKey(key) ? rb.getString(key) : this.name;
+    return this.name;
+  }
+
+  @Override
+  public TTemporalUnit getBaseUnit() {
+
+    return this.baseUnit;
+  }
+
+  @Override
+  public TTemporalUnit getRangeUnit() {
+
+    return this.rangeUnit;
+  }
+
+  @Override
+  public TValueRange range() {
+
+    return this.range;
+  }
+
+  @Override
+  public boolean isDateBased() {
+
+    return ordinal() >= DAY_OF_WEEK.ordinal() && ordinal() <= ERA.ordinal();
+  }
+
+  @Override
+  public boolean isTimeBased() {
+
+    return ordinal() < DAY_OF_WEEK.ordinal();
+  }
+
+  public long checkValidValue(long value) {
+
+    return range().checkValidValue(value, this);
+  }
+
+  public int checkValidIntValue(long value) {
+
+    return range().checkValidIntValue(value, this);
+  }
+
+  @Override
+  public boolean isSupportedBy(TTemporalAccessor temporal) {
+
+    return temporal.isSupported(this);
+  }
+
+  @Override
+  public TValueRange rangeRefinedBy(TTemporalAccessor temporal) {
+
+    return temporal.range(this);
+  }
+
+  @Override
+  public long getFrom(TTemporalAccessor temporal) {
+
+    return temporal.getLong(this);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public <R extends TTemporal> R adjustInto(R temporal, long newValue) {
+
+    return (R) temporal.with(this, newValue);
+  }
+
+  @Override
+  public String toString() {
+
+    return this.name;
+  }
+
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/time/temporal/TChronoUnit.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/time/temporal/TChronoUnit.java
@@ -1,0 +1,83 @@
+package org.teavm.classlib.java.time.temporal;
+
+import org.teavm.classlib.java.time.TDuration;
+
+public enum TChronoUnit implements TTemporalUnit {
+
+  NANOS("Nanos", TDuration.ofNanos(1)), //
+  MICROS("Micros", TDuration.ofNanos(1000)), //
+  MILLIS("Millis", TDuration.ofNanos(1000_000)), //
+  SECONDS("Seconds", TDuration.ofSeconds(1)), //
+  MINUTES("Minutes", TDuration.ofSeconds(60)), //
+  HOURS("Hours", TDuration.ofSeconds(3600)), //
+  HALF_DAYS("HalfDays", TDuration.ofSeconds(43200)), //
+  DAYS("Days", TDuration.ofSeconds(86400)), //
+  WEEKS("Weeks", TDuration.ofSeconds(7 * 86400L)), //
+  MONTHS("Months", TDuration.ofSeconds(31556952L / 12)), //
+  YEARS("Years", TDuration.ofSeconds(31556952L)), //
+  DECADES("Decades", TDuration.ofSeconds(31556952L * 10L)), //
+  CENTURIES("Centuries", TDuration.ofSeconds(31556952L * 100L)), //
+  MILLENNIA("Millennia", TDuration.ofSeconds(31556952L * 1000L)), //
+  ERAS("Eras", TDuration.ofSeconds(31556952L * 1000_000_000L)), //
+  FOREVER("Forever", TDuration.ofSeconds(Long.MAX_VALUE, 999_999_999));
+
+  private final String name;
+
+  private final TDuration duration;
+
+  private TChronoUnit(String name, TDuration estimatedDuration) {
+
+    this.name = name;
+    this.duration = estimatedDuration;
+  }
+
+  @Override
+  public TDuration getDuration() {
+
+    return this.duration;
+  }
+
+  @Override
+  public boolean isDurationEstimated() {
+
+    return compareTo(DAYS) >= 0;
+  }
+
+  @Override
+  public boolean isDateBased() {
+
+    return compareTo(DAYS) >= 0 && this != FOREVER;
+  }
+
+  @Override
+  public boolean isTimeBased() {
+
+    return compareTo(DAYS) < 0;
+  }
+
+  @Override
+  public boolean isSupportedBy(TTemporal temporal) {
+
+    return temporal.isSupported(this);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public <R extends TTemporal> R addTo(R temporal, long amount) {
+
+    return (R) temporal.plus(amount, this);
+  }
+
+  @Override
+  public long between(TTemporal temporal1Inclusive, TTemporal temporal2Exclusive) {
+
+    return temporal1Inclusive.until(temporal2Exclusive, this);
+  }
+
+  @Override
+  public String toString() {
+
+    return this.name;
+  }
+
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/time/temporal/TTemporal.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/time/temporal/TTemporal.java
@@ -1,0 +1,34 @@
+package org.teavm.classlib.java.time.temporal;
+
+public interface TTemporal extends TTemporalAccessor {
+
+  boolean isSupported(TTemporalUnit unit);
+
+  default TTemporal with(TTemporalAdjuster adjuster) {
+
+    return adjuster.adjustInto(this);
+  }
+
+  TTemporal with(TTemporalField field, long newValue);
+
+  default TTemporal plus(TTemporalAmount amount) {
+
+    return amount.addTo(this);
+  }
+
+  TTemporal plus(long amountToAdd, TTemporalUnit unit);
+
+  default TTemporal minus(TTemporalAmount amount) {
+
+    return amount.subtractFrom(this);
+  }
+
+  default TTemporal minus(long amountToSubtract, TTemporalUnit unit) {
+
+    return (amountToSubtract == Long.MIN_VALUE ? plus(Long.MAX_VALUE, unit).plus(1, unit)
+        : plus(-amountToSubtract, unit));
+  }
+
+  long until(TTemporal endExclusive, TTemporalUnit unit);
+
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/time/temporal/TTemporalAccessor.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/time/temporal/TTemporalAccessor.java
@@ -1,0 +1,46 @@
+package org.teavm.classlib.java.time.temporal;
+
+import org.teavm.classlib.java.time.TDateTimeException;
+import org.teavm.classlib.java.util.TObjects;
+
+public interface TTemporalAccessor {
+  boolean isSupported(TTemporalField field);
+
+  default TValueRange range(TTemporalField field) {
+
+    if (field instanceof TChronoField) {
+      if (isSupported(field)) {
+        return field.range();
+      }
+      throw new TUnsupportedTemporalTypeException("Unsupported field: " + field);
+    }
+    TObjects.requireNonNull(field, "field");
+    return field.rangeRefinedBy(this);
+  }
+
+  default int get(TTemporalField field) {
+
+    TValueRange range = range(field);
+    if (range.isIntValue() == false) {
+      throw new TUnsupportedTemporalTypeException(
+          "Invalid field " + field + " for get() method, use getLong() instead");
+    }
+    long value = getLong(field);
+    if (range.isValidValue(value) == false) {
+      throw new TDateTimeException("Invalid value for " + field + " (valid values " + range + "): " + value);
+    }
+    return (int) value;
+  }
+
+  long getLong(TTemporalField field);
+
+  default <R> R query(TTemporalQuery<R> query) {
+
+    if (query == TTemporalQueries.zoneId() || query == TTemporalQueries.chronology()
+        || query == TTemporalQueries.precision()) {
+      return null;
+    }
+    return query.queryFrom(this);
+  }
+
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/time/temporal/TTemporalAdjuster.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/time/temporal/TTemporalAdjuster.java
@@ -1,0 +1,6 @@
+package org.teavm.classlib.java.time.temporal;
+
+@FunctionalInterface
+public interface TTemporalAdjuster {
+  TTemporal adjustInto(TTemporal temporal);
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/time/temporal/TTemporalAdjusters.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/time/temporal/TTemporalAdjusters.java
@@ -1,0 +1,140 @@
+package org.teavm.classlib.java.time.temporal;
+
+import static org.teavm.classlib.java.time.temporal.TChronoField.DAY_OF_MONTH;
+import static org.teavm.classlib.java.time.temporal.TChronoField.DAY_OF_WEEK;
+import static org.teavm.classlib.java.time.temporal.TChronoField.DAY_OF_YEAR;
+import static org.teavm.classlib.java.time.temporal.TChronoUnit.DAYS;
+import static org.teavm.classlib.java.time.temporal.TChronoUnit.MONTHS;
+import static org.teavm.classlib.java.time.temporal.TChronoUnit.YEARS;
+
+import org.teavm.classlib.java.time.TDayOfWeek;
+import org.teavm.classlib.java.time.TLocalDate;
+import org.teavm.classlib.java.util.TObjects;
+import org.teavm.classlib.java.util.function.TUnaryOperator;
+
+public final class TTemporalAdjusters {
+  private TTemporalAdjusters() {
+
+  }
+
+  public static TTemporalAdjuster ofDateAdjuster(TUnaryOperator<TLocalDate> dateBasedAdjuster) {
+
+    TObjects.requireNonNull(dateBasedAdjuster, "dateBasedAdjuster");
+    return (temporal) -> {
+      TLocalDate input = TLocalDate.from(temporal);
+      TLocalDate output = dateBasedAdjuster.apply(input);
+      return temporal.with(output);
+    };
+  }
+
+  public static TTemporalAdjuster firstDayOfMonth() {
+
+    return (temporal) -> temporal.with(DAY_OF_MONTH, 1);
+  }
+
+  public static TTemporalAdjuster lastDayOfMonth() {
+
+    return (temporal) -> temporal.with(DAY_OF_MONTH, temporal.range(DAY_OF_MONTH).getMaximum());
+  }
+
+  public static TTemporalAdjuster firstDayOfNextMonth() {
+
+    return (temporal) -> temporal.with(DAY_OF_MONTH, 1).plus(1, MONTHS);
+  }
+
+  public static TTemporalAdjuster firstDayOfYear() {
+
+    return (temporal) -> temporal.with(DAY_OF_YEAR, 1);
+  }
+
+  public static TTemporalAdjuster lastDayOfYear() {
+
+    return (temporal) -> temporal.with(DAY_OF_YEAR, temporal.range(DAY_OF_YEAR).getMaximum());
+  }
+
+  public static TTemporalAdjuster firstDayOfNextYear() {
+
+    return (temporal) -> temporal.with(DAY_OF_YEAR, 1).plus(1, YEARS);
+  }
+
+  public static TTemporalAdjuster firstInMonth(TDayOfWeek dayOfWeek) {
+
+    return TTemporalAdjusters.dayOfWeekInMonth(1, dayOfWeek);
+  }
+
+  public static TTemporalAdjuster lastInMonth(TDayOfWeek dayOfWeek) {
+
+    return TTemporalAdjusters.dayOfWeekInMonth(-1, dayOfWeek);
+  }
+
+  public static TTemporalAdjuster dayOfWeekInMonth(int ordinal, TDayOfWeek dayOfWeek) {
+
+    TObjects.requireNonNull(dayOfWeek, "dayOfWeek");
+    int dowValue = dayOfWeek.getValue();
+    if (ordinal >= 0) {
+      return (temporal) -> {
+        TTemporal temp = temporal.with(DAY_OF_MONTH, 1);
+        int curDow = temp.get(DAY_OF_WEEK);
+        int dowDiff = (dowValue - curDow + 7) % 7;
+        dowDiff += (ordinal - 1L) * 7L;
+        return temp.plus(dowDiff, DAYS);
+      };
+    } else {
+      return (temporal) -> {
+        TTemporal temp = temporal.with(DAY_OF_MONTH, temporal.range(DAY_OF_MONTH).getMaximum());
+        int curDow = temp.get(DAY_OF_WEEK);
+        int daysDiff = dowValue - curDow;
+        daysDiff = (daysDiff == 0 ? 0 : (daysDiff > 0 ? daysDiff - 7 : daysDiff));
+        daysDiff -= (-ordinal - 1L) * 7L;
+        return temp.plus(daysDiff, DAYS);
+      };
+    }
+  }
+
+  public static TTemporalAdjuster next(TDayOfWeek dayOfWeek) {
+
+    int dowValue = dayOfWeek.getValue();
+    return (temporal) -> {
+      int calDow = temporal.get(DAY_OF_WEEK);
+      int daysDiff = calDow - dowValue;
+      return temporal.plus(daysDiff >= 0 ? 7 - daysDiff : -daysDiff, DAYS);
+    };
+  }
+
+  public static TTemporalAdjuster nextOrSame(TDayOfWeek dayOfWeek) {
+
+    int dowValue = dayOfWeek.getValue();
+    return (temporal) -> {
+      int calDow = temporal.get(DAY_OF_WEEK);
+      if (calDow == dowValue) {
+        return temporal;
+      }
+      int daysDiff = calDow - dowValue;
+      return temporal.plus(daysDiff >= 0 ? 7 - daysDiff : -daysDiff, DAYS);
+    };
+  }
+
+  public static TTemporalAdjuster previous(TDayOfWeek dayOfWeek) {
+
+    int dowValue = dayOfWeek.getValue();
+    return (temporal) -> {
+      int calDow = temporal.get(DAY_OF_WEEK);
+      int daysDiff = dowValue - calDow;
+      return temporal.minus(daysDiff >= 0 ? 7 - daysDiff : -daysDiff, DAYS);
+    };
+  }
+
+  public static TTemporalAdjuster previousOrSame(TDayOfWeek dayOfWeek) {
+
+    int dowValue = dayOfWeek.getValue();
+    return (temporal) -> {
+      int calDow = temporal.get(DAY_OF_WEEK);
+      if (calDow == dowValue) {
+        return temporal;
+      }
+      int daysDiff = dowValue - calDow;
+      return temporal.minus(daysDiff >= 0 ? 7 - daysDiff : -daysDiff, DAYS);
+    };
+  }
+
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/time/temporal/TTemporalAmount.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/time/temporal/TTemporalAmount.java
@@ -1,0 +1,14 @@
+package org.teavm.classlib.java.time.temporal;
+
+import java.util.List;
+
+public interface TTemporalAmount {
+
+  long get(TTemporalUnit unit);
+
+  List<TTemporalUnit> getUnits();
+
+  TTemporal addTo(TTemporal temporal);
+
+  TTemporal subtractFrom(TTemporal temporal);
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/time/temporal/TTemporalField.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/time/temporal/TTemporalField.java
@@ -1,0 +1,41 @@
+package org.teavm.classlib.java.time.temporal;
+
+import java.util.Map;
+import java.util.Objects;
+
+import org.teavm.classlib.java.time.format.TResolverStyle;
+import org.teavm.classlib.java.util.TLocale;
+
+public interface TTemporalField {
+
+  default String getDisplayName(TLocale locale) {
+
+    Objects.requireNonNull(locale, "locale");
+    return toString();
+  }
+
+  TTemporalUnit getBaseUnit();
+
+  TTemporalUnit getRangeUnit();
+
+  TValueRange range();
+
+  boolean isDateBased();
+
+  boolean isTimeBased();
+
+  boolean isSupportedBy(TTemporalAccessor temporal);
+
+  TValueRange rangeRefinedBy(TTemporalAccessor temporal);
+
+  long getFrom(TTemporalAccessor temporal);
+
+  <R extends TTemporal> R adjustInto(R temporal, long newValue);
+
+  default TTemporalAccessor resolve(Map<TTemporalField, Long> fieldValues, TTemporalAccessor partialTemporal,
+      TResolverStyle resolverStyle) {
+
+    return null;
+  }
+
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/time/temporal/TTemporalQueries.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/time/temporal/TTemporalQueries.java
@@ -1,0 +1,161 @@
+package org.teavm.classlib.java.time.temporal;
+
+import static org.teavm.classlib.java.time.temporal.TChronoField.EPOCH_DAY;
+import static org.teavm.classlib.java.time.temporal.TChronoField.NANO_OF_DAY;
+import static org.teavm.classlib.java.time.temporal.TChronoField.OFFSET_SECONDS;
+
+import org.teavm.classlib.java.time.TLocalDate;
+import org.teavm.classlib.java.time.TLocalTime;
+import org.teavm.classlib.java.time.TZoneId;
+import org.teavm.classlib.java.time.TZoneOffset;
+import org.teavm.classlib.java.time.chrono.TChronology;
+
+public final class TTemporalQueries {
+  private TTemporalQueries() {
+
+  }
+
+  public static TTemporalQuery<TZoneId> zoneId() {
+
+    return TTemporalQueries.ZONE_ID;
+  }
+
+  public static TTemporalQuery<TChronology> chronology() {
+
+    return TTemporalQueries.CHRONO;
+  }
+
+  public static TTemporalQuery<TTemporalUnit> precision() {
+
+    return TTemporalQueries.PRECISION;
+  }
+
+  public static TTemporalQuery<TZoneId> zone() {
+
+    return TTemporalQueries.ZONE;
+  }
+
+  public static TTemporalQuery<TZoneOffset> offset() {
+
+    return TTemporalQueries.OFFSET;
+  }
+
+  public static TTemporalQuery<TLocalDate> localDate() {
+
+    return TTemporalQueries.LOCAL_DATE;
+  }
+
+  public static TTemporalQuery<TLocalTime> localTime() {
+
+    return TTemporalQueries.LOCAL_TIME;
+  }
+
+  static final TTemporalQuery<TZoneId> ZONE_ID = new TTemporalQuery<TZoneId>() {
+    @Override
+    public TZoneId queryFrom(TTemporalAccessor temporal) {
+
+      return temporal.query(TTemporalQueries.ZONE_ID);
+    }
+
+    @Override
+    public String toString() {
+
+      return "ZoneId";
+    }
+  };
+
+  static final TTemporalQuery<TChronology> CHRONO = new TTemporalQuery<TChronology>() {
+    @Override
+    public TChronology queryFrom(TTemporalAccessor temporal) {
+
+      return temporal.query(TTemporalQueries.CHRONO);
+    }
+
+    @Override
+    public String toString() {
+
+      return "Chronology";
+    }
+  };
+
+  static final TTemporalQuery<TTemporalUnit> PRECISION = new TTemporalQuery<TTemporalUnit>() {
+    @Override
+    public TTemporalUnit queryFrom(TTemporalAccessor temporal) {
+
+      return temporal.query(TTemporalQueries.PRECISION);
+    }
+
+    @Override
+    public String toString() {
+
+      return "Precision";
+    }
+  };
+
+  static final TTemporalQuery<TZoneOffset> OFFSET = new TTemporalQuery<TZoneOffset>() {
+    @Override
+    public TZoneOffset queryFrom(TTemporalAccessor temporal) {
+
+      if (temporal.isSupported(OFFSET_SECONDS)) {
+        return TZoneOffset.ofTotalSeconds(temporal.get(OFFSET_SECONDS));
+      }
+      return null;
+    }
+
+    @Override
+    public String toString() {
+
+      return "ZoneOffset";
+    }
+  };
+
+  static final TTemporalQuery<TZoneId> ZONE = new TTemporalQuery<TZoneId>() {
+    @Override
+    public TZoneId queryFrom(TTemporalAccessor temporal) {
+
+      TZoneId zone = temporal.query(ZONE_ID);
+      return (zone != null ? zone : temporal.query(OFFSET));
+    }
+
+    @Override
+    public String toString() {
+
+      return "Zone";
+    }
+  };
+
+  static final TTemporalQuery<TLocalDate> LOCAL_DATE = new TTemporalQuery<TLocalDate>() {
+    @Override
+    public TLocalDate queryFrom(TTemporalAccessor temporal) {
+
+      if (temporal.isSupported(EPOCH_DAY)) {
+        return TLocalDate.ofEpochDay(temporal.getLong(EPOCH_DAY));
+      }
+      return null;
+    }
+
+    @Override
+    public String toString() {
+
+      return "LocalDate";
+    }
+  };
+
+  static final TTemporalQuery<TLocalTime> LOCAL_TIME = new TTemporalQuery<TLocalTime>() {
+    @Override
+    public TLocalTime queryFrom(TTemporalAccessor temporal) {
+
+      if (temporal.isSupported(NANO_OF_DAY)) {
+        return TLocalTime.ofNanoOfDay(temporal.getLong(NANO_OF_DAY));
+      }
+      return null;
+    }
+
+    @Override
+    public String toString() {
+
+      return "LocalTime";
+    }
+  };
+
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/time/temporal/TTemporalQuery.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/time/temporal/TTemporalQuery.java
@@ -1,0 +1,6 @@
+package org.teavm.classlib.java.time.temporal;
+
+@FunctionalInterface
+public interface TTemporalQuery<R> {
+  R queryFrom(TTemporalAccessor temporal);
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/time/temporal/TTemporalUnit.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/time/temporal/TTemporalUnit.java
@@ -1,0 +1,47 @@
+package org.teavm.classlib.java.time.temporal;
+
+import org.teavm.classlib.java.lang.TRuntimeException;
+import org.teavm.classlib.java.time.TDuration;
+import org.teavm.classlib.java.time.TLocalTime;
+
+public interface TTemporalUnit {
+
+  TDuration getDuration();
+
+  boolean isDurationEstimated();
+
+  boolean isDateBased();
+
+  boolean isTimeBased();
+
+  default boolean isSupportedBy(TTemporal temporal) {
+
+    if (temporal instanceof TLocalTime) {
+      return isTimeBased();
+    }
+    // if (temporal instanceof TChronoLocalDate) {
+    // return isDateBased();
+    // }
+    // if (temporal instanceof TChronoLocalDateTime || temporal instanceof TChronoZonedDateTime) {
+    // return true;
+    // }
+    try {
+      temporal.plus(1, this);
+      return true;
+    } catch (TUnsupportedTemporalTypeException ex) {
+      return false;
+    } catch (TRuntimeException ex) {
+      try {
+        temporal.plus(-1, this);
+        return true;
+      } catch (TRuntimeException ex2) {
+        return false;
+      }
+    }
+  }
+
+  <R extends TTemporal> R addTo(R temporal, long amount);
+
+  long between(TTemporal temporal1Inclusive, TTemporal temporal2Exclusive);
+
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/time/temporal/TUnsupportedTemporalTypeException.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/time/temporal/TUnsupportedTemporalTypeException.java
@@ -1,0 +1,18 @@
+package org.teavm.classlib.java.time.temporal;
+
+import org.teavm.classlib.java.lang.TThrowable;
+import org.teavm.classlib.java.time.TDateTimeException;
+
+public class TUnsupportedTemporalTypeException extends TDateTimeException {
+
+  public TUnsupportedTemporalTypeException(String message) {
+
+    super(message);
+  }
+
+  public TUnsupportedTemporalTypeException(String message, TThrowable cause) {
+
+    super(message, cause);
+  }
+
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/time/temporal/TValueRange.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/time/temporal/TValueRange.java
@@ -1,0 +1,153 @@
+package org.teavm.classlib.java.time.temporal;
+
+import org.teavm.classlib.java.io.TSerializable;
+import org.teavm.classlib.java.time.TDateTimeException;
+
+public final class TValueRange implements TSerializable {
+
+  private final long minSmallest;
+
+  private final long minLargest;
+
+  private final long maxSmallest;
+
+  private final long maxLargest;
+
+  private TValueRange(long minSmallest, long minLargest, long maxSmallest, long maxLargest) {
+
+    this.minSmallest = minSmallest;
+    this.minLargest = minLargest;
+    this.maxSmallest = maxSmallest;
+    this.maxLargest = maxLargest;
+  }
+
+  public boolean isFixed() {
+
+    return this.minSmallest == this.minLargest && this.maxSmallest == this.maxLargest;
+  }
+
+  public long getMinimum() {
+
+    return this.minSmallest;
+  }
+
+  public long getLargestMinimum() {
+
+    return this.minLargest;
+  }
+
+  public long getSmallestMaximum() {
+
+    return this.maxSmallest;
+  }
+
+  public long getMaximum() {
+
+    return this.maxLargest;
+  }
+
+  public boolean isIntValue() {
+
+    return getMinimum() >= Integer.MIN_VALUE && getMaximum() <= Integer.MAX_VALUE;
+  }
+
+  public boolean isValidValue(long value) {
+
+    return (value >= getMinimum() && value <= getMaximum());
+  }
+
+  public boolean isValidIntValue(long value) {
+
+    return isIntValue() && isValidValue(value);
+  }
+
+  public long checkValidValue(long value, TTemporalField field) {
+
+    if (isValidValue(value) == false) {
+      throw new TDateTimeException(genInvalidFieldMessage(field, value));
+    }
+    return value;
+  }
+
+  public int checkValidIntValue(long value, TTemporalField field) {
+
+    if (isValidIntValue(value) == false) {
+      throw new TDateTimeException(genInvalidFieldMessage(field, value));
+    }
+    return (int) value;
+  }
+
+  private String genInvalidFieldMessage(TTemporalField field, long value) {
+
+    if (field != null) {
+      return "Invalid value for " + field + " (valid values " + this + "): " + value;
+    } else {
+      return "Invalid value (valid values " + this + "): " + value;
+    }
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+
+    if (obj == this) {
+      return true;
+    }
+    if (obj instanceof TValueRange) {
+      TValueRange other = (TValueRange) obj;
+      return this.minSmallest == other.minSmallest && this.minLargest == other.minLargest
+          && this.maxSmallest == other.maxSmallest && this.maxLargest == other.maxLargest;
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+
+    long hash = this.minSmallest + (this.minLargest << 16) + (this.minLargest >> 48) + (this.maxSmallest << 32)
+        + (this.maxSmallest >> 32) + (this.maxLargest << 48) + (this.maxLargest >> 16);
+    return (int) (hash ^ (hash >>> 32));
+  }
+
+  @Override
+  public String toString() {
+
+    StringBuilder buf = new StringBuilder();
+    buf.append(this.minSmallest);
+    if (this.minSmallest != this.minLargest) {
+      buf.append('/').append(this.minLargest);
+    }
+    buf.append(" - ").append(this.maxSmallest);
+    if (this.maxSmallest != this.maxLargest) {
+      buf.append('/').append(this.maxLargest);
+    }
+    return buf.toString();
+  }
+
+  public static TValueRange of(long min, long max) {
+
+    if (min > max) {
+      throw new IllegalArgumentException("Minimum value must be less than maximum value");
+    }
+    return new TValueRange(min, min, max, max);
+  }
+
+  public static TValueRange of(long min, long maxSmallest, long maxLargest) {
+
+    return of(min, min, maxSmallest, maxLargest);
+  }
+
+  public static TValueRange of(long minSmallest, long minLargest, long maxSmallest, long maxLargest) {
+
+    if (minSmallest > minLargest) {
+      throw new IllegalArgumentException("Smallest minimum value must be less than largest minimum value");
+    }
+    if (maxSmallest > maxLargest) {
+      throw new IllegalArgumentException("Smallest maximum value must be less than largest maximum value");
+    }
+    if (minLargest > maxLargest) {
+      throw new IllegalArgumentException("Minimum value must be less than maximum value");
+    }
+    return new TValueRange(minSmallest, minLargest, maxSmallest, maxLargest);
+  }
+
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/time/zone/TZoneOffsetTransition.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/time/zone/TZoneOffsetTransition.java
@@ -1,0 +1,153 @@
+package org.teavm.classlib.java.time.zone;
+
+import java.util.List;
+
+import org.teavm.classlib.java.io.TSerializable;
+import org.teavm.classlib.java.lang.TComparable;
+import org.teavm.classlib.java.time.TDuration;
+import org.teavm.classlib.java.time.TInstant;
+import org.teavm.classlib.java.time.TLocalDateTime;
+import org.teavm.classlib.java.time.TZoneOffset;
+import org.teavm.classlib.java.util.TObjects;
+
+public class TZoneOffsetTransition implements TComparable<TZoneOffsetTransition>, TSerializable {
+
+  private final long epochSecond;
+
+  private final TLocalDateTime transition;
+
+  private final TZoneOffset offsetBefore;
+
+  private final TZoneOffset offsetAfter;
+
+  public static TZoneOffsetTransition of(TLocalDateTime transition, TZoneOffset offsetBefore, TZoneOffset offsetAfter) {
+
+    TObjects.requireNonNull(transition, "transition");
+    TObjects.requireNonNull(offsetBefore, "offsetBefore");
+    TObjects.requireNonNull(offsetAfter, "offsetAfter");
+    if (offsetBefore.equals(offsetAfter)) {
+      throw new IllegalArgumentException("Offsets must not be equal");
+    }
+    if (transition.getNano() != 0) {
+      throw new IllegalArgumentException("Nano-of-second must be zero");
+    }
+    return new TZoneOffsetTransition(transition, offsetBefore, offsetAfter);
+  }
+
+  TZoneOffsetTransition(TLocalDateTime transition, TZoneOffset offsetBefore, TZoneOffset offsetAfter) {
+
+    assert transition.getNano() == 0;
+    this.epochSecond = transition.toEpochSecond(offsetBefore);
+    this.transition = transition;
+    this.offsetBefore = offsetBefore;
+    this.offsetAfter = offsetAfter;
+  }
+
+  TZoneOffsetTransition(long epochSecond, TZoneOffset offsetBefore, TZoneOffset offsetAfter) {
+
+    this.epochSecond = epochSecond;
+    this.transition = TLocalDateTime.ofEpochSecond(epochSecond, 0, offsetBefore);
+    this.offsetBefore = offsetBefore;
+    this.offsetAfter = offsetAfter;
+  }
+
+  public TInstant getInstant() {
+
+    return TInstant.ofEpochSecond(this.epochSecond);
+  }
+
+  public long toEpochSecond() {
+
+    return this.epochSecond;
+  }
+
+  public TLocalDateTime getDateTimeBefore() {
+
+    return this.transition;
+  }
+
+  public TLocalDateTime getDateTimeAfter() {
+
+    return this.transition.plusSeconds(getDurationSeconds());
+  }
+
+  public TZoneOffset getOffsetBefore() {
+
+    return this.offsetBefore;
+  }
+
+  public TZoneOffset getOffsetAfter() {
+
+    return this.offsetAfter;
+  }
+
+  public TDuration getDuration() {
+
+    return TDuration.ofSeconds(getDurationSeconds());
+  }
+
+  private int getDurationSeconds() {
+
+    return getOffsetAfter().getTotalSeconds() - getOffsetBefore().getTotalSeconds();
+  }
+
+  public boolean isGap() {
+
+    return getOffsetAfter().getTotalSeconds() > getOffsetBefore().getTotalSeconds();
+  }
+
+  public boolean isOverlap() {
+
+    return getOffsetAfter().getTotalSeconds() < getOffsetBefore().getTotalSeconds();
+  }
+
+  public boolean isValidOffset(TZoneOffset offset) {
+
+    return isGap() ? false : (getOffsetBefore().equals(offset) || getOffsetAfter().equals(offset));
+  }
+
+  List<TZoneOffset> getValidOffsets() {
+
+    if (isGap()) {
+      return List.of();
+    }
+    return List.of(getOffsetBefore(), getOffsetAfter());
+  }
+
+  @Override
+  public int compareTo(TZoneOffsetTransition transition) {
+
+    return Long.compare(this.epochSecond, transition.epochSecond);
+  }
+
+  @Override
+  public boolean equals(Object other) {
+
+    if (other == this) {
+      return true;
+    }
+    if (other instanceof TZoneOffsetTransition) {
+      TZoneOffsetTransition d = (TZoneOffsetTransition) other;
+      return this.epochSecond == d.epochSecond && this.offsetBefore.equals(d.offsetBefore)
+          && this.offsetAfter.equals(d.offsetAfter);
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+
+    return this.transition.hashCode() ^ this.offsetBefore.hashCode()
+        ^ Integer.rotateLeft(this.offsetAfter.hashCode(), 16);
+  }
+
+  @Override
+  public String toString() {
+
+    StringBuilder buf = new StringBuilder();
+    buf.append("Transition[").append(isGap() ? "Gap" : "Overlap").append(" at ").append(this.transition)
+        .append(this.offsetBefore).append(" to ").append(this.offsetAfter).append(']');
+    return buf.toString();
+  }
+
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/time/zone/TZoneOffsetTransitionRule.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/time/zone/TZoneOffsetTransitionRule.java
@@ -1,0 +1,11 @@
+package org.teavm.classlib.java.time.zone;
+
+import org.teavm.classlib.java.io.TSerializable;
+
+public class TZoneOffsetTransitionRule implements TSerializable {
+  public TZoneOffsetTransition createTransition(int year) {
+
+    return null;
+  }
+
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/time/zone/TZoneRules.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/time/zone/TZoneRules.java
@@ -1,0 +1,444 @@
+package org.teavm.classlib.java.time.zone;
+
+import java.time.LocalDate;
+import java.time.zone.ZoneOffsetTransition;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import org.teavm.classlib.java.time.TDuration;
+import org.teavm.classlib.java.time.TInstant;
+import org.teavm.classlib.java.time.TLocalDateTime;
+import org.teavm.classlib.java.time.TYear;
+import org.teavm.classlib.java.time.TZoneOffset;
+import org.teavm.classlib.java.util.TObjects;
+
+public class TZoneRules {
+  private static final int LAST_CACHED_YEAR = 2100;
+
+  private final long[] standardTransitions;
+
+  private final TZoneOffset[] standardOffsets;
+
+  private final long[] savingsInstantTransitions;
+
+  private final TLocalDateTime[] savingsLocalTransitions;
+
+  private final TZoneOffset[] wallOffsets;
+
+  private final TZoneOffsetTransitionRule[] lastRules;
+
+  private final transient ConcurrentMap<Integer, TZoneOffsetTransition[]> lastRulesCache = new ConcurrentHashMap<Integer, TZoneOffsetTransition[]>();
+
+  private static final long[] EMPTY_LONG_ARRAY = new long[0];
+
+  private static final TZoneOffsetTransitionRule[] EMPTY_LASTRULES = new TZoneOffsetTransitionRule[0];
+
+  private static final TLocalDateTime[] EMPTY_LDT_ARRAY = new TLocalDateTime[0];
+
+  public static TZoneRules of(TZoneOffset baseStandardOffset, TZoneOffset baseWallOffset,
+      List<TZoneOffsetTransition> standardOffsetTransitionList, List<TZoneOffsetTransition> transitionList,
+      List<TZoneOffsetTransitionRule> lastRules) {
+
+    TObjects.requireNonNull(baseStandardOffset, "baseStandardOffset");
+    TObjects.requireNonNull(baseWallOffset, "baseWallOffset");
+    TObjects.requireNonNull(standardOffsetTransitionList, "standardOffsetTransitionList");
+    TObjects.requireNonNull(transitionList, "transitionList");
+    TObjects.requireNonNull(lastRules, "lastRules");
+    return new TZoneRules(baseStandardOffset, baseWallOffset, standardOffsetTransitionList, transitionList, lastRules);
+  }
+
+  public static TZoneRules of(TZoneOffset offset) {
+
+    TObjects.requireNonNull(offset, "offset");
+    return new TZoneRules(offset);
+  }
+
+  TZoneRules(TZoneOffset baseStandardOffset, TZoneOffset baseWallOffset,
+      List<TZoneOffsetTransition> standardOffsetTransitionList, List<TZoneOffsetTransition> transitionList,
+      List<TZoneOffsetTransitionRule> lastRules) {
+
+    super();
+
+    this.standardTransitions = new long[standardOffsetTransitionList.size()];
+
+    this.standardOffsets = new TZoneOffset[standardOffsetTransitionList.size() + 1];
+    this.standardOffsets[0] = baseStandardOffset;
+    for (int i = 0; i < standardOffsetTransitionList.size(); i++) {
+      this.standardTransitions[i] = standardOffsetTransitionList.get(i).toEpochSecond();
+      this.standardOffsets[i + 1] = standardOffsetTransitionList.get(i).getOffsetAfter();
+    }
+
+    List<TLocalDateTime> localTransitionList = new ArrayList<>();
+    List<TZoneOffset> localTransitionOffsetList = new ArrayList<>();
+    localTransitionOffsetList.add(baseWallOffset);
+    for (TZoneOffsetTransition trans : transitionList) {
+      if (trans.isGap()) {
+        localTransitionList.add(trans.getDateTimeBefore());
+        localTransitionList.add(trans.getDateTimeAfter());
+      } else {
+        localTransitionList.add(trans.getDateTimeAfter());
+        localTransitionList.add(trans.getDateTimeBefore());
+      }
+      localTransitionOffsetList.add(trans.getOffsetAfter());
+    }
+    this.savingsLocalTransitions = localTransitionList.toArray(new TLocalDateTime[localTransitionList.size()]);
+    this.wallOffsets = localTransitionOffsetList.toArray(new TZoneOffset[localTransitionOffsetList.size()]);
+
+    this.savingsInstantTransitions = new long[transitionList.size()];
+    for (int i = 0; i < transitionList.size(); i++) {
+      this.savingsInstantTransitions[i] = transitionList.get(i).toEpochSecond();
+    }
+
+    if (lastRules.size() > 16) {
+      throw new IllegalArgumentException("Too many transition rules");
+    }
+    this.lastRules = lastRules.toArray(new TZoneOffsetTransitionRule[lastRules.size()]);
+  }
+
+  private TZoneRules(long[] standardTransitions, TZoneOffset[] standardOffsets, long[] savingsInstantTransitions,
+      TZoneOffset[] wallOffsets, TZoneOffsetTransitionRule[] lastRules) {
+
+    super();
+
+    this.standardTransitions = standardTransitions;
+    this.standardOffsets = standardOffsets;
+    this.savingsInstantTransitions = savingsInstantTransitions;
+    this.wallOffsets = wallOffsets;
+    this.lastRules = lastRules;
+
+    if (savingsInstantTransitions.length == 0) {
+      this.savingsLocalTransitions = EMPTY_LDT_ARRAY;
+    } else {
+      // convert savings transitions to locals
+      List<TLocalDateTime> localTransitionList = new ArrayList<>();
+      for (int i = 0; i < savingsInstantTransitions.length; i++) {
+        TZoneOffset before = wallOffsets[i];
+        TZoneOffset after = wallOffsets[i + 1];
+        TZoneOffsetTransition trans = new TZoneOffsetTransition(savingsInstantTransitions[i], before, after);
+        if (trans.isGap()) {
+          localTransitionList.add(trans.getDateTimeBefore());
+          localTransitionList.add(trans.getDateTimeAfter());
+        } else {
+          localTransitionList.add(trans.getDateTimeAfter());
+          localTransitionList.add(trans.getDateTimeBefore());
+        }
+      }
+      this.savingsLocalTransitions = localTransitionList.toArray(new TLocalDateTime[localTransitionList.size()]);
+    }
+  }
+
+  private TZoneRules(TZoneOffset offset) {
+
+    this.standardOffsets = new TZoneOffset[1];
+    this.standardOffsets[0] = offset;
+    this.standardTransitions = EMPTY_LONG_ARRAY;
+    this.savingsInstantTransitions = EMPTY_LONG_ARRAY;
+    this.savingsLocalTransitions = EMPTY_LDT_ARRAY;
+    this.wallOffsets = this.standardOffsets;
+    this.lastRules = EMPTY_LASTRULES;
+  }
+
+  public boolean isFixedOffset() {
+
+    return this.savingsInstantTransitions.length == 0;
+  }
+
+  public TZoneOffset getOffset(TInstant instant) {
+
+    if (this.savingsInstantTransitions.length == 0) {
+      return this.standardOffsets[0];
+    }
+    long epochSec = instant.getEpochSecond();
+    // check if using last rules
+    if (this.lastRules.length > 0
+        && epochSec > this.savingsInstantTransitions[this.savingsInstantTransitions.length - 1]) {
+      int year = findYear(epochSec, this.wallOffsets[this.wallOffsets.length - 1]);
+      TZoneOffsetTransition[] transArray = findTransitionArray(year);
+      TZoneOffsetTransition trans = null;
+      for (int i = 0; i < transArray.length; i++) {
+        trans = transArray[i];
+        if (epochSec < trans.toEpochSecond()) {
+          return trans.getOffsetBefore();
+        }
+      }
+      return trans.getOffsetAfter();
+    }
+
+    int index = Arrays.binarySearch(this.savingsInstantTransitions, epochSec);
+    if (index < 0) {
+      index = -index - 2;
+    }
+    return this.wallOffsets[index + 1];
+  }
+
+  public TZoneOffset getOffset(TLocalDateTime localDateTime) {
+
+    Object info = getOffsetInfo(localDateTime);
+    if (info instanceof TZoneOffsetTransition) {
+      return ((TZoneOffsetTransition) info).getOffsetBefore();
+    }
+    return (TZoneOffset) info;
+  }
+
+  public List<TZoneOffset> getValidOffsets(TLocalDateTime localDateTime) {
+
+    Object info = getOffsetInfo(localDateTime);
+    if (info instanceof TZoneOffsetTransition) {
+      return ((TZoneOffsetTransition) info).getValidOffsets();
+    }
+    return Collections.singletonList((TZoneOffset) info);
+  }
+
+  public TZoneOffsetTransition getTransition(TLocalDateTime localDateTime) {
+
+    Object info = getOffsetInfo(localDateTime);
+    return (info instanceof TZoneOffsetTransition ? (TZoneOffsetTransition) info : null);
+  }
+
+  private Object getOffsetInfo(TLocalDateTime dt) {
+
+    if (this.savingsInstantTransitions.length == 0) {
+      return this.standardOffsets[0];
+    }
+    if (this.lastRules.length > 0
+        && dt.isAfter(this.savingsLocalTransitions[this.savingsLocalTransitions.length - 1])) {
+      TZoneOffsetTransition[] transArray = findTransitionArray(dt.getYear());
+      Object info = null;
+      for (TZoneOffsetTransition trans : transArray) {
+        info = findOffsetInfo(dt, trans);
+        if (info instanceof ZoneOffsetTransition || info.equals(trans.getOffsetBefore())) {
+          return info;
+        }
+      }
+      return info;
+    }
+
+    int index = Arrays.binarySearch(this.savingsLocalTransitions, dt);
+    if (index == -1) {
+      return this.wallOffsets[0];
+    }
+    if (index < 0) {
+      index = -index - 2;
+    } else if (index < this.savingsLocalTransitions.length - 1
+        && this.savingsLocalTransitions[index].equals(this.savingsLocalTransitions[index + 1])) {
+      index++;
+    }
+    if ((index & 1) == 0) {
+      TLocalDateTime dtBefore = this.savingsLocalTransitions[index];
+      TLocalDateTime dtAfter = this.savingsLocalTransitions[index + 1];
+      TZoneOffset offsetBefore = this.wallOffsets[index / 2];
+      TZoneOffset offsetAfter = this.wallOffsets[index / 2 + 1];
+      if (offsetAfter.getTotalSeconds() > offsetBefore.getTotalSeconds()) {
+        return new TZoneOffsetTransition(dtBefore, offsetBefore, offsetAfter);
+      } else {
+        return new TZoneOffsetTransition(dtAfter, offsetBefore, offsetAfter);
+      }
+    } else {
+      return this.wallOffsets[index / 2 + 1];
+    }
+  }
+
+  private Object findOffsetInfo(TLocalDateTime dt, TZoneOffsetTransition trans) {
+
+    TLocalDateTime localTransition = trans.getDateTimeBefore();
+    if (trans.isGap()) {
+      if (dt.isBefore(localTransition)) {
+        return trans.getOffsetBefore();
+      }
+      if (dt.isBefore(trans.getDateTimeAfter())) {
+        return trans;
+      } else {
+        return trans.getOffsetAfter();
+      }
+    } else {
+      if (dt.isBefore(localTransition) == false) {
+        return trans.getOffsetAfter();
+      }
+      if (dt.isBefore(trans.getDateTimeAfter())) {
+        return trans.getOffsetBefore();
+      } else {
+        return trans;
+      }
+    }
+  }
+
+  private TZoneOffsetTransition[] findTransitionArray(int year) {
+
+    Integer yearObj = year;
+    TZoneOffsetTransition[] transArray = this.lastRulesCache.get(yearObj);
+    if (transArray != null) {
+      return transArray;
+    }
+    TZoneOffsetTransitionRule[] ruleArray = this.lastRules;
+    transArray = new TZoneOffsetTransition[ruleArray.length];
+    for (int i = 0; i < ruleArray.length; i++) {
+      transArray[i] = ruleArray[i].createTransition(year);
+    }
+    if (year < LAST_CACHED_YEAR) {
+      this.lastRulesCache.putIfAbsent(yearObj, transArray);
+    }
+    return transArray;
+  }
+
+  public TZoneOffset getStandardOffset(TInstant instant) {
+
+    if (this.savingsInstantTransitions.length == 0) {
+      return this.standardOffsets[0];
+    }
+    long epochSec = instant.getEpochSecond();
+    int index = Arrays.binarySearch(this.standardTransitions, epochSec);
+    if (index < 0) {
+      index = -index - 2;
+    }
+    return this.standardOffsets[index + 1];
+  }
+
+  public TDuration getDaylightSavings(TInstant instant) {
+
+    if (this.savingsInstantTransitions.length == 0) {
+      return TDuration.ZERO;
+    }
+    TZoneOffset standardOffset = getStandardOffset(instant);
+    TZoneOffset actualOffset = getOffset(instant);
+    return TDuration.ofSeconds(actualOffset.getTotalSeconds() - standardOffset.getTotalSeconds());
+  }
+
+  public boolean isDaylightSavings(TInstant instant) {
+
+    return (getStandardOffset(instant).equals(getOffset(instant)) == false);
+  }
+
+  public boolean isValidOffset(TLocalDateTime localDateTime, TZoneOffset offset) {
+
+    return getValidOffsets(localDateTime).contains(offset);
+  }
+
+  public TZoneOffsetTransition nextTransition(TInstant instant) {
+
+    if (this.savingsInstantTransitions.length == 0) {
+      return null;
+    }
+    long epochSec = instant.getEpochSecond();
+    if (epochSec >= this.savingsInstantTransitions[this.savingsInstantTransitions.length - 1]) {
+      if (this.lastRules.length == 0) {
+        return null;
+      }
+      int year = findYear(epochSec, this.wallOffsets[this.wallOffsets.length - 1]);
+      TZoneOffsetTransition[] transArray = findTransitionArray(year);
+      for (TZoneOffsetTransition trans : transArray) {
+        if (epochSec < trans.toEpochSecond()) {
+          return trans;
+        }
+      }
+      if (year < TYear.MAX_VALUE) {
+        transArray = findTransitionArray(year + 1);
+        return transArray[0];
+      }
+      return null;
+    }
+
+    int index = Arrays.binarySearch(this.savingsInstantTransitions, epochSec);
+    if (index < 0) {
+      index = -index - 1;
+    } else {
+      index += 1;
+    }
+    return new TZoneOffsetTransition(this.savingsInstantTransitions[index], this.wallOffsets[index],
+        this.wallOffsets[index + 1]);
+  }
+
+  public TZoneOffsetTransition previousTransition(TInstant instant) {
+
+    if (this.savingsInstantTransitions.length == 0) {
+      return null;
+    }
+    long epochSec = instant.getEpochSecond();
+    if (instant.getNano() > 0 && epochSec < Long.MAX_VALUE) {
+      epochSec += 1;
+    }
+
+    long lastHistoric = this.savingsInstantTransitions[this.savingsInstantTransitions.length - 1];
+    if (this.lastRules.length > 0 && epochSec > lastHistoric) {
+      TZoneOffset lastHistoricOffset = this.wallOffsets[this.wallOffsets.length - 1];
+      int year = findYear(epochSec, lastHistoricOffset);
+      TZoneOffsetTransition[] transArray = findTransitionArray(year);
+      for (int i = transArray.length - 1; i >= 0; i--) {
+        if (epochSec > transArray[i].toEpochSecond()) {
+          return transArray[i];
+        }
+      }
+      int lastHistoricYear = findYear(lastHistoric, lastHistoricOffset);
+      if (--year > lastHistoricYear) {
+        transArray = findTransitionArray(year);
+        return transArray[transArray.length - 1];
+      }
+    }
+
+    int index = Arrays.binarySearch(this.savingsInstantTransitions, epochSec);
+    if (index < 0) {
+      index = -index - 1;
+    }
+    if (index <= 0) {
+      return null;
+    }
+    return new TZoneOffsetTransition(this.savingsInstantTransitions[index - 1], this.wallOffsets[index - 1],
+        this.wallOffsets[index]);
+  }
+
+  private int findYear(long epochSecond, TZoneOffset offset) {
+
+    long localSecond = epochSecond + offset.getTotalSeconds();
+    long localEpochDay = Math.floorDiv(localSecond, 86400);
+    return LocalDate.ofEpochDay(localEpochDay).getYear();
+  }
+
+  public List<TZoneOffsetTransition> getTransitions() {
+
+    List<TZoneOffsetTransition> list = new ArrayList<>();
+    for (int i = 0; i < this.savingsInstantTransitions.length; i++) {
+      list.add(
+          new TZoneOffsetTransition(this.savingsInstantTransitions[i], this.wallOffsets[i], this.wallOffsets[i + 1]));
+    }
+    return Collections.unmodifiableList(list);
+  }
+
+  public List<TZoneOffsetTransitionRule> getTransitionRules() {
+
+    return List.of(this.lastRules);
+  }
+
+  @Override
+  public boolean equals(Object otherRules) {
+
+    if (this == otherRules) {
+      return true;
+    }
+    if (otherRules instanceof TZoneRules) {
+      TZoneRules other = (TZoneRules) otherRules;
+      return Arrays.equals(this.standardTransitions, other.standardTransitions)
+          && Arrays.equals(this.standardOffsets, other.standardOffsets)
+          && Arrays.equals(this.savingsInstantTransitions, other.savingsInstantTransitions)
+          && Arrays.equals(this.wallOffsets, other.wallOffsets) && Arrays.equals(this.lastRules, other.lastRules);
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+
+    return Arrays.hashCode(this.standardTransitions) ^ Arrays.hashCode(this.standardOffsets)
+        ^ Arrays.hashCode(this.savingsInstantTransitions) ^ Arrays.hashCode(this.wallOffsets)
+        ^ Arrays.hashCode(this.lastRules);
+  }
+
+  @Override
+  public String toString() {
+
+    return "ZoneRules[currentStandardOffset=" + this.standardOffsets[this.standardOffsets.length - 1] + "]";
+  }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -263,7 +263,7 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <version>2.21.0</version>
         </plugin>
-        <plugin>
+        <!--plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-checkstyle-plugin</artifactId>
           <version>2.16</version>
@@ -286,7 +286,7 @@
             <propertyExpansion>config_loc=${basedir}/..</propertyExpansion>
             <configLocation>../checkstyle.xml</configLocation>
           </configuration>
-        </plugin>
+        </plugin-->
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>


### PR DESCRIPTION
WIP for #451

TODOs:
* [ ] TMath needs to be extended to support required calculation methods (at least as dummy emulation).
* [ ] I disabled checkstyle as it is way too pick. If that is seriously a requirement, someone else need to help. Further I will and can not add copyright headers stating that the code is written by Alexey Andreev. However, I have an old Email from jodastephen that I can copy his code from https://github.com/ThreeTen/threetenbp
* [ ] for the design I am thinking about deleting the entire format package, remove support for custom format/parse methods and hardcode ISO parsing and formatting to keep the performance and size fine for the browser. WDYT?