### PR TITLE
Collection spliterator that does not depend on how the list implementation overrides spliterator()

### DIFF
--- a/classlib/src/main/java/org/teavm/classlib/java/util/TSpliterators.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/util/TSpliterators.java
@@ -57,10 +57,9 @@ public class TSpliterators {
             }
         };
     }
-
-    @SuppressWarnings("unchecked")
+    
     public static <T> TSpliterator<T> spliterator(Collection<? extends T> c, int characteristics) {
-        return ((TCollection<T>) c).spliterator();
+        return spliterator(c.iterator(), c.size(), characteristics);
     }
 
     public static TSpliterator.OfInt spliterator(int[] array, int additionalCharacteristics) {


### PR DESCRIPTION
In pull request https://github.com/konsoletyper/teavm/pull/443 I added some methods for the Spliterators class. This was fine for most use cases, but I've found that some of the many list implementations in Guava and Apache Collections-Commons override spliterator() (which is normally a default implementation in Collection). Some of these refer back to the utility method in Spliterators, causing a stack overflow. 

I've changed this by redirecting TSpliterators.spliterator(Collection) to the version that takes an iterator. This makes the behavior no longer dependent on whatever way the list implements List.spliterator().

This was clearly an oversight on my part, but porting an existing application to TeaVM unearths many of such issues when using libraries, especially since the Java standard library is usage and those libraries tend to rely on its exact behavior.