### PR TITLE
add HTMLElement.innerText

### DIFF
--- a/jso/apis/src/main/java/org/teavm/jso/dom/html/HTMLElement.java
+++ b/jso/apis/src/main/java/org/teavm/jso/dom/html/HTMLElement.java
@@ -136,6 +136,12 @@ public interface HTMLElement extends Element, ElementCSSInlineStyle, EventTarget
     @JSProperty
     void setInnerHTML(String content);
 
+    @JSProperty
+    String getInnerText();
+
+    @JSProperty
+    void setInnerText(String content);
+
     TextRectangle getBoundingClientRect();
 
     @JSProperty


### PR DESCRIPTION
This adds the HTMLElement.innerText property, as specified in https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/innerText .