### PR TITLE
Java 9 collection factories

### DIFF
--- a/classlib/src/main/java/org/teavm/classlib/java/util/CollectionsFactory.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/util/CollectionsFactory.java
@@ -1,0 +1,92 @@
+/*
+ *  Copyright 2014 Alexey Andreev.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.teavm.classlib.java.util;
+
+import static org.teavm.classlib.java.util.TObjects.requireNonNull;
+import org.teavm.classlib.java.lang.TIllegalArgumentException;
+import org.teavm.classlib.java.lang.TNullPointerException;
+
+/**
+ * Factory-methods for List/Set/Map.of(...).
+ */
+class CollectionsFactory {
+
+    private CollectionsFactory() {
+    }
+
+    /**
+     * Create an immutable list for the {@code List.of(...)} factory methods.
+     *
+     * @throws TNullPointerException if any element is null
+     */
+    @SafeVarargs
+    static <E> TList<E> createList(E... elements) {
+        if (elements == null || elements.length == 0) {
+            return TCollections.emptyList();
+        }
+
+        final TList<E> list = new TArrayList<>();
+        for (E element : elements) {
+            list.add(requireNonNull(element, "element"));
+        }
+
+        return TCollections.unmodifiableList(list);
+    }
+
+    /**
+     * Create an immutable set for the {@code Set.of(...)} factory methods.
+     *
+     * @throws TNullPointerException     if any element is null
+     * @throws TIllegalArgumentException if duplicate elements are given
+     */
+    @SafeVarargs
+    static <E> TSet<E> createSet(E... elements) {
+        if (elements == null || elements.length == 0) {
+            return TCollections.emptySet();
+        }
+
+        final TSet<E> set = new THashSet<>();
+        for (E element : elements) {
+            if (!set.add(requireNonNull(element, "element"))) {
+                throw new TIllegalArgumentException("duplicate element: " + element);
+            }
+        }
+
+        return TCollections.unmodifiableSet(set);
+    }
+
+    /**
+     * Create an immutable set for the {@code Map.of(...)} and {@code Map.ofEntries(...)} factory methods.
+     *
+     * @throws TNullPointerException     if any key or value is null
+     * @throws TIllegalArgumentException if duplicate keys are given
+     */
+    @SafeVarargs
+    static <K, V> TMap<K, V> createMap(TMap.Entry<K, V>... entries) {
+        if (entries == null || entries.length == 0) {
+            return TCollections.emptyMap();
+        }
+
+        final TMap<K, V> map = new THashMap<>();
+        for (TMap.Entry<K, V> entry : entries) {
+            if (map.put(requireNonNull(entry.getKey(), "key"), requireNonNull(entry.getValue(), "value")) != null) {
+                throw new TIllegalArgumentException("duplicate key: " + entry.getKey());
+            }
+        }
+
+        return TCollections.unmodifiableMap(map);
+    }
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/util/TList.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/util/TList.java
@@ -15,6 +15,7 @@
  */
 package org.teavm.classlib.java.util;
 
+import java.util.Arrays;
 import org.teavm.classlib.java.util.function.TUnaryOperator;
 
 public interface TList<E> extends TCollection<E> {
@@ -95,6 +96,8 @@ public interface TList<E> extends TCollection<E> {
 
     @SafeVarargs
     static <E> TList<E> of(E... elements) {
-        return CollectionsFactory.createList(elements);
+        // the returned list reuses the given array
+        // create a copy to prevent modifying the list by modifying the original array
+        return CollectionsFactory.createList(Arrays.copyOf(elements, elements.length));
     }
 }

--- a/classlib/src/main/java/org/teavm/classlib/java/util/TList.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/util/TList.java
@@ -48,4 +48,53 @@ public interface TList<E> extends TCollection<E> {
     default void sort(TComparator<? super E> c) {
         TCollections.sort(this, c);
     }
+
+    static <E> TList<E> of() {
+        return TCollections.emptyList();
+    }
+
+    static <E> TList<E> of(E e) {
+        return CollectionsFactory.createList(e);
+    }
+
+    static <E> TList<E> of(E e1, E e2) {
+        return CollectionsFactory.createList(e1, e2);
+    }
+
+    static <E> TList<E> of(E e1, E e2, E e3) {
+        return CollectionsFactory.createList(e1, e2, e3);
+    }
+
+    static <E> TList<E> of(E e1, E e2, E e3, E e4) {
+        return CollectionsFactory.createList(e1, e2, e3, e4);
+    }
+
+    static <E> TList<E> of(E e1, E e2, E e3, E e4, E e5) {
+        return CollectionsFactory.createList(e1, e2, e3, e4, e5);
+    }
+
+    static <E> TList<E> of(E e1, E e2, E e3, E e4, E e5, E e6) {
+        return CollectionsFactory.createList(e1, e2, e3, e4, e5, e6);
+    }
+
+    static <E> TList<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7) {
+        return CollectionsFactory.createList(e1, e2, e3, e4, e5, e6, e7);
+    }
+
+    static <E> TList<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7, E e8) {
+        return CollectionsFactory.createList(e1, e2, e3, e4, e5, e6, e7, e8);
+    }
+
+    static <E> TList<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7, E e8, E e9) {
+        return CollectionsFactory.createList(e1, e2, e3, e4, e5, e6, e7, e8, e9);
+    }
+
+    static <E> TList<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7, E e8, E e9, E e10) {
+        return CollectionsFactory.createList(e1, e2, e3, e4, e5, e6, e7, e8, e9, e10);
+    }
+
+    @SafeVarargs
+    static <E> TList<E> of(E... elements) {
+        return CollectionsFactory.createList(elements);
+    }
 }

--- a/classlib/src/main/java/org/teavm/classlib/java/util/TMap.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/util/TMap.java
@@ -15,11 +15,11 @@
  */
 package org.teavm.classlib.java.util;
 
-import static org.teavm.classlib.java.util.TObjects.requireNonNull;
+import static java.util.Objects.requireNonNull;
 import java.util.Objects;
+import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Function;
-import org.teavm.classlib.java.util.function.TBiConsumer;
 
 public interface TMap<K, V> {
     interface Entry<K1, V1> {
@@ -146,7 +146,7 @@ public interface TMap<K, V> {
         return newValue;
     }
 
-    default void forEach(TBiConsumer<? super K, ? super V> action) {
+    default void forEach(BiConsumer<? super K, ? super V> action) {
         final TIterator<Entry<K, V>> iterator = entrySet().iterator();
         while (iterator.hasNext()) {
             final Entry<K, V> entry = iterator.next();
@@ -160,7 +160,7 @@ public interface TMap<K, V> {
 
     static <K, V> TMap<K, V> of(K k1, V v1) {
         return CollectionsFactory.createMap(
-                new TMapEntry<>(requireNonNull(k1), requireNonNull(v1))
+                entry(k1, v1)
         );
     }
 

--- a/classlib/src/main/java/org/teavm/classlib/java/util/TMap.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/util/TMap.java
@@ -15,8 +15,11 @@
  */
 package org.teavm.classlib.java.util;
 
+import static org.teavm.classlib.java.util.TObjects.requireNonNull;
+import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.function.Function;
+import org.teavm.classlib.java.util.function.TBiConsumer;
 
 public interface TMap<K, V> {
     interface Entry<K1, V1> {
@@ -45,6 +48,14 @@ public interface TMap<K, V> {
 
     V remove(Object key);
 
+    default boolean remove(Object key, Object value) {
+        if (containsKey(key) && Objects.equals(get(key), value)) {
+            remove(key);
+            return true;
+        }
+        return false;
+    }
+
     void putAll(TMap<? extends K, ? extends V> m);
 
     void clear();
@@ -54,7 +65,7 @@ public interface TMap<K, V> {
     TCollection<V> values();
 
     TSet<Entry<K, V>> entrySet();
-    
+
     default boolean replace(K key, V value, V newValue) {
         if (containsKey(key) && TObjects.equals(get(key), value)) {
             put(key, newValue);
@@ -133,5 +144,135 @@ public interface TMap<K, V> {
             put(key, newValue);
         }
         return newValue;
+    }
+
+    default void forEach(TBiConsumer<? super K, ? super V> action) {
+        final TIterator<Entry<K, V>> iterator = entrySet().iterator();
+        while (iterator.hasNext()) {
+            final Entry<K, V> entry = iterator.next();
+            action.accept(entry.getKey(), entry.getValue());
+        }
+    }
+
+    static <K, V> TMap<K, V> of() {
+        return TCollections.emptyMap();
+    }
+
+    static <K, V> TMap<K, V> of(K k1, V v1) {
+        return CollectionsFactory.createMap(
+                new TMapEntry<>(requireNonNull(k1), requireNonNull(v1))
+        );
+    }
+
+    static <K, V> TMap<K, V> of(K k1, V v1, K k2, V v2) {
+        return CollectionsFactory.createMap(
+                entry(k1, v1),
+                entry(k2, v2)
+        );
+    }
+
+    static <K, V> TMap<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3) {
+        return CollectionsFactory.createMap(
+                entry(k1, v1),
+                entry(k2, v2),
+                entry(k3, v3)
+        );
+    }
+
+    static <K, V> TMap<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4) {
+        return CollectionsFactory.createMap(
+                entry(k1, v1),
+                entry(k2, v2),
+                entry(k3, v3),
+                entry(k4, v4)
+        );
+    }
+
+    static <K, V> TMap<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5) {
+        return CollectionsFactory.createMap(
+                entry(k1, v1),
+                entry(k2, v2),
+                entry(k3, v3),
+                entry(k4, v4),
+                entry(k5, v5)
+        );
+    }
+
+    static <K, V> TMap<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5, K k6, V v6) {
+        return CollectionsFactory.createMap(
+                entry(k1, v1),
+                entry(k2, v2),
+                entry(k3, v3),
+                entry(k4, v4),
+                entry(k5, v5),
+                entry(k6, v6)
+        );
+    }
+
+    static <K, V> TMap<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5,
+            K k6, V v6, K k7, V v7) {
+        return CollectionsFactory.createMap(
+                entry(k1, v1),
+                entry(k2, v2),
+                entry(k3, v3),
+                entry(k4, v4),
+                entry(k5, v5),
+                entry(k6, v6),
+                entry(k7, v7)
+        );
+    }
+
+    static <K, V> TMap<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5,
+            K k6, V v6, K k7, V v7, K k8, V v8) {
+        return CollectionsFactory.createMap(
+                entry(k1, v1),
+                entry(k2, v2),
+                entry(k3, v3),
+                entry(k4, v4),
+                entry(k5, v5),
+                entry(k6, v6),
+                entry(k7, v7),
+                entry(k8, v8)
+        );
+    }
+
+    static <K, V> TMap<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5,
+            K k6, V v6, K k7, V v7, K k8, V v8, K k9, V v9) {
+        return CollectionsFactory.createMap(
+                entry(k1, v1),
+                entry(k2, v2),
+                entry(k3, v3),
+                entry(k4, v4),
+                entry(k5, v5),
+                entry(k6, v6),
+                entry(k7, v7),
+                entry(k8, v8),
+                entry(k9, v9)
+        );
+    }
+
+    static <K, V> TMap<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5,
+            K k6, V v6, K k7, V v7, K k8, V v8, K k9, V v9, K k10, V v10) {
+        return CollectionsFactory.createMap(
+                entry(k1, v1),
+                entry(k2, v2),
+                entry(k3, v3),
+                entry(k4, v4),
+                entry(k5, v5),
+                entry(k6, v6),
+                entry(k7, v7),
+                entry(k8, v8),
+                entry(k9, v9),
+                entry(k10, v10)
+        );
+    }
+
+    @SafeVarargs
+    static <K, V> TMap<K, V> ofEntries(TMap.Entry<K, V>... entries) {
+        return CollectionsFactory.createMap(entries);
+    }
+
+    static <K, V> TMap.Entry<K, V> entry(K k, V v) {
+        return new TMapEntry<>(requireNonNull(k), requireNonNull(v));
     }
 }

--- a/classlib/src/main/java/org/teavm/classlib/java/util/TSet.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/util/TSet.java
@@ -21,4 +21,54 @@ package org.teavm.classlib.java.util;
  * @param <E>
  */
 public interface TSet<E> extends TCollection<E> {
+
+    static <E> TSet<E> of() {
+        return TCollections.emptySet();
+    }
+
+    static <E> TSet<E> of(E e) {
+        return CollectionsFactory.createSet(e);
+    }
+
+    static <E> TSet<E> of(E e1, E e2) {
+        return CollectionsFactory.createSet(e1, e2);
+    }
+
+    static <E> TSet<E> of(E e1, E e2, E e3) {
+        return CollectionsFactory.createSet(e1, e2, e3);
+    }
+
+    static <E> TSet<E> of(E e1, E e2, E e3, E e4) {
+        return CollectionsFactory.createSet(e1, e2, e3, e4);
+    }
+
+    static <E> TSet<E> of(E e1, E e2, E e3, E e4, E e5) {
+        return CollectionsFactory.createSet(e1, e2, e3, e4, e5);
+    }
+
+    static <E> TSet<E> of(E e1, E e2, E e3, E e4, E e5, E e6) {
+        return CollectionsFactory.createSet(e1, e2, e3, e4, e5, e6);
+    }
+
+    static <E> TSet<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7) {
+        return CollectionsFactory.createSet(e1, e2, e3, e4, e5, e6, e7);
+    }
+
+    static <E> TSet<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7, E e8) {
+        return CollectionsFactory.createSet(e1, e2, e3, e4, e5, e6, e7, e8);
+    }
+
+    static <E> TSet<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7, E e8, E e9) {
+        return CollectionsFactory.createSet(e1, e2, e3, e4, e5, e6, e7, e8, e9);
+    }
+
+    static <E> TSet<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7, E e8, E e9, E e10) {
+        return CollectionsFactory.createSet(e1, e2, e3, e4, e5, e6, e7, e8, e9, e10);
+    }
+
+    @SafeVarargs
+    static <E> TSet<E> of(E... elements) {
+        return CollectionsFactory.createSet(elements);
+    }
+
 }

--- a/classlib/src/test/java/org/teavm/classlib/java/util/CollectionsFactoryTest.java
+++ b/classlib/src/test/java/org/teavm/classlib/java/util/CollectionsFactoryTest.java
@@ -1,0 +1,134 @@
+/*
+ *  Copyright 2020 Alexey Andreev.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.teavm.classlib.java.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import org.junit.Test;
+
+public class CollectionsFactoryTest {
+
+    @Test
+    public void createList() {
+        assertEquals(
+                TArrays.asList(1, 2, 3),
+                CollectionsFactory.createList(1, 2, 3)
+        );
+    }
+
+    @Test
+    public void createList_zero_elements() {
+        assertSame(CollectionsFactory.createList(), TCollections.emptyList());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void createList_null_element() {
+        CollectionsFactory.createList(new Object[] { null });
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void createList_null_array() {
+        CollectionsFactory.createList((Object[]) null);
+    }
+
+    @Test
+    public void createSet() {
+        assertEquals(
+                new THashSet<>(TArrays.asList(1, 2, 3)),
+                CollectionsFactory.createSet(1, 2, 3)
+        );
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void createSet_duplicate_elements() {
+        CollectionsFactory.createSet(1, 1, 1);
+    }
+
+    @Test
+    public void createSet_zero_elements() {
+        assertSame(CollectionsFactory.createSet(), TCollections.emptySet());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void createSet_null_element() {
+        CollectionsFactory.createSet(new Object[] { null });
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void createSet_null_array() {
+        CollectionsFactory.createSet((Object[]) null);
+    }
+
+    @Test
+    public void createMap() {
+        final THashMap<Integer, String> hashMap = new THashMap<>();
+        hashMap.put(1, "one");
+        hashMap.put(2, "two");
+        hashMap.put(3, "three");
+
+        assertEquals(
+                hashMap,
+                CollectionsFactory.createMap(
+                        TMap.entry(1, "one"),
+                        TMap.entry(2, "two"),
+                        TMap.entry(3, "three")
+                )
+        );
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void createMap_null_key() {
+        CollectionsFactory.createMap(TMap.entry(null, "value"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void createMap_duplicate_key() {
+        CollectionsFactory.createMap(
+                TMap.entry(1, "value"),
+                TMap.entry(1, "another value")
+        );
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void createMap_null_value() {
+        CollectionsFactory.createMap(TMap.entry("key", null));
+    }
+
+    @Test
+    public void createMap_duplicate_value() {
+        final THashMap<Integer, String> hashMap = new THashMap<>();
+        hashMap.put(1, "value");
+        hashMap.put(2, "value");
+
+        assertEquals(
+                hashMap,
+                CollectionsFactory.createMap(
+                        TMap.entry(1, "value"),
+                        TMap.entry(2, "value")
+                )
+        );
+    }
+
+    @Test
+    public void createMap_zero_elements() {
+        assertSame(CollectionsFactory.createMap(), TCollections.emptyMap());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void createMap_null_array() {
+        CollectionsFactory.createMap((TMap.Entry<Object, Object>[]) null);
+    }
+}


### PR DESCRIPTION
This adds the collection factories List.of(...), Set.of(...), Map.of(...) and Map.ofEntries(...) which were introduced to the JDK in Java 9.
It also adds the methods Map.remove(K, V) and Map.forEach(BiConsumer<K, V>) which were introduced in Java 8.

Unlike the implementation in OpenJDK, this doesn't use special implementations for the returned unmodifiable collections, but wraps the regular collection classes in an unmodifiable wrapper.
