### PR TITLE
added support for java.lang.reflect.Type

### DIFF
--- a/classlib/src/main/java/org/teavm/classlib/java/lang/TClass.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/lang/TClass.java
@@ -50,7 +50,7 @@ import org.teavm.platform.PlatformSequence;
 import org.teavm.runtime.RuntimeClass;
 import org.teavm.runtime.RuntimeObject;
 
-public class TClass<T> extends TObject implements TAnnotatedElement {
+public class TClass<T> extends TObject implements TAnnotatedElement, TType {
     String name;
     String simpleName;
     String canonicalName;

--- a/classlib/src/main/java/org/teavm/classlib/java/lang/reflect/TType.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/lang/reflect/TType.java
@@ -1,0 +1,20 @@
+/*
+ *  Copyright 2020 by Joerg Hohwiller
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.teavm.classlib.java.lang.reflect;
+
+public interface TType {
+
+}


### PR DESCRIPTION
I have faced various situations where an API was designed more generic and accepts `java.lang.reflect.Type` as input rahter than `Class`. Support for just the empty `Type` interface implemented by `Class` allows the same API to be used in server and client (shared code) while using an implementation in the client that only supports `Class` and only on the server side also support generic types.