### PR TITLE
support for Thread.UncaughtExceptionHandler

### DIFF
--- a/classlib/src/main/java/org/teavm/classlib/java/lang/TDefaultUncaughtExceptionHandler.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/lang/TDefaultUncaughtExceptionHandler.java
@@ -1,0 +1,29 @@
+/*
+ *  Copyright 2020 by Joerg Hohwiller
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.teavm.classlib.java.lang;
+
+import org.teavm.classlib.java.lang.TThread.UncaughtExceptionHandler;
+
+public class TDefaultUncaughtExceptionHandler implements UncaughtExceptionHandler {
+
+    @Override
+    public void uncaughtException(Thread t, Throwable e) {
+
+        // print to browser console by default
+        e.printStackTrace();
+    }
+
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/lang/TDefaultUncaughtExceptionHandler.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/lang/TDefaultUncaughtExceptionHandler.java
@@ -20,7 +20,7 @@ import org.teavm.classlib.java.lang.TThread.UncaughtExceptionHandler;
 public class TDefaultUncaughtExceptionHandler implements UncaughtExceptionHandler {
 
     @Override
-    public void uncaughtException(Thread t, Throwable e) {
+    public void uncaughtException(TThread t, Throwable e) {
 
         // print to browser console by default
         e.printStackTrace();

--- a/classlib/src/main/java/org/teavm/classlib/java/lang/TThread.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/lang/TThread.java
@@ -28,6 +28,8 @@ public class TThread extends TObject implements TRunnable {
     private static TThread currentThread = mainThread;
     private static int nextId = 1;
     private static int activeCount = 1;
+    private static UncaughtExceptionHandler defaultUncaughtExceptionHandler = new TDefaultUncaughtExceptionHandler();
+    private UncaughtExceptionHandler uncaughtExceptionHandler;
     private long id;
     private int priority;
     private boolean daemon;
@@ -268,5 +270,25 @@ public class TThread extends TObject implements TRunnable {
 
     public TClassLoader getContextClassLoader() {
         return TClassLoader.getSystemClassLoader();
+    }
+    
+    public UncaughtExceptionHandler getUncaughtExceptionHandler() {
+        return (this.uncaughtExceptionHandler != null) ? this.uncaughtExceptionHandler: defaultUncaughtExceptionHandler;
+    }
+    
+    public void setUncaughtExceptionHandler(UncaughtExceptionHandler uncaughtExceptionHandler) {
+        this.uncaughtExceptionHandler = uncaughtExceptionHandler;
+    }
+    
+    public static UncaughtExceptionHandler getDefaultUncaughtExceptionHandler() {
+        return defaultUncaughtExceptionHandler;
+    }
+    
+    public static void setDefaultUncaughtExceptionHandler(UncaughtExceptionHandler handler) {
+        defaultUncaughtExceptionHandler = handler;
+    }
+    
+    public interface UncaughtExceptionHandler {
+        void uncaughtException(Thread t, Throwable e);
     }
 }

--- a/classlib/src/main/java/org/teavm/classlib/java/lang/TThread.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/lang/TThread.java
@@ -275,7 +275,10 @@ public class TThread extends TObject implements TRunnable {
     }
     
     public UncaughtExceptionHandler getUncaughtExceptionHandler() {
-        return (this.uncaughtExceptionHandler != null) ? this.uncaughtExceptionHandler : defaultUncaughtExceptionHandler;
+        if (this.uncaughtExceptionHandler != null) {
+            return this.uncaughtExceptionHandler;
+        }
+        return defaultUncaughtExceptionHandler;
     }
     
     public void setUncaughtExceptionHandler(UncaughtExceptionHandler uncaughtExceptionHandler) {

--- a/classlib/src/main/java/org/teavm/classlib/java/lang/TThread.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/lang/TThread.java
@@ -78,6 +78,8 @@ public class TThread extends TObject implements TRunnable {
             activeCount++;
             setCurrentThread(TThread.this);
             TThread.this.run();
+        } catch (Throwable t) {
+            getUncaughtExceptionHandler().uncaughtException(this, t);
         } finally {
             synchronized (finishedLock) {
                 finishedLock.notifyAll();
@@ -273,7 +275,7 @@ public class TThread extends TObject implements TRunnable {
     }
     
     public UncaughtExceptionHandler getUncaughtExceptionHandler() {
-        return (this.uncaughtExceptionHandler != null) ? this.uncaughtExceptionHandler: defaultUncaughtExceptionHandler;
+        return (this.uncaughtExceptionHandler != null) ? this.uncaughtExceptionHandler : defaultUncaughtExceptionHandler;
     }
     
     public void setUncaughtExceptionHandler(UncaughtExceptionHandler uncaughtExceptionHandler) {
@@ -289,6 +291,6 @@ public class TThread extends TObject implements TRunnable {
     }
     
     public interface UncaughtExceptionHandler {
-        void uncaughtException(Thread t, Throwable e);
+        void uncaughtException(TThread t, Throwable e);
     }
 }


### PR DESCRIPTION
Support for `UncaughtExceptionHandler` in `Thread`. Some libraries are using the Java feature to handle exceptions (e.g. event bus). It would be nice to allow using such lib in TeaVM.