### PR TITLE
added Flow API for reactive programming

### DIFF
--- a/classlib/src/main/java/org/teavm/classlib/java/util/concurrent/TFlow.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/util/concurrent/TFlow.java
@@ -1,0 +1,45 @@
+/*
+ *  Copyright 2020 by Joerg Hohwiller
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.teavm.classlib.java.util.concurrent;
+
+// https://www.reactive-streams.org/
+public class TFlow {
+
+    public interface Processor<T, R> extends Subscriber<T>, Publisher<R> {
+
+    }
+
+    public interface Publisher<T> {
+        void subscribe(Subscriber<? super T> s);
+    }
+
+    public interface Subscriber<T> {
+        void onComplete();
+
+        void onError​(Throwable t);
+
+        void onNext​(T t);
+
+        void onSubscribe​(Subscription s);
+    }
+
+    public interface Subscription {
+        void cancel();
+
+        void request​(long n);
+    }
+
+}


### PR DESCRIPTION
Support for reactive programming API that was added in Java9 from https://www.reactive-streams.org/
It is just an API but a very important one for future frameworks and interoperability. As the API is "standardized" both for JavaScript and Java it is valuable to have it in TeaVM so in the future a library can provide a reactive client/server communication supporting both JVM and Browser via TeaVM using the same API. I rewrote the API from the JavaDoc (https://www.reactive-streams.org/reactive-streams-1.0.3-javadoc/org/reactivestreams/package-summary.html) and did not copy anything from JDK.