### PR TITLE
added module names form JPMS

### DIFF
--- a/jso/apis/pom.xml
+++ b/jso/apis/pom.xml
@@ -59,6 +59,17 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>org.teavm.jso.apis</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
       </plugin>
       <plugin>

--- a/jso/core/pom.xml
+++ b/jso/core/pom.xml
@@ -49,6 +49,17 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>org.teavm.jso</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
       </plugin>
       <plugin>

--- a/metaprogramming/api/pom.xml
+++ b/metaprogramming/api/pom.xml
@@ -51,6 +51,17 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>org.teavm.metaprogramming.api</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
       </plugin>
       <plugin>


### PR DESCRIPTION
For using teavm in Java9+ with JMPS (modules) it would be required to have stable module names. Otherwise module name is derived from filename of the JAR file and that will raise warnings and cause severe issues:
```
[WARNING] ***************************************************************************************************************************************************************************************
[WARNING] * Required filename-based automodules detected: [teavm-jso-0.6.1.jar, teavm-jso-apis-0.6.1.jar]. Please don't publish this project to a public artifact repository! *
[WARNING] ***************************************************************************************************************************************************************************************
```
I therefore added reasonable module names to Manifest via maven (so no `module-info` is required what would again need `java.version` >= 9):
* `org.teavm.jso`
* `org.teavm.jso.apis`
* `org.teavm.metaprogramming.api`

These names were just natural according to java packaging and maven GAV. Feel free to change if you do not like them.

https://medium.com/technowriter/heres-a-cool-java-9-feature-automatic-module-name-2746641ebb7
http://branchandbound.net/blog/java/2017/12/automatic-module-name/

FYI: Another nice feature to consider for Manifests is also this one:
https://maven.apache.org/shared/maven-archiver/examples/manifest.html
