### PR TITLE
prevent javadoc error: code being documented uses modules but the packages are in the unnamed module.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -242,6 +242,7 @@
             </execution>
           </executions>
           <configuration>
+            <source>${java.version}</source>
             <show>protected</show>
             <failOnError>false</failOnError>
           </configuration>


### PR DESCRIPTION
As I was stumbling over these annoying JavaDoc errors in your maven build when using Java11, I added this fix to your POM.
Source:
https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8212233