### PR TITLE
add int constructor for Java9+ compatibility

### DIFF
--- a/classlib/src/main/java/org/teavm/classlib/java/lang/TIndexOutOfBoundsException.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/lang/TIndexOutOfBoundsException.java
@@ -25,4 +25,8 @@ public class TIndexOutOfBoundsException extends TRuntimeException {
     public TIndexOutOfBoundsException(String message) {
         super(message);
     }
+
+    public TIndexOutOfBoundsException(int index) {
+        super("Index out of range: " + index);
+    }
 }


### PR DESCRIPTION
Fixes error from TeaVM compiler:
```
java.lang.IndexOutOfBoundsException.<init>(I)V was not found
```
This int constructor was added in Java 9.