### PR TITLE
add static hashCode(i) method like in java.lang.Integer

### DIFF
--- a/classlib/src/main/java/org/teavm/classlib/java/lang/TInteger.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/lang/TInteger.java
@@ -42,6 +42,10 @@ public class TInteger extends TNumber implements TComparable<TInteger> {
         return new TAbstractStringBuilder(20).append(i, radix).toString();
     }
 
+    public static int hashCode(int value) {
+        return (value >>> 4) ^ (value << 28) ^ (value << 8) ^ (value >>> 24);
+    }
+
     public static String toHexString(int i) {
         return toUnsignedLogRadixString(i, 4);
     }
@@ -156,7 +160,7 @@ public class TInteger extends TNumber implements TComparable<TInteger> {
 
     @Override
     public int hashCode() {
-        return (value >>> 4) ^ (value << 28) ^ (value << 8) ^ (value >>> 24);
+        return TInteger.hashCode(value);
     }
 
     @Override


### PR DESCRIPTION
That should fix the following error:
```
ERROR: Method java.lang.Integer.hashCode(I)I was not found
    at com.jetbrains.python.lexer.PyLexerFStringHelper$FStringState.hashCode(-1)
    at java.util.LinkedHashMap.get(TLinkedHashMap.java:245)
    at jetbrains.ocelot.base.json.JsonObject.get(JsonObject.java:36)
    at jetbrains.datalore.base.json.persister.JsonPersisterBase.readField(JsonPersisterBase.java:20)
    at jetbrains.datalore.base.json.persister.JsonPersisterBase.readField(JsonPersisterBase.java:8)
    at jetbrains.datalore.publishing.shared.appInit.AppInitPersister.fromJson(AppInitPersister.java:37)
    at jetbrains.datalore.publishing.teavmApp.PublishingMain.readAppInit(PublishingMain.java:108)
    at jetbrains.datalore.publishing.teavmApp.PublishingMain.main(PublishingMain.java:59)
```
where `PyLexerFStringHelper$FStringState` is a kotlin data class with `Int` type:
```
private data class FStringState(val oldState: Int,
                                val offset: Int,
                                val prefix: String,
                                val openingQuotes: String) {
  val fragmentStates = Stack<FragmentState>()
}
```