### PR TITLE
Error message if @JSBody with return type does not return

### DIFF
--- a/jso/impl/src/main/java/org/teavm/jso/impl/JSClassProcessor.java
+++ b/jso/impl/src/main/java/org/teavm/jso/impl/JSClassProcessor.java
@@ -550,6 +550,12 @@ class JSClassProcessor {
                 .map(AnnotationValue::getString)
                 .toArray(String[]::new) : new String[0];
 
+        if (methodToProcess.getResultType() != ValueType.VOID
+                && !script.contains("return")) {
+            diagnostics.error(location, "JSBody method {{m0}} has return type {{t1}}, but the script does not "
+                    + "contain a return statement", methodToProcess.getReference(), methodToProcess.getResultType());
+        }
+
         // Parse JS script
         TeaVMErrorReporter errorReporter = new TeaVMErrorReporter(diagnostics,
                 new CallLocation(methodToProcess.getReference()));


### PR DESCRIPTION
If a @JSBody-annotated method has a return type (not void), but does not
have a return statement in the script, print an error.

I can't think of a case where someone would actually want the returned value to always be `undefined`, as it would be if the return was missing.

This addition in no way validates the script, and does not catch all cases, but prevents simple errors such as

```
@JSBody(params = "id", script = "document.getElementById(id)")
public static native HTMLElement getElementById(String id);
```