### PR TITLE
Fix JavaScript generation for default methods which override other default methods

### DIFF
--- a/core/src/main/java/org/teavm/backend/javascript/rendering/Renderer.java
+++ b/core/src/main/java/org/teavm/backend/javascript/rendering/Renderer.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -620,16 +621,16 @@ public class Renderer implements RenderingManager {
             }
             writer.append(',').ws();
 
-            List<MethodReference> virtualMethods = new ArrayList<>();
+            Map<MethodDescriptor, MethodReference> virtualMethods = new LinkedHashMap<>();
+            collectMethodsToCopyFromInterfaces(classSource.get(cls.getName()), virtualMethods);
             for (PreparedMethod method : cls.getMethods()) {
                 if (!method.methodHolder.getModifiers().contains(ElementModifier.STATIC)
                         && method.methodHolder.getLevel() != AccessLevel.PRIVATE) {
-                    virtualMethods.add(method.reference);
+                    virtualMethods.put(method.reference.getDescriptor(), method.reference);
                 }
             }
-            collectMethodsToCopyFromInterfaces(classSource.get(cls.getName()), virtualMethods);
 
-            renderVirtualDeclarations(virtualMethods);
+            renderVirtualDeclarations(virtualMethods.values());
             debugEmitter.emitClass(null);
         }
         writer.append("]);").newLine();
@@ -701,7 +702,7 @@ public class Renderer implements RenderingManager {
         }
     }
 
-    private void collectMethodsToCopyFromInterfaces(ClassReader cls, List<MethodReference> targetList) {
+    private void collectMethodsToCopyFromInterfaces(ClassReader cls, Map<MethodDescriptor, MethodReference> target) {
         Set<MethodDescriptor> implementedMethods = new HashSet<>();
         ClassReader superclass = cls;
         while (superclass != null) {
@@ -716,33 +717,38 @@ public class Renderer implements RenderingManager {
         }
 
         Set<String> visitedClasses = new HashSet<>();
-        for (String ifaceName : cls.getInterfaces()) {
-            ClassReader iface = classSource.get(ifaceName);
-            if (iface != null) {
-                collectMethodsToCopyFromInterfacesImpl(iface, targetList, implementedMethods, visitedClasses);
+        superclass = cls;
+        while (superclass != null) {
+            for (String ifaceName : superclass.getInterfaces()) {
+                ClassReader iface = classSource.get(ifaceName);
+                if (iface != null) {
+                    collectMethodsToCopyFromInterfacesImpl(iface, target, implementedMethods, visitedClasses);
+                }
             }
+            superclass = superclass.getParent() != null ? classSource.get(superclass.getParent()) : null;
         }
     }
 
-    private void collectMethodsToCopyFromInterfacesImpl(ClassReader cls, List<MethodReference> targetList,
-            Set<MethodDescriptor> visited, Set<String> visitedClasses) {
+    private void collectMethodsToCopyFromInterfacesImpl(ClassReader cls, Map<MethodDescriptor, MethodReference> target,
+            Set<MethodDescriptor> implementedMethods, Set<String> visitedClasses) {
         if (!visitedClasses.add(cls.getName())) {
             return;
+        }
+
+        for (String ifaceName : cls.getInterfaces()) {
+            ClassReader iface = classSource.get(ifaceName);
+            if (iface != null) {
+                collectMethodsToCopyFromInterfacesImpl(iface, target, implementedMethods, visitedClasses);
+            }
         }
 
         for (MethodReader method : cls.getMethods()) {
             if (!method.hasModifier(ElementModifier.STATIC)
                     && !method.hasModifier(ElementModifier.ABSTRACT)) {
-                if (visited.add(method.getDescriptor())) {
-                    targetList.add(method.getReference());
+                MethodDescriptor descriptor = method.getDescriptor();
+                if (!implementedMethods.contains(descriptor)) {
+                    target.put(descriptor, method.getReference());
                 }
-            }
-        }
-
-        for (String ifaceName : cls.getInterfaces()) {
-            ClassReader iface = classSource.get(ifaceName);
-            if (iface != null) {
-                collectMethodsToCopyFromInterfacesImpl(iface, targetList, visited, visitedClasses);
             }
         }
     }

--- a/tests/src/test/java/org/teavm/vm/VMTest.java
+++ b/tests/src/test/java/org/teavm/vm/VMTest.java
@@ -491,7 +491,15 @@ public class VMTest {
 
     @Test
     public void indirectDefaultMethod() {
+        new FirstPathOptimizationPrevention().foo();
         PathJoint o = new PathJoint();
+        assertEquals("SecondPath.foo", o.foo());
+    }
+
+    @Test
+    public void indirectDefaultMethodSubclass() {
+        new FirstPathOptimizationPrevention().foo();
+        PathJointSubclass o = new PathJointSubclass();
         assertEquals("SecondPath.foo", o.foo());
     }
 
@@ -509,6 +517,13 @@ public class VMTest {
     }
 
     class PathJoint implements FirstPath, SecondPath {
+    }
+
+    class PathJointSubclass extends PathJoint implements FirstPath {
+    }
+
+    class FirstPathOptimizationPrevention implements FirstPath {
+        // Used to ensure that the implementation of FirstPath.foo() is not optimized away by TeaVM.
     }
 
     @Test


### PR DESCRIPTION
At my company we had the problem that *TeaVM* generates incorrect JavaScript in some cases. We were able to fix the issue by ourselves in commit 8c5b10be9f1 but we have trouble to make the tests work correctly.

There are two similar bugs which occur in two different scenarios. Both bugs might occur when a default method of some interface overrides the default method of another interface. In both cases, the wrong method is called.

* The first bug occurs when the first path to the base interface does not contain the interface overriding the method.
* The second bug occurs when the interface overriding the method is only reachable over a super class.

Both cases are [demonstrated in commit 3ed067b4059](https://github.com/konsoletyper/teavm/blob/3ed067b405940c2cb97acb6ff502baabb62a3e2b/tests/src/test/java/org/teavm/vm/VMTest.java#L492-L527).

The test `VMTest.indirectDefaultMethod` already exists in previous commits but doesn't fail. The test does not detect the issue because some optimizations obscure the bug. In commit 3ed067b4059, I made some changes to prevent the *devirtualization*. As a result, you can see incorrect metadata generated for `$rt_metadata` in `tests/target/js-tests/org/teavm/vm/VMTest/indirectDefaultMethod/test.js`.

```
otv_VMTest$PathJoint, 0, jl_Object, [otv_VMTest$FirstPath, otv_VMTest$SecondPath], 0, 0, 0, 0, ["$_init_1", $rt_wrapFunction1(otv_VMTest$PathJoint__init_0), "$foo", $rt_wrapFunction0(otv_VMTest$FirstPath_foo)],
```

Unfortunately, the tests still cannot detect the bugs. Some other optimizations seem to obscure them in `test-optimized.js`. My best bet is that only the optimized file is executed. We should prevent the optimizations from obscuring the bugs. Any idea how we can achieve that? Do you have any other objections or suggestions for this pull request?

---

**PS:** I am executing the tests with `mvn -pl tests -e clean test [-Dtest=VMTest]`. When I try to run all tests with `mvn -e clean test`, some goal always fails with a `ClassNotFoundException`.

<details><summary>Full stacktrace</summary>

```
[ERROR] Failed to execute goal org.teavm:teavm-maven-plugin:0.7.0-SNAPSHOT:compile (compile-deobfuscator) on project teavm-junit: Unexpected error occurred: com/carrotsearch/hppc/ObjectIntMap: com.carrotsearch.hppc.ObjectIntMap -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.teavm:teavm-maven-plugin:0.7.0-SNAPSHOT:compile (compile-deobfuscator) on project teavm-junit: Unexpected error occurred
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:215)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:156)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:148)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:81)
    at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:56)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:128)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:305)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:192)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:105)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:957)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:289)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:193)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:566)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
    at org.codehaus.classworlds.Launcher.main (Launcher.java:47)
Caused by: org.apache.maven.plugin.MojoExecutionException: Unexpected error occurred
    at org.teavm.maven.TeaVMCompileMojo.executeWithBuilder (TeaVMCompileMojo.java:303)
    at org.teavm.maven.TeaVMCompileMojo.execute (TeaVMCompileMojo.java:246)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:137)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:210)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:156)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:148)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:81)
    at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:56)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:128)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:305)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:192)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:105)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:957)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:289)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:193)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:566)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
    at org.codehaus.classworlds.Launcher.main (Launcher.java:47)
Caused by: java.lang.NoClassDefFoundError: com/carrotsearch/hppc/ObjectIntMap
    at org.teavm.tooling.TeaVMTool.prepareJavaScriptTarget (TeaVMTool.java:313)
    at org.teavm.tooling.TeaVMTool.prepareTarget (TeaVMTool.java:303)
    at org.teavm.tooling.TeaVMTool.generate (TeaVMTool.java:353)
    at org.teavm.tooling.builder.InProcessBuildStrategy.build (InProcessBuildStrategy.java:261)
    at org.teavm.maven.TeaVMCompileMojo.executeWithBuilder (TeaVMCompileMojo.java:297)
    at org.teavm.maven.TeaVMCompileMojo.execute (TeaVMCompileMojo.java:246)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:137)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:210)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:156)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:148)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:81)
    at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:56)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:128)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:305)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:192)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:105)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:957)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:289)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:193)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:566)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
    at org.codehaus.classworlds.Launcher.main (Launcher.java:47)
Caused by: java.lang.ClassNotFoundException: com.carrotsearch.hppc.ObjectIntMap
    at org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy.loadClass (SelfFirstStrategy.java:50)
    at org.codehaus.plexus.classworlds.realm.ClassRealm.unsynchronizedLoadClass (ClassRealm.java:271)
    at org.codehaus.plexus.classworlds.realm.ClassRealm.loadClass (ClassRealm.java:247)
    at org.codehaus.plexus.classworlds.realm.ClassRealm.loadClass (ClassRealm.java:239)
    at org.teavm.tooling.TeaVMTool.prepareJavaScriptTarget (TeaVMTool.java:313)
    at org.teavm.tooling.TeaVMTool.prepareTarget (TeaVMTool.java:303)
    at org.teavm.tooling.TeaVMTool.generate (TeaVMTool.java:353)
    at org.teavm.tooling.builder.InProcessBuildStrategy.build (InProcessBuildStrategy.java:261)
    at org.teavm.maven.TeaVMCompileMojo.executeWithBuilder (TeaVMCompileMojo.java:297)
    at org.teavm.maven.TeaVMCompileMojo.execute (TeaVMCompileMojo.java:246)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:137)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:210)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:156)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:148)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:81)
    at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:56)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:128)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:305)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:192)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:105)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:957)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:289)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:193)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:566)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
    at org.codehaus.classworlds.Launcher.main (Launcher.java:47)
```

</details>