### PR TITLE
Fixed invalid JSBody annotation in IDBObjectStore, fixed IDBFactory compatibility check

### DIFF
--- a/jso/apis/src/main/java/org/teavm/jso/indexeddb/IDBFactory.java
+++ b/jso/apis/src/main/java/org/teavm/jso/indexeddb/IDBFactory.java
@@ -28,7 +28,7 @@ public abstract class IDBFactory implements JSObject {
 
     public static IDBFactory getInstance() {
         IDBFactory factory = getInstanceImpl();
-        if (!factory.isUndefined()) {
+        if (factory.isUndefined()) {
             throw new IllegalStateException("IndexedDB is not supported in this browser");
         }
         return factory;

--- a/jso/apis/src/main/java/org/teavm/jso/indexeddb/IDBObjectStore.java
+++ b/jso/apis/src/main/java/org/teavm/jso/indexeddb/IDBObjectStore.java
@@ -36,7 +36,7 @@ public abstract class IDBObjectStore implements JSObject, IDBCursorSource {
         }
     }
 
-    @JSBody(script = "return this;")
+    @JSBody(params = "obj", script = "return obj;")
     private native String[] unwrapStringArray(JSObject obj);
 
     @JSProperty

--- a/jso/apis/src/main/java/org/teavm/jso/indexeddb/IDBObjectStore.java
+++ b/jso/apis/src/main/java/org/teavm/jso/indexeddb/IDBObjectStore.java
@@ -37,7 +37,7 @@ public abstract class IDBObjectStore implements JSObject, IDBCursorSource {
     }
 
     @JSBody(params = "obj", script = "return obj;")
-    private native String[] unwrapStringArray(JSObject obj);
+    private static native String[] unwrapStringArray(JSObject obj);
 
     @JSProperty
     public abstract String[] getIndexNames();


### PR DESCRIPTION
The annotation was missing a 'params' definition in the constructor which prevented the IndexedDB JSO API from successfully compiling to JavaScript in the current version of TeaVM.

**I do not know if this was the ideal way to patch this function, feel free to reject this request and patch it differently if the 30 second change I have provided here was not the correct way to fix this problem**