### PR TITLE
Added setName method to TThread.

### DIFF
--- a/classlib/src/main/java/org/teavm/classlib/java/lang/TThread.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/lang/TThread.java
@@ -116,6 +116,10 @@ public class TThread extends TObject implements TRunnable {
         return name;
     }
 
+    public void setName(String name) {
+        this.name = name;
+    }
+
     public final boolean isDaemon() {
         return daemon;
     }


### PR DESCRIPTION
This adds a simple setName implementation to TThread. This fixes a big where `TTimer` is calling `thread.setName(threadName)` but no method is found. With this fix I am able to use Timer#scheduleAtFixedRate in my project.