### PR TITLE
Added Random next origin, bound methods for float, double, int and long

### DIFF
--- a/classlib/src/main/java/org/teavm/classlib/java/util/TRandom.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/util/TRandom.java
@@ -74,8 +74,16 @@ public class TRandom extends TObject implements TSerializable {
         return (int) (nextDouble() * n);
     }
 
+    public int nextInt(int origin, int bound) {
+        return origin + nextInt() * (bound - origin);
+    }
+
     public long nextLong() {
         return ((long) nextInt() << 32) | nextInt();
+    }
+
+    public long nextLong(long origin, long bound) {
+        return origin + nextLong() * (bound - origin);
     }
 
     public boolean nextBoolean() {
@@ -86,12 +94,20 @@ public class TRandom extends TObject implements TSerializable {
         return (float) nextDouble();
     }
 
+    public float nextFloat(float origin, float bound) {
+        return origin + nextFloat() * (bound - origin);
+    }
+
     public double nextDouble() {
         if (PlatformDetector.isC()) {
             return crand();
         } else {
             return random();
         }
+    }
+
+    public double nextDouble(double origin, double bound) {
+        return origin + nextDouble() * (bound - origin);
     }
 
     @Import(name = "teavm_rand")


### PR DESCRIPTION
In one of my projects I am using `Random#nextInt(origin, bound)` and `Random#nextFloat(origin, bound)`. These have default implementations in the `RandomGenerator` interface but do not exist in `TRandom` currently. This adds implementations for nextFloat, nextDouble, nextInt and nextLong.

I believe these methods were introduced in Java 17.