### PR TITLE
fix(sec): upgrade jackson-databind to 2.12.6.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
 
     <jetty.version>9.4.38.v20210224</jetty.version>
     <javax-websocket.version>1.0</javax-websocket.version>
-    <jackson.version>2.12.2</jackson.version>
+    <jackson.version>2.12.6.1</jackson.version>
     <gson.version>2.8.6</gson.version>
 
     <idea.version>2018.2.8</idea.version>


### PR DESCRIPTION
Upgrade jackson-databind 2.12.2 to 2.12.6.1 for vulnerability fix:
         - [MPS-2022-12500](https://www.oscs1024.com/hd/MPS-2022-12500)
         - [CVE-2020-36518](https://www.oscs1024.com/hd/MPS-2022-6242)