### PR TITLE
add missing scrollIntoView method to org.teavm.jso.dom.xml.Element

### DIFF
--- a/jso/apis/src/main/java/org/teavm/jso/dom/xml/Element.java
+++ b/jso/apis/src/main/java/org/teavm/jso/dom/xml/Element.java
@@ -60,4 +60,6 @@ public interface Element extends Node {
 
     @JSProperty
     String getTagName();
+
+    void scrollIntoView();
 }


### PR DESCRIPTION
the purpose of this pull request is to add missing method to the Element class
documentation: https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView
