### PR TITLE
fix(sec): upgrade org.mozilla:rhino to 1.7.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,8 +13,7 @@
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
--->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+--><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>org.teavm</groupId>
@@ -73,7 +72,7 @@
     <java.version>1.8</java.version>
     <java-tests.version>17</java-tests.version>
 
-    <rhino.version>1.7.11</rhino.version>
+    <rhino.version>1.7.12</rhino.version>
 
     <testng.version>7.1.0</testng.version>
     <junit.version>4.13.2</junit.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.mozilla:rhino 1.7.11
- [MPS-2022-11928](https://www.oscs1024.com/hd/MPS-2022-11928)


### What did I do？
Upgrade org.mozilla:rhino from 1.7.11 to 1.7.12 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How was this patch tested?
Run `mvn compile` failed locally, couldn't complete the build process.
Run `mvn clean test` failed locally, unit-test couldn't pass.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS