### PR TITLE
fix(sec): upgrade org.scala-lang:scala-library to 2.13.9

### DIFF
--- a/samples/scala/pom.xml
+++ b/samples/scala/pom.xml
@@ -15,7 +15,7 @@
 
   <properties>
     <java.version>1.8</java.version>
-    <scala.version>2.13.8</scala.version>
+    <scala.version>2.13.9</scala.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
   


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.scala-lang:scala-library 2.13.8
- [CVE-2022-36944](https://www.oscs1024.com/hd/CVE-2022-36944)


### What did I do？
Upgrade org.scala-lang:scala-library from 2.13.8 to 2.13.9 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How was this patch tested?
Run `mvn compile` failed locally, couldn't complete the build process.
Run `mvn clean test` failed locally, unit-test couldn't pass.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS