### PR TITLE
fix(sec): upgrade com.fasterxml.jackson.core:jackson-databind to 2.12.6.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
 
     <jetty.version>9.4.38.v20210224</jetty.version>
     <javax-websocket.version>1.0</javax-websocket.version>
-    <jackson.version>2.12.2</jackson.version>
+    <jackson.version>2.12.6.1</jackson.version>
     <gson.version>2.8.6</gson.version>
 
     <idea.version>2018.2.8</idea.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in com.fasterxml.jackson.core:jackson-databind 2.12.2
- [CVE-2020-36518](https://www.oscs1024.com/hd/CVE-2020-36518)


### What did I do？
Upgrade com.fasterxml.jackson.core:jackson-databind from 2.12.2 to 2.12.6.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How was this patch tested?
Run `mvn compile` failed locally, couldn't complete the build process.
Run `mvn clean test` failed locally, unit-test couldn't pass.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS