### PR TITLE
fix(sec): upgrade org.eclipse.jetty:jetty-server to 9.4.41

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
     <joda-time.version>2.7</joda-time.version>
     <hppc.version>0.8.2</hppc.version>
 
-    <jetty.version>9.4.38.v20210224</jetty.version>
+    <jetty.version>9.4.41</jetty.version>
     <javax-websocket.version>1.0</javax-websocket.version>
     <jackson.version>2.12.2</jackson.version>
     <gson.version>2.8.6</gson.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.eclipse.jetty:jetty-server 9.4.38.v20210224
- [CVE-2021-34428](https://www.oscs1024.com/hd/CVE-2021-34428)


### What did I do？
Upgrade org.eclipse.jetty:jetty-server from 9.4.38.v20210224 to 9.4.41 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How was this patch tested?
Run `mvn compile` failed locally, couldn't complete the build process.
Run `mvn clean test` failed locally, unit-test couldn't pass.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS