### PR TITLE
Fix TAbstractStringBuilder for MIN_VALUE.

### DIFF
--- a/classlib/src/main/java/org/teavm/classlib/java/lang/TAbstractStringBuilder.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/lang/TAbstractStringBuilder.java
@@ -148,16 +148,16 @@ class TAbstractStringBuilder extends TObject implements TSerializable, TCharSequ
 
     protected TAbstractStringBuilder insert(int target, long value, int radix) {
         boolean positive = true;
-        long isMin;
+        boolean isMin;
         if (value < 0) {
             positive = false;
             value = -value;
-            isMin = (value & -value) >> 63 | 1L;
+            isMin = value == TLong.MIN_VALUE;
         }
         else {
-            isMin = 0L;
+            isMin = false;
         }
-        if (value < radix && isMin == 0L) {
+        if (value < radix && !isMin) {
             if (!positive) {
                 insertSpace(target, target + 2);
                 buffer[target++] = '-';
@@ -168,7 +168,7 @@ class TAbstractStringBuilder extends TObject implements TSerializable, TCharSequ
         } else {
             int sz = 1;
             long pos = -1L;
-            value *= isMin;
+            value = -value;
             while (pos * radix < pos && pos * radix >= value) {
                 pos *= radix;
                 ++sz;

--- a/classlib/src/main/java/org/teavm/classlib/java/lang/TAbstractStringBuilder.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/lang/TAbstractStringBuilder.java
@@ -99,11 +99,16 @@ class TAbstractStringBuilder extends TObject implements TSerializable, TCharSequ
 
     TAbstractStringBuilder insert(int target, int value, int radix) {
         boolean positive = true;
+        boolean isMin;
         if (value < 0) {
             positive = false;
             value = -value;
+            isMin = value == TInteger.MIN_VALUE;
         }
-        if (value < radix) {
+        else {
+            isMin = false;
+        }
+        if (value < radix && !isMin) {
             if (!positive) {
                 insertSpace(target, target + 2);
                 buffer[target++] = '-';
@@ -112,13 +117,15 @@ class TAbstractStringBuilder extends TObject implements TSerializable, TCharSequ
             }
             buffer[target++] = TCharacter.forDigit(value, radix);
         } else {
-            int pos = 1;
+            int pos = -1;
+            value = -value;
             int sz = 1;
-            int posLimit = TInteger.MAX_VALUE / radix;
-            while (pos * radix <= value) {
+            int posLimit = TInteger.MIN_VALUE / radix;
+
+            while (pos * radix >= value) {
                 pos *= radix;
                 ++sz;
-                if (pos > posLimit) {
+                if (pos < posLimit) {
                     break;
                 }
             }
@@ -129,7 +136,7 @@ class TAbstractStringBuilder extends TObject implements TSerializable, TCharSequ
             if (!positive) {
                 buffer[target++] = '-';
             }
-            while (pos > 0) {
+            while (pos < 0) {
                 buffer[target++] = TCharacter.forDigit(value / pos, radix);
                 value %= pos;
                 pos /= radix;

--- a/classlib/src/main/java/org/teavm/classlib/java/lang/TAbstractStringBuilder.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/lang/TAbstractStringBuilder.java
@@ -148,22 +148,28 @@ class TAbstractStringBuilder extends TObject implements TSerializable, TCharSequ
 
     protected TAbstractStringBuilder insert(int target, long value, int radix) {
         boolean positive = true;
+        long isMin;
         if (value < 0) {
             positive = false;
             value = -value;
+            isMin = (value & -value) >> 63 | 1L;
         }
-        if (value < radix) {
+        else {
+            isMin = 0L;
+        }
+        if (value < radix && isMin == 0L) {
             if (!positive) {
                 insertSpace(target, target + 2);
                 buffer[target++] = '-';
             } else {
                 insertSpace(target, target + 1);
             }
-            buffer[target++] = Character.forDigit((int) value, radix);
+            buffer[target++] = TCharacter.forDigit((int) value, radix);
         } else {
             int sz = 1;
-            long pos = 1;
-            while (pos * radix > pos && pos * radix <= value) {
+            long pos = -1L;
+            value *= isMin;
+            while (pos * radix < pos && pos * radix >= value) {
                 pos *= radix;
                 ++sz;
             }
@@ -174,7 +180,7 @@ class TAbstractStringBuilder extends TObject implements TSerializable, TCharSequ
             if (!positive) {
                 buffer[target++] = '-';
             }
-            while (pos > 0) {
+            while (pos < 0) {
                 buffer[target++] = TCharacter.forDigit((int) (value / pos), radix);
                 value %= pos;
                 pos /= radix;

--- a/classlib/src/main/java/org/teavm/classlib/java/lang/TAbstractStringBuilder.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/lang/TAbstractStringBuilder.java
@@ -104,8 +104,7 @@ class TAbstractStringBuilder extends TObject implements TSerializable, TCharSequ
             positive = false;
             value = -value;
             isMin = value == TInteger.MIN_VALUE;
-        }
-        else {
+        } else {
             isMin = false;
         }
         if (value < radix && !isMin) {
@@ -160,8 +159,7 @@ class TAbstractStringBuilder extends TObject implements TSerializable, TCharSequ
             positive = false;
             value = -value;
             isMin = value == TLong.MIN_VALUE;
-        }
-        else {
+        } else {
             isMin = false;
         }
         if (value < radix && !isMin) {

--- a/tests/src/test/java/org/teavm/classlib/java/lang/StringBuilderTest.java
+++ b/tests/src/test/java/org/teavm/classlib/java/lang/StringBuilderTest.java
@@ -64,6 +64,13 @@ public class StringBuilderTest {
     }
 
     @Test
+    public void minIntegerAppended() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(-2147483648);
+        assertEquals("-2147483648", sb.toString());
+    }
+
+    @Test
     public void longAppended() {
         StringBuilder sb = new StringBuilder();
         sb.append(23L);
@@ -96,6 +103,29 @@ public class StringBuilderTest {
         StringBuilder sb = new StringBuilder();
         sb.append(9223372036854775807L);
         assertEquals("9223372036854775807", sb.toString());
+    }
+
+    @Test
+    public void minLongAppended() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(-9223372036854775808L);
+        assertEquals("-9223372036854775808", sb.toString());
+    }
+
+    // This appends the MIN_VALUE argument as an int, not a short.
+    @Test
+    public void minShortAppended() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(Short.MIN_VALUE);
+        assertEquals("-32768", sb.toString());
+    }
+
+    // This appends the MIN_VALUE argument as an int, not a byte.
+    @Test
+    public void minByteAppended() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(Byte.MIN_VALUE);
+        assertEquals("-128", sb.toString());
     }
 
     @Test


### PR DESCRIPTION
`Long.MIN_VALUE` and `Integer.MIN_VALUE` currently are appended as `-0`, instead of `-9223372036854775808` and `-2147483648`, respectively. This fixes the behavior for those values, and keeps other values how they are currently appended. I haven't tried radices other than 10, because the tests only cover radix 10; I added tests for the minimum values to augment the existing tests for the maximum values.

The reason the behavior was wrong before had to do with the oddball behavior of `-Long.MIN_VALUE`, which is the same as `Long.MIN_VALUE` (both negative, and this is also true for Integer). This always works with values significant enough to go into the second branch as negative numbers, which allows `-9223372036854775808` to be used as-is, and all positive numbers fit between `0` and `-9223372036854775808`.

I ran `gradlew check` and it said there were no failing tests or checkstyle violations, but it had some internal Exception that I couldn't find any more info on. I don't know if this is something I can or should change.

```
> Task :tests:test
java.lang.RuntimeException
	at org.teavm.vm.VMTest.throwException(VMTest.java:480)
	at org.teavm.vm.VMTest.lambda$catchExceptionFromLambda$0(VMTest.java:74)
	at org.teavm.vm.VMTest.catchExceptionFromLambda(VMTest.java:75)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at org.teavm.junit.TeaVMTestRunner$SimpleMethodRunner.run(TeaVMTestRunner.java:784)
	at org.teavm.junit.TeaVMTestRunner.runInJvm(TeaVMTestRunner.java:672)
	at org.teavm.junit.TeaVMTestRunner.runChild(TeaVMTestRunner.java:453)
	at org.teavm.junit.TeaVMTestRunner.run(TeaVMTestRunner.java:333)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.runTestClass(JUnitTestClassExecutor.java:108)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.execute(JUnitTestClassExecutor.java:58)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.execute(JUnitTestClassExecutor.java:40)
	at org.gradle.api.internal.tasks.testing.junit.AbstractJUnitTestClassProcessor.processTestClass(AbstractJUnitTestClassProcessor.java:60)
	at org.gradle.api.internal.tasks.testing.SuiteTestClassProcessor.processTestClass(SuiteTestClassProcessor.java:52)
	at jdk.internal.reflect.GeneratedMethodAccessor5.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:36)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
	at org.gradle.internal.dispatch.ContextClassLoaderDispatch.dispatch(ContextClassLoaderDispatch.java:33)
	at org.gradle.internal.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:94)
	at jdk.proxy1/jdk.proxy1.$Proxy2.processTestClass(Unknown Source)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker$2.run(TestWorker.java:176)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.executeAndMaintainThreadName(TestWorker.java:129)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:100)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:60)
	at org.gradle.process.internal.worker.child.ActionExecutionWorker.execute(ActionExecutionWorker.java:56)
	at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:113)
	at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:65)
	at worker.org.gradle.process.internal.worker.GradleWorkerMain.run(GradleWorkerMain.java:69)
	at worker.org.gradle.process.internal.worker.GradleWorkerMain.main(GradleWorkerMain.java:74)
> Task :tests:check
BUILD SUCCESSFUL in 12m 56s
```