### PR TITLE
Java reflection: return empty array when no reflection data available

### DIFF
--- a/classlib/src/main/java/org/teavm/classlib/java/lang/TClass.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/lang/TClass.java
@@ -45,6 +45,7 @@ import org.teavm.interop.DelegateTo;
 import org.teavm.interop.NoSideEffects;
 import org.teavm.interop.Unmanaged;
 import org.teavm.jso.core.JSArray;
+import org.teavm.jso.core.JSObjects;
 import org.teavm.platform.Platform;
 import org.teavm.platform.PlatformClass;
 import org.teavm.platform.PlatformSequence;
@@ -305,6 +306,9 @@ public class TClass<T> extends TObject implements TAnnotatedElement, TType {
             initReflection();
             JSClass jsClass = (JSClass) getPlatformClass().getMetadata();
             JSArray<JSField> jsFields = jsClass.getFields();
+            if (jsFields == null || jsFields == JSObjects.undefined()) {
+                jsFields = JSArray.create();
+            }
             declaredFields = new TField[jsFields.getLength()];
             for (int i = 0; i < jsFields.getLength(); ++i) {
                 JSField jsField = jsFields.get(i);
@@ -497,6 +501,9 @@ public class TClass<T> extends TObject implements TAnnotatedElement, TType {
             initReflection();
             JSClass jsClass = (JSClass) getPlatformClass().getMetadata();
             JSArray<JSMethodMember> jsMethods = jsClass.getMethods();
+            if (jsMethods == null || jsMethods == JSObjects.undefined()) {
+                jsMethods = JSArray.create();
+            }
             declaredMethods = new TMethod[jsMethods.getLength()];
             int count = 0;
             for (int i = 0; i < jsMethods.getLength(); ++i) {


### PR DESCRIPTION
getDeclaredMethods() and getDeclaredFields() call fails when no reflection data available. In this case process and return an empty array.