### PR TITLE
Added stripLeading and stripTrailing methods to String class

### DIFF
--- a/classlib/src/main/java/org/teavm/classlib/java/lang/TString.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/lang/TString.java
@@ -487,6 +487,22 @@ public class TString extends TObject implements TSerializable, TComparable<TStri
         return substring(lower, upper + 1);
     }
 
+    public TString stripLeading() {
+        var lower = 0;
+        while (lower < length() && Character.isWhitespace(charAt(lower))) {
+            ++lower;
+        }
+        return substring(lower, length());
+    }
+
+    public TString stripTrailing() {
+        var upper = length() - 1;
+        while (0 <= upper && Character.isWhitespace(charAt(upper))) {
+            --upper;
+        }
+        return substring(0, upper + 1);
+    }
+
     @Override
     public String toString() {
         return (String) (Object) this;

--- a/tests/src/test/java/org/teavm/classlib/java/lang/StringTest.java
+++ b/tests/src/test/java/org/teavm/classlib/java/lang/StringTest.java
@@ -210,6 +210,26 @@ public class StringTest {
     }
 
     @Test
+    public void stripLeadingWorks() {
+        assertEquals("ab   ", "  ab   ".stripLeading());
+        assertEquals("ab   ", "ab   ".stripLeading());
+        assertEquals("ab", "ab".stripLeading());
+        assertEquals("a b", "a b".stripLeading());
+        assertEquals("", "  \t".stripLeading());
+        assertEquals("ab", "\t\n \u2008\r\fab".stripLeading());
+    }
+
+    @Test
+    public void stripTrailingWorks() {
+        assertEquals("  ab", "  ab   ".stripTrailing());
+        assertEquals("  ab", "  ab".stripTrailing());
+        assertEquals("ab", "ab".stripTrailing());
+        assertEquals("a b", "a b".stripTrailing());
+        assertEquals("", "  \t".stripTrailing());
+        assertEquals("ab", "ab\t\n \u2008\r\f".stripTrailing());
+    }
+
+    @Test
     public void convertedToCharArray() {
         char[] array = "123".toCharArray();
         assertEquals(3, array.length);


### PR DESCRIPTION
The stripLeading and stripTrailing methods were added in Java 11 to the String class.

Based on the implementation of the existing strip method in TeaVM this commit adds the stripLeading() and stripTrailing() methods (and tests) to the String class in the class library.