### PR TITLE
Added the copyOf method to List, Set and Map interfaces

### DIFF
--- a/classlib/src/main/java/org/teavm/classlib/java/util/TList.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/util/TList.java
@@ -155,4 +155,8 @@ public interface TList<E> extends TCollection<E> {
         }
         return new TTemplateCollections.ImmutableArrayList<>(elements.clone());
     }
+
+    static <E> TList<E> copyOf(TCollection<? extends E> collection) {
+        return new TTemplateCollections.ImmutableArrayList<>(collection);
+    }
 }

--- a/classlib/src/main/java/org/teavm/classlib/java/util/TMap.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/util/TMap.java
@@ -294,4 +294,8 @@ public interface TMap<K, V> {
     static <K, V> TMap.Entry<K, V> entry(K k, V v) {
         return new TTemplateCollections.ImmutableEntry<>(requireNonNull(k), requireNonNull(v));
     }
+
+    static <K, V> TMap<K, V> copyOf(TMap<? extends K, ? extends V> map) {
+        return new TTemplateCollections.NEtriesMap<>(map);
+    }
 }

--- a/classlib/src/main/java/org/teavm/classlib/java/util/TSet.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/util/TSet.java
@@ -73,4 +73,8 @@ public interface TSet<E> extends TCollection<E> {
     static <E> TSet<E> of(E... elements) {
         return new TTemplateCollections.NElementSet<>(elements);
     }
+
+    static <E> TSet<E> copyOf(TCollection<E> collection) {
+        return new TTemplateCollections.NElementSet<>(collection);
+    }
 }

--- a/tests/src/test/java/org/teavm/classlib/java/util/ListTest.java
+++ b/tests/src/test/java/org/teavm/classlib/java/util/ListTest.java
@@ -19,6 +19,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -46,6 +48,24 @@ public class ListTest {
                 List.of("q", "w", "e", "r", "t", "y", "u", "i", "o", "p"));
         testOf(new String[] { "q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "a" },
                 List.of("q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "a"));
+    }
+
+    @Test
+    public void copyOfWorks() {
+        testOf(new String[0], List.copyOf(new ArrayList<>()));
+        testOf(new String[] { "q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "a" },
+                List.copyOf(Arrays.asList("q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "a")));
+
+        try {
+            // copyOf() must throw a NullPointerException on any 'null' element.
+            List<String> listWithNull = new ArrayList<>(1);
+            listWithNull.add(null);
+
+            List.copyOf(listWithNull);
+            fail("Expected NullPointerException");
+        } catch (NullPointerException e) {
+            // ok
+        }
     }
 
     private void testOf(String[] expected, List<String> actual) {

--- a/tests/src/test/java/org/teavm/classlib/java/util/MapTest.java
+++ b/tests/src/test/java/org/teavm/classlib/java/util/MapTest.java
@@ -54,6 +54,16 @@ public class MapTest {
                         Map.entry("p", 9), Map.entry("a", 10)));
     }
 
+    @Test
+    public void copyOfWorks() {
+        testOf(new String[0], Map.copyOf(new HashMap<>()));
+        testOf(new String[] { "q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "a" },
+                Map.copyOf(
+                        Map.ofEntries(Map.entry("q", 0), Map.entry("w", 1), Map.entry("e", 2), Map.entry("r", 3),
+                        Map.entry("t", 4), Map.entry("y", 5), Map.entry("u", 6), Map.entry("i", 7), Map.entry("o", 8),
+                        Map.entry("p", 9), Map.entry("a", 10))));
+    }
+
     private void testOf(String[] expected, Map<String, Integer> actual) {
         if (actual.size() != expected.length) {
             fail("Expected size is " + expected.length + ", actual size is " + actual.size());

--- a/tests/src/test/java/org/teavm/classlib/java/util/SetTest.java
+++ b/tests/src/test/java/org/teavm/classlib/java/util/SetTest.java
@@ -20,6 +20,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import org.junit.Test;
@@ -59,6 +61,24 @@ public class SetTest {
         expectIAE(() -> Set.of("q", "w", "e", "r", "t", "y", "u", "i", "q"));
         expectIAE(() -> Set.of("q", "w", "e", "r", "t", "y", "u", "i", "o", "q"));
         expectIAE(() -> Set.of("q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "q"));
+    }
+
+    @Test
+    public void copyOfWorks() {
+        testOf(new String[0], Set.copyOf(new HashSet<>()));
+        testOf(new String[] { "q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "a" },
+                Set.copyOf(Arrays.asList("q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "a")));
+        // Duplicates must be silently removed by copyOf(). Unlike of() where they throw an exception.
+        testOf(new String[] { "q", "e", "r", "u", "i", "o", "p" },
+                Set.copyOf(Arrays.asList("q", "q", "e", "r", "q", "q", "u", "i", "o", "p", "q")));
+
+        try {
+            // copyOf() must throw a NullPointerException on any 'null' element.
+            Set.copyOf(Arrays.asList("q", "q", "e", "r", "q", "q", "u", "i", "o", "p", "q", null));
+            fail("Expected NullPointerException");
+        } catch (NullPointerException e) {
+            // ok
+        }
     }
 
     private void expectIAE(Runnable r) {


### PR DESCRIPTION
The `copyOf` static method was added in Java 10 to the `List`, `Set` and `Map` interfaces. 

Since no other additions were made since Java 10 to these interfaces this commit brings the `List`, `Set` and `Map` interfaces to 100% completion for the latest LTS (Java 17) at the time of writing.