### PR TITLE
Added not method to Predicate interface

### DIFF
--- a/classlib/src/main/java/org/teavm/classlib/java/util/function/TPredicate.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/util/function/TPredicate.java
@@ -33,7 +33,11 @@ public interface TPredicate<T> {
         return t -> test(t) || other.test(t);
     }
 
-    default TPredicate<T> isEqual(Object targetRef) {
+    static <T> TPredicate<T> isEqual(Object targetRef) {
         return t -> TObjects.equals(t, targetRef);
+    }
+
+    static <T> TPredicate<T> not(TPredicate<? super T> target) {
+        return (TPredicate<T>) target.negate();
     }
 }

--- a/tests/src/test/java/org/teavm/classlib/java/util/function/PredicateTest.java
+++ b/tests/src/test/java/org/teavm/classlib/java/util/function/PredicateTest.java
@@ -1,0 +1,74 @@
+/*
+ *  Copyright 2023 Jasper Siepkes.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.teavm.classlib.java.util.function;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import java.util.function.Predicate;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.teavm.junit.TeaVMTestRunner;
+import org.teavm.junit.WholeClassCompilation;
+
+@RunWith(TeaVMTestRunner.class)
+@WholeClassCompilation
+public class PredicateTest {
+
+    @Test
+    public void andWorks() {
+        Predicate<Integer> greaterThenFour = x -> x > 4;
+        Predicate<Integer> greaterThenEight = x -> x > 8;
+
+        assertTrue(greaterThenFour.and(greaterThenEight).test(10));
+        assertFalse(greaterThenFour.and(greaterThenEight).test(6));
+    }
+
+    @Test
+    public void negateWorks() {
+        Predicate<Integer> greaterThenFour = x -> x > 4;
+
+        assertFalse(greaterThenFour.negate().test(10));
+        assertTrue(greaterThenFour.negate().test(1));
+    }
+
+    @Test
+    public void orWorks() {
+        Predicate<Integer> smallerThenFour = x -> x < 4;
+        Predicate<Integer> greaterThenEight = x -> x > 8;
+
+        assertTrue(smallerThenFour.or(greaterThenEight).test(3));
+        assertFalse(smallerThenFour.or(greaterThenEight).test(6));
+        assertTrue(smallerThenFour.or(greaterThenEight).test(9));
+    }
+
+    @Test
+    public void isEqualWorks() {
+        Predicate<Integer> isThree = Predicate.isEqual(3);
+
+        assertFalse(isThree.test(2));
+        assertTrue(isThree.test(3));
+        assertFalse(isThree.test(4));
+    }
+
+    @Test
+    public void notWorks() {
+        Predicate<Integer> isThree = x -> x == 3;
+
+        assertTrue(Predicate.not(isThree).test(2));
+        assertFalse(Predicate.not(isThree).test(3));
+        assertTrue(Predicate.not(isThree).test(4));
+    }
+}


### PR DESCRIPTION
Additionally added tests for all methods on the Predicate interface.

With this addition the Predicate interface is 100% complete for Java 17.

There is a problem with this PR however with which I need some help. The `isEqualWorks` and `notWorks` tests are disabled because they error out. Below is for example the error of `isEqualWorks` which tests the already existing `Predicate.isEqual()` method (so this PR doesn't add the implementation for `Predicate.isEqual()`, just the test) . Now as far as I can tell (and could test) the tests are reasonable and should work. However they error-out. If someone could point me in the right direction here I would be grateful!

```
java.lang.AssertionError: null
Error: null
    at $rt_exception (http://localhost:36079/tests/org/teavm/classlib/java/util/function/PredicateTest/isEqualWorks/test.js:256:31)
    at $rt_throw (http://localhost:36079/tests/org/teavm/classlib/java/util/function/PredicateTest/isEqualWorks/test.js:245:11)
    at oj_Assert_fail (http://localhost:36079/tests/org/teavm/classlib/java/util/function/PredicateTest/isEqualWorks/test.js:2075:5)
    at oj_Assert_assertTrue0 (http://localhost:36079/tests/org/teavm/classlib/java/util/function/PredicateTest/isEqualWorks/test.js:2061:9)
    at oj_Assert_assertTrue (http://localhost:36079/tests/org/teavm/classlib/java/util/function/PredicateTest/isEqualWorks/test.js:2064:5)
    at otcjuf_PredicateTest_isEqualWorks (http://localhost:36079/tests/org/teavm/classlib/java/util/function/PredicateTest/isEqualWorks/test.js:1981:5)
    at otj_TestEntryPoint$LauncherImpl0_launch (http://localhost:36079/tests/org/teavm/classlib/java/util/function/PredicateTest/isEqualWorks/test.js:1371:5)
    at jl_Object.$launch (http://localhost:36079/tests/org/teavm/classlib/java/util/function/PredicateTest/isEqualWorks/test.js:562:16)
    at otj_TestEntryPoint_run (http://localhost:36079/tests/org/teavm/classlib/java/util/function/PredicateTest/isEqualWorks/test.js:1393:23)
    at otj_TestJsEntryPoint_main (http://localhost:36079/tests/org/teavm/classlib/java/util/function/PredicateTest/isEqualWorks/test.js:1915:13)
java.lang.RuntimeException: java.lang.AssertionError: null
Error: null
    at $rt_exception (http://localhost:36079/tests/org/teavm/classlib/java/util/function/PredicateTest/isEqualWorks/test.js:256:31)
    at $rt_throw (http://localhost:36079/tests/org/teavm/classlib/java/util/function/PredicateTest/isEqualWorks/test.js:245:11)
    at oj_Assert_fail (http://localhost:36079/tests/org/teavm/classlib/java/util/function/PredicateTest/isEqualWorks/test.js:2075:5)
    at oj_Assert_assertTrue0 (http://localhost:36079/tests/org/teavm/classlib/java/util/function/PredicateTest/isEqualWorks/test.js:2061:9)
    at oj_Assert_assertTrue (http://localhost:36079/tests/org/teavm/classlib/java/util/function/PredicateTest/isEqualWorks/test.js:2064:5)
    at otcjuf_PredicateTest_isEqualWorks (http://localhost:36079/tests/org/teavm/classlib/java/util/function/PredicateTest/isEqualWorks/test.js:1981:5)
    at otj_TestEntryPoint$LauncherImpl0_launch (http://localhost:36079/tests/org/teavm/classlib/java/util/function/PredicateTest/isEqualWorks/test.js:1371:5)
    at jl_Object.$launch (http://localhost:36079/tests/org/teavm/classlib/java/util/function/PredicateTest/isEqualWorks/test.js:562:16)
    at otj_TestEntryPoint_run (http://localhost:36079/tests/org/teavm/classlib/java/util/function/PredicateTest/isEqualWorks/test.js:1393:23)
    at otj_TestJsEntryPoint_main (http://localhost:36079/tests/org/teavm/classlib/java/util/function/PredicateTest/isEqualWorks/test.js:1915:13)
	at org.teavm.junit.BrowserRunStrategy$TestCodeSocket.onWebSocketText(BrowserRunStrategy.java:375)
	at org.eclipse.jetty.websocket.common.events.JettyListenerEventDriver.onTextMessage(JettyListenerEventDriver.java:296)
	at org.eclipse.jetty.websocket.common.message.SimpleTextMessage.messageComplete(SimpleTextMessage.java:69)
	at org.eclipse.jetty.websocket.common.events.AbstractEventDriver.appendMessage(AbstractEventDriver.java:67)
	at org.eclipse.jetty.websocket.common.events.JettyListenerEventDriver.onTextFrame(JettyListenerEventDriver.java:235)
	at org.eclipse.jetty.websocket.common.events.AbstractEventDriver.incomingFrame(AbstractEventDriver.java:152)
	at org.eclipse.jetty.websocket.common.WebSocketSession.incomingFrame(WebSocketSession.java:326)
	at org.eclipse.jetty.websocket.common.extensions.AbstractExtension.nextIncomingFrame(AbstractExtension.java:148)
	at org.eclipse.jetty.websocket.common.extensions.compress.PerMessageDeflateExtension.nextIncomingFrame(PerMessageDeflateExtension.java:111)
	at org.eclipse.jetty.websocket.common.extensions.compress.CompressExtension.forwardIncoming(CompressExtension.java:169)
	at org.eclipse.jetty.websocket.common.extensions.compress.PerMessageDeflateExtension.incomingFrame(PerMessageDeflateExtension.java:90)
	at org.eclipse.jetty.websocket.common.extensions.ExtensionStack.incomingFrame(ExtensionStack.java:202)
	at org.eclipse.jetty.websocket.common.Parser.notifyFrame(Parser.java:225)
	at org.eclipse.jetty.websocket.common.Parser.parseSingleFrame(Parser.java:259)
	at org.eclipse.jetty.websocket.common.io.AbstractWebSocketConnection.onFillable(AbstractWebSocketConnection.java:459)
	at org.eclipse.jetty.websocket.common.io.AbstractWebSocketConnection.onFillable(AbstractWebSocketConnection.java:440)
	at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:311)
	at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:105)
	at org.eclipse.jetty.io.ChannelEndPoint$1.run(ChannelEndPoint.java:104)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.runTask(EatWhatYouKill.java:338)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.doProduce(EatWhatYouKill.java:315)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.tryProduce(EatWhatYouKill.java:173)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.run(EatWhatYouKill.java:131)
	at org.eclipse.jetty.util.thread.ReservedThreadExecutor$ReservedThread.run(ReservedThreadExecutor.java:409)
	at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:883)
	at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.run(QueuedThreadPool.java:1034)
	at java.base/java.lang.Thread.run(Thread.java:833)


org.teavm.classlib.java.util.function.PredicateTest > isEqualWorks FAILED
    java.lang.RuntimeException at BrowserRunStrategy.java:375
```