### PR TITLE
Fix commons-cli not being vendored

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -121,8 +121,10 @@ fun MavenPom.setupPom(project: Project) {
 }
 
 extensions.configure<DependencyRelocationExtension> {
-    library("libs", "commons-io") {
-        relocate("org.apache.commons", "org.teavm.apachecommons")
+    for (commonsLib in listOf("commons-io", "commons-cli")) {
+        library("libs", commonsLib) {
+            relocate("org.apache.commons", "org.teavm.apachecommons")
+        }
     }
     for (asmLib in listOf("asm", "asm-tree", "asm-analysis", "asm-commons", "asm-util")) {
         library("libs", asmLib) {


### PR DESCRIPTION
The relocating of `org.apache.commons` also includes `org.apache.commons.cli`. This means attempting to run the CLI fails as it cannot find classes under `org.teavm.apachecommons.cli`.

Vendoring commons-cli as well as commons-io fixes this issue.