### PR TITLE
Add Java 9's Arrays.equals and Arrays.mismatch

### DIFF
--- a/classlib/src/main/java/org/teavm/classlib/java/util/TArrays.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/util/TArrays.java
@@ -1253,6 +1253,25 @@ public class TArrays extends TObject {
         }
     }
 
+    private static int mismatchImpl(long[] a, long[] a2, int length) {
+        for (int i = 0; i < length; ++i) {
+            if (a[i] != a2[i]) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    public static int mismatch(long[] a, long[] a2) {
+        int length = Math.min(a.length, a2.length);
+        if (a == a2) {
+            return -1;
+        }
+
+        int mismatch = mismatchImpl(a, a2, length);
+        return mismatch < 0 && a.length != a2.length ? length : mismatch;
+    }
+
     public static boolean equals(long[] a, long[] a2) {
         if (a == a2) {
             return true;
@@ -1260,12 +1279,55 @@ public class TArrays extends TObject {
         if (a == null || a2 == null || a.length != a2.length) {
             return false;
         }
-        for (int i = 0; i < a.length; ++i) {
-            if (a[i] != a2[i]) {
-                return false;
+        return mismatchImpl(a, a2, a.length) < 0;
+    }
+
+    private static int mismatchImpl(long[] a, int aStart, long[] a2, int a2Start, int length) {
+        for (int i = 0; i < length; ++i) {
+            if (a[i + aStart] != a2[i + a2Start]) {
+                return i;
             }
         }
-        return true;
+        return -1;
+    }
+
+    public static int mismatch(long[] a, int aFromIndex, int aToIndex, long[] b, int bFromIndex, int bToIndex) {
+        checkInBounds(a.length, aFromIndex, aToIndex);
+        checkInBounds(b.length, bFromIndex, bToIndex);
+
+        int aLength = aToIndex - aFromIndex;
+        int bLength = bToIndex - bFromIndex;
+        int length = Math.min(aLength, bLength);
+        int mismatch = mismatchImpl(a, aFromIndex, b, bFromIndex, length);
+        return mismatch < 0 && aLength != bLength ? length : mismatch;
+    }
+
+    public static boolean equals(long[] a, int aFromIndex, int aToIndex, long[] b, int bFromIndex, int bToIndex) {
+        checkInBounds(a.length, aFromIndex, aToIndex);
+        checkInBounds(b.length, bFromIndex, bToIndex);
+
+        int aLength = aToIndex - aFromIndex;
+        int bLength = bToIndex - bFromIndex;
+        return aLength == bLength && mismatchImpl(a, aFromIndex, b, bFromIndex, aLength) < 0;
+    }
+
+    private static int mismatchImpl(int[] a, int[] a2, int length) {
+        for (int i = 0; i < length; ++i) {
+            if (a[i] != a2[i]) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    public static int mismatch(int[] a, int[] a2) {
+        int length = Math.min(a.length, a2.length);
+        if (a == a2) {
+            return -1;
+        }
+
+        int mismatch = mismatchImpl(a, a2, length);
+        return mismatch < 0 && a.length != a2.length ? length : mismatch;
     }
 
     public static boolean equals(int[] a, int[] a2) {
@@ -1275,12 +1337,55 @@ public class TArrays extends TObject {
         if (a == null || a2 == null || a.length != a2.length) {
             return false;
         }
-        for (int i = 0; i < a.length; ++i) {
-            if (a[i] != a2[i]) {
-                return false;
+        return mismatchImpl(a, a2, a.length) < 0;
+    }
+
+    private static int mismatchImpl(int[] a, int aStart, int[] a2, int a2Start, int length) {
+        for (int i = 0; i < length; ++i) {
+            if (a[i + aStart] != a2[i + a2Start]) {
+                return i;
             }
         }
-        return true;
+        return -1;
+    }
+
+    public static int mismatch(int[] a, int aFromIndex, int aToIndex, int[] b, int bFromIndex, int bToIndex) {
+        checkInBounds(a.length, aFromIndex, aToIndex);
+        checkInBounds(b.length, bFromIndex, bToIndex);
+
+        int aLength = aToIndex - aFromIndex;
+        int bLength = bToIndex - bFromIndex;
+        int length = Math.min(aLength, bLength);
+        int mismatch = mismatchImpl(a, aFromIndex, b, bFromIndex, length);
+        return mismatch < 0 && aLength != bLength ? length : mismatch;
+    }
+
+    public static boolean equals(int[] a, int aFromIndex, int aToIndex, int[] b, int bFromIndex, int bToIndex) {
+        checkInBounds(a.length, aFromIndex, aToIndex);
+        checkInBounds(b.length, bFromIndex, bToIndex);
+
+        int aLength = aToIndex - aFromIndex;
+        int bLength = bToIndex - bFromIndex;
+        return aLength == bLength && mismatchImpl(a, aFromIndex, b, bFromIndex, aLength) < 0;
+    }
+
+    private static int mismatchImpl(short[] a, short[] a2, int length) {
+        for (int i = 0; i < length; ++i) {
+            if (a[i] != a2[i]) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    public static int mismatch(short[] a, short[] a2) {
+        int length = Math.min(a.length, a2.length);
+        if (a == a2) {
+            return -1;
+        }
+
+        int mismatch = mismatchImpl(a, a2, length);
+        return mismatch < 0 && a.length != a2.length ? length : mismatch;
     }
 
     public static boolean equals(short[] a, short[] a2) {
@@ -1290,12 +1395,55 @@ public class TArrays extends TObject {
         if (a == null || a2 == null || a.length != a2.length) {
             return false;
         }
-        for (int i = 0; i < a.length; ++i) {
-            if (a[i] != a2[i]) {
-                return false;
+        return mismatchImpl(a, a2, a.length) < 0;
+    }
+
+    private static int mismatchImpl(short[] a, int aStart, short[] a2, int a2Start, int length) {
+        for (int i = 0; i < length; ++i) {
+            if (a[i + aStart] != a2[i + a2Start]) {
+                return i;
             }
         }
-        return true;
+        return -1;
+    }
+
+    public static int mismatch(short[] a, int aFromIndex, int aToIndex, short[] b, int bFromIndex, int bToIndex) {
+        checkInBounds(a.length, aFromIndex, aToIndex);
+        checkInBounds(b.length, bFromIndex, bToIndex);
+
+        int aLength = aToIndex - aFromIndex;
+        int bLength = bToIndex - bFromIndex;
+        int length = Math.min(aLength, bLength);
+        int mismatch = mismatchImpl(a, aFromIndex, b, bFromIndex, length);
+        return mismatch < 0 && aLength != bLength ? length : mismatch;
+    }
+
+    public static boolean equals(short[] a, int aFromIndex, int aToIndex, short[] b, int bFromIndex, int bToIndex) {
+        checkInBounds(a.length, aFromIndex, aToIndex);
+        checkInBounds(b.length, bFromIndex, bToIndex);
+
+        int aLength = aToIndex - aFromIndex;
+        int bLength = bToIndex - bFromIndex;
+        return aLength == bLength && mismatchImpl(a, aFromIndex, b, bFromIndex, aLength) < 0;
+    }
+
+    private static int mismatchImpl(char[] a, char[] a2, int length) {
+        for (int i = 0; i < length; ++i) {
+            if (a[i] != a2[i]) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    public static int mismatch(char[] a, char[] a2) {
+        int length = Math.min(a.length, a2.length);
+        if (a == a2) {
+            return -1;
+        }
+
+        int mismatch = mismatchImpl(a, a2, length);
+        return mismatch < 0 && a.length != a2.length ? length : mismatch;
     }
 
     public static boolean equals(char[] a, char[] a2) {
@@ -1305,12 +1453,55 @@ public class TArrays extends TObject {
         if (a == null || a2 == null || a.length != a2.length) {
             return false;
         }
-        for (int i = 0; i < a.length; ++i) {
-            if (a[i] != a2[i]) {
-                return false;
+        return mismatchImpl(a, a2, a.length) < 0;
+    }
+
+    private static int mismatchImpl(char[] a, int aStart, char[] a2, int a2Start, int length) {
+        for (int i = 0; i < length; ++i) {
+            if (a[i + aStart] != a2[i + a2Start]) {
+                return i;
             }
         }
-        return true;
+        return -1;
+    }
+
+    public static int mismatch(char[] a, int aFromIndex, int aToIndex, char[] b, int bFromIndex, int bToIndex) {
+        checkInBounds(a.length, aFromIndex, aToIndex);
+        checkInBounds(b.length, bFromIndex, bToIndex);
+
+        int aLength = aToIndex - aFromIndex;
+        int bLength = bToIndex - bFromIndex;
+        int length = Math.min(aLength, bLength);
+        int mismatch = mismatchImpl(a, aFromIndex, b, bFromIndex, length);
+        return mismatch < 0 && aLength != bLength ? length : mismatch;
+    }
+
+    public static boolean equals(char[] a, int aFromIndex, int aToIndex, char[] b, int bFromIndex, int bToIndex) {
+        checkInBounds(a.length, aFromIndex, aToIndex);
+        checkInBounds(b.length, bFromIndex, bToIndex);
+
+        int aLength = aToIndex - aFromIndex;
+        int bLength = bToIndex - bFromIndex;
+        return aLength == bLength && mismatchImpl(a, aFromIndex, b, bFromIndex, aLength) < 0;
+    }
+
+    private static int mismatchImpl(byte[] a, byte[] a2, int length) {
+        for (int i = 0; i < length; ++i) {
+            if (a[i] != a2[i]) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    public static int mismatch(byte[] a, byte[] a2) {
+        int length = Math.min(a.length, a2.length);
+        if (a == a2) {
+            return -1;
+        }
+
+        int mismatch = mismatchImpl(a, a2, length);
+        return mismatch < 0 && a.length != a2.length ? length : mismatch;
     }
 
     public static boolean equals(byte[] a, byte[] a2) {
@@ -1320,12 +1511,55 @@ public class TArrays extends TObject {
         if (a == null || a2 == null || a.length != a2.length) {
             return false;
         }
-        for (int i = 0; i < a.length; ++i) {
-            if (a[i] != a2[i]) {
-                return false;
+        return mismatchImpl(a, a2, a.length) < 0;
+    }
+
+    private static int mismatchImpl(byte[] a, int aStart, byte[] a2, int a2Start, int length) {
+        for (int i = 0; i < length; ++i) {
+            if (a[i + aStart] != a2[i + a2Start]) {
+                return i;
             }
         }
-        return true;
+        return -1;
+    }
+
+    public static int mismatch(byte[] a, int aFromIndex, int aToIndex, byte[] b, int bFromIndex, int bToIndex) {
+        checkInBounds(a.length, aFromIndex, aToIndex);
+        checkInBounds(b.length, bFromIndex, bToIndex);
+
+        int aLength = aToIndex - aFromIndex;
+        int bLength = bToIndex - bFromIndex;
+        int length = Math.min(aLength, bLength);
+        int mismatch = mismatchImpl(a, aFromIndex, b, bFromIndex, length);
+        return mismatch < 0 && aLength != bLength ? length : mismatch;
+    }
+
+    public static boolean equals(byte[] a, int aFromIndex, int aToIndex, byte[] b, int bFromIndex, int bToIndex) {
+        checkInBounds(a.length, aFromIndex, aToIndex);
+        checkInBounds(b.length, bFromIndex, bToIndex);
+
+        int aLength = aToIndex - aFromIndex;
+        int bLength = bToIndex - bFromIndex;
+        return aLength == bLength && mismatchImpl(a, aFromIndex, b, bFromIndex, aLength) < 0;
+    }
+
+    private static int mismatchImpl(float[] a, float[] a2, int length) {
+        for (int i = 0; i < length; ++i) {
+            if (a[i] != a2[i]) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    public static int mismatch(float[] a, float[] a2) {
+        int length = Math.min(a.length, a2.length);
+        if (a == a2) {
+            return -1;
+        }
+
+        int mismatch = mismatchImpl(a, a2, length);
+        return mismatch < 0 && a.length != a2.length ? length : mismatch;
     }
 
     public static boolean equals(float[] a, float[] a2) {
@@ -1335,12 +1569,55 @@ public class TArrays extends TObject {
         if (a == null || a2 == null || a.length != a2.length) {
             return false;
         }
-        for (int i = 0; i < a.length; ++i) {
-            if (a[i] != a2[i]) {
-                return false;
+        return mismatchImpl(a, a2, a.length) < 0;
+    }
+
+    private static int mismatchImpl(float[] a, int aStart, float[] a2, int a2Start, int length) {
+        for (int i = 0; i < length; ++i) {
+            if (a[i + aStart] != a2[i + a2Start]) {
+                return i;
             }
         }
-        return true;
+        return -1;
+    }
+
+    public static int mismatch(float[] a, int aFromIndex, int aToIndex, float[] b, int bFromIndex, int bToIndex) {
+        checkInBounds(a.length, aFromIndex, aToIndex);
+        checkInBounds(b.length, bFromIndex, bToIndex);
+
+        int aLength = aToIndex - aFromIndex;
+        int bLength = bToIndex - bFromIndex;
+        int length = Math.min(aLength, bLength);
+        int mismatch = mismatchImpl(a, aFromIndex, b, bFromIndex, length);
+        return mismatch < 0 && aLength != bLength ? length : mismatch;
+    }
+
+    public static boolean equals(float[] a, int aFromIndex, int aToIndex, float[] b, int bFromIndex, int bToIndex) {
+        checkInBounds(a.length, aFromIndex, aToIndex);
+        checkInBounds(b.length, bFromIndex, bToIndex);
+
+        int aLength = aToIndex - aFromIndex;
+        int bLength = bToIndex - bFromIndex;
+        return aLength == bLength && mismatchImpl(a, aFromIndex, b, bFromIndex, aLength) < 0;
+    }
+
+    private static int mismatchImpl(double[] a, double[] a2, int length) {
+        for (int i = 0; i < length; ++i) {
+            if (a[i] != a2[i]) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    public static int mismatch(double[] a, double[] a2) {
+        int length = Math.min(a.length, a2.length);
+        if (a == a2) {
+            return -1;
+        }
+
+        int mismatch = mismatchImpl(a, a2, length);
+        return mismatch < 0 && a.length != a2.length ? length : mismatch;
     }
 
     public static boolean equals(double[] a, double[] a2) {
@@ -1350,12 +1627,55 @@ public class TArrays extends TObject {
         if (a == null || a2 == null || a.length != a2.length) {
             return false;
         }
-        for (int i = 0; i < a.length; ++i) {
-            if (a[i] != a2[i]) {
-                return false;
+        return mismatchImpl(a, a2, a.length) < 0;
+    }
+
+    private static int mismatchImpl(double[] a, int aStart, double[] a2, int a2Start, int length) {
+        for (int i = 0; i < length; ++i) {
+            if (a[i + aStart] != a2[i + a2Start]) {
+                return i;
             }
         }
-        return true;
+        return -1;
+    }
+
+    public static int mismatch(double[] a, int aFromIndex, int aToIndex, double[] b, int bFromIndex, int bToIndex) {
+        checkInBounds(a.length, aFromIndex, aToIndex);
+        checkInBounds(b.length, bFromIndex, bToIndex);
+
+        int aLength = aToIndex - aFromIndex;
+        int bLength = bToIndex - bFromIndex;
+        int length = Math.min(aLength, bLength);
+        int mismatch = mismatchImpl(a, aFromIndex, b, bFromIndex, length);
+        return mismatch < 0 && aLength != bLength ? length : mismatch;
+    }
+
+    public static boolean equals(double[] a, int aFromIndex, int aToIndex, double[] b, int bFromIndex, int bToIndex) {
+        checkInBounds(a.length, aFromIndex, aToIndex);
+        checkInBounds(b.length, bFromIndex, bToIndex);
+
+        int aLength = aToIndex - aFromIndex;
+        int bLength = bToIndex - bFromIndex;
+        return aLength == bLength && mismatchImpl(a, aFromIndex, b, bFromIndex, aLength) < 0;
+    }
+
+    private static int mismatchImpl(boolean[] a, boolean[] a2, int length) {
+        for (int i = 0; i < length; ++i) {
+            if (a[i] != a2[i]) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    public static int mismatch(boolean[] a, boolean[] a2) {
+        int length = Math.min(a.length, a2.length);
+        if (a == a2) {
+            return -1;
+        }
+
+        int mismatch = mismatchImpl(a, a2, length);
+        return mismatch < 0 && a.length != a2.length ? length : mismatch;
     }
 
     public static boolean equals(boolean[] a, boolean[] a2) {
@@ -1365,12 +1685,55 @@ public class TArrays extends TObject {
         if (a == null || a2 == null || a.length != a2.length) {
             return false;
         }
-        for (int i = 0; i < a.length; ++i) {
-            if (a[i] != a2[i]) {
-                return false;
+        return mismatchImpl(a, a2, a.length) < 0;
+    }
+
+    private static int mismatchImpl(boolean[] a, int aStart, boolean[] a2, int a2Start, int length) {
+        for (int i = 0; i < length; ++i) {
+            if (a[i + aStart] != a2[i + a2Start]) {
+                return i;
             }
         }
-        return true;
+        return -1;
+    }
+
+    public static int mismatch(boolean[] a, int aFromIndex, int aToIndex, boolean[] b, int bFromIndex, int bToIndex) {
+        checkInBounds(a.length, aFromIndex, aToIndex);
+        checkInBounds(b.length, bFromIndex, bToIndex);
+
+        int aLength = aToIndex - aFromIndex;
+        int bLength = bToIndex - bFromIndex;
+        int length = Math.min(aLength, bLength);
+        int mismatch = mismatchImpl(a, aFromIndex, b, bFromIndex, length);
+        return mismatch < 0 && aLength != bLength ? length : mismatch;
+    }
+
+    public static boolean equals(boolean[] a, int aFromIndex, int aToIndex, boolean[] b, int bFromIndex, int bToIndex) {
+        checkInBounds(a.length, aFromIndex, aToIndex);
+        checkInBounds(b.length, bFromIndex, bToIndex);
+
+        int aLength = aToIndex - aFromIndex;
+        int bLength = bToIndex - bFromIndex;
+        return aLength == bLength && mismatchImpl(a, aFromIndex, b, bFromIndex, aLength) < 0;
+    }
+
+    private static int mismatchImpl(Object[] a, Object[] a2, int length) {
+        for (int i = 0; i < length; ++i) {
+            if (!Objects.equals(a[i], a2[i])) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    public static int mismatch(Object[] a, Object[] a2) {
+        int length = Math.min(a.length, a2.length);
+        if (a == a2) {
+            return -1;
+        }
+
+        int mismatch = mismatchImpl(a, a2, length);
+        return mismatch < 0 && a.length != a2.length ? length : mismatch;
     }
 
     public static boolean equals(Object[] a, Object[] a2) {
@@ -1380,12 +1743,36 @@ public class TArrays extends TObject {
         if (a == null || a2 == null || a.length != a2.length) {
             return false;
         }
-        for (int i = 0; i < a.length; ++i) {
-            if (!Objects.equals(a[i], a2[i])) {
-                return false;
+        return mismatchImpl(a, a2, a.length) < 0;
+    }
+
+    private static int mismatchImpl(Object[] a, int aStart, Object[] a2, int a2Start, int length) {
+        for (int i = 0; i < length; ++i) {
+            if (!Objects.equals(a[i + aStart], a2[i + a2Start])) {
+                return i;
             }
         }
-        return true;
+        return -1;
+    }
+
+    public static int mismatch(Object[] a, int aFromIndex, int aToIndex, Object[] b, int bFromIndex, int bToIndex) {
+        checkInBounds(a.length, aFromIndex, aToIndex);
+        checkInBounds(b.length, bFromIndex, bToIndex);
+
+        int aLength = aToIndex - aFromIndex;
+        int bLength = bToIndex - bFromIndex;
+        int length = Math.min(aLength, bLength);
+        int mismatch = mismatchImpl(a, aFromIndex, b, bFromIndex, length);
+        return mismatch < 0 && aLength != bLength ? length : mismatch;
+    }
+
+    public static boolean equals(Object[] a, int aFromIndex, int aToIndex, Object[] b, int bFromIndex, int bToIndex) {
+        checkInBounds(a.length, aFromIndex, aToIndex);
+        checkInBounds(b.length, bFromIndex, bToIndex);
+
+        int aLength = aToIndex - aFromIndex;
+        int bLength = bToIndex - bFromIndex;
+        return aLength == bLength && mismatchImpl(a, aFromIndex, b, bFromIndex, aLength) < 0;
     }
 
     public static int hashCode(boolean[] a) {
@@ -1604,9 +1991,7 @@ public class TArrays extends TObject {
     }
 
     public static <T> TStream<T> stream(T[] array, int startInclusive, int endExclusive) {
-        if (startInclusive < 0 || endExclusive < startInclusive || endExclusive > array.length) {
-            throw new ArrayIndexOutOfBoundsException();
-        }
+        checkInBounds(array.length, startInclusive, endExclusive);
         return new TArrayStreamImpl<>(array, startInclusive, endExclusive);
     }
 
@@ -1615,9 +2000,7 @@ public class TArrays extends TObject {
     }
 
     public static TIntStream stream(int[] array, int startInclusive, int endExclusive) {
-        if (startInclusive < 0 || endExclusive < startInclusive || endExclusive > array.length) {
-            throw new ArrayIndexOutOfBoundsException();
-        }
+        checkInBounds(array.length, startInclusive, endExclusive);
         return new TArrayIntStreamImpl(array, startInclusive, endExclusive);
     }
 
@@ -1626,9 +2009,7 @@ public class TArrays extends TObject {
     }
 
     public static TLongStream stream(long[] array, int startInclusive, int endExclusive) {
-        if (startInclusive < 0 || endExclusive < startInclusive || endExclusive > array.length) {
-            throw new ArrayIndexOutOfBoundsException();
-        }
+        checkInBounds(array.length, startInclusive, endExclusive);
         return new TArrayLongStreamImpl(array, startInclusive, endExclusive);
     }
 
@@ -1637,9 +2018,7 @@ public class TArrays extends TObject {
     }
 
     public static TDoubleStream stream(double[] array, int startInclusive, int endExclusive) {
-        if (startInclusive < 0 || endExclusive < startInclusive || endExclusive > array.length) {
-            throw new ArrayIndexOutOfBoundsException();
-        }
+        checkInBounds(array.length, startInclusive, endExclusive);
         return new TArrayDoubleStreamImpl(array, startInclusive, endExclusive);
     }
 
@@ -1664,6 +2043,12 @@ public class TArrays extends TObject {
     public static void setAll(double[] array, IntToDoubleFunction generator) {
         for (int i = 0; i < array.length; ++i) {
             array[i] = generator.applyAsDouble(i);
+        }
+    }
+
+    private static void checkInBounds(int length, int startInclusive, int endExclusive) {
+        if (startInclusive < 0 || endExclusive < startInclusive || endExclusive > length) {
+            throw new ArrayIndexOutOfBoundsException();
         }
     }
 }

--- a/classlib/src/main/java/org/teavm/classlib/java/util/TArrays.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/util/TArrays.java
@@ -1253,9 +1253,9 @@ public class TArrays extends TObject {
         }
     }
 
-    private static int mismatchImpl(long[] a, long[] a2, int length) {
+    private static int mismatchImpl(long[] a, int aStart, long[] a2, int a2Start, int length) {
         for (int i = 0; i < length; ++i) {
-            if (a[i] != a2[i]) {
+            if (a[i + aStart] != a2[i + a2Start]) {
                 return i;
             }
         }
@@ -1268,7 +1268,7 @@ public class TArrays extends TObject {
             return -1;
         }
 
-        int mismatch = mismatchImpl(a, a2, length);
+        int mismatch = mismatchImpl(a, 0, a2, 0, length);
         return mismatch < 0 && a.length != a2.length ? length : mismatch;
     }
 
@@ -1279,16 +1279,7 @@ public class TArrays extends TObject {
         if (a == null || a2 == null || a.length != a2.length) {
             return false;
         }
-        return mismatchImpl(a, a2, a.length) < 0;
-    }
-
-    private static int mismatchImpl(long[] a, int aStart, long[] a2, int a2Start, int length) {
-        for (int i = 0; i < length; ++i) {
-            if (a[i + aStart] != a2[i + a2Start]) {
-                return i;
-            }
-        }
-        return -1;
+        return mismatchImpl(a, 0, a2, 0, a.length) < 0;
     }
 
     public static int mismatch(long[] a, int aFromIndex, int aToIndex, long[] b, int bFromIndex, int bToIndex) {
@@ -1311,9 +1302,9 @@ public class TArrays extends TObject {
         return aLength == bLength && mismatchImpl(a, aFromIndex, b, bFromIndex, aLength) < 0;
     }
 
-    private static int mismatchImpl(int[] a, int[] a2, int length) {
+    private static int mismatchImpl(int[] a, int aStart, int[] a2, int a2Start, int length) {
         for (int i = 0; i < length; ++i) {
-            if (a[i] != a2[i]) {
+            if (a[i + aStart] != a2[i + a2Start]) {
                 return i;
             }
         }
@@ -1326,7 +1317,7 @@ public class TArrays extends TObject {
             return -1;
         }
 
-        int mismatch = mismatchImpl(a, a2, length);
+        int mismatch = mismatchImpl(a, 0, a2, 0, length);
         return mismatch < 0 && a.length != a2.length ? length : mismatch;
     }
 
@@ -1337,16 +1328,7 @@ public class TArrays extends TObject {
         if (a == null || a2 == null || a.length != a2.length) {
             return false;
         }
-        return mismatchImpl(a, a2, a.length) < 0;
-    }
-
-    private static int mismatchImpl(int[] a, int aStart, int[] a2, int a2Start, int length) {
-        for (int i = 0; i < length; ++i) {
-            if (a[i + aStart] != a2[i + a2Start]) {
-                return i;
-            }
-        }
-        return -1;
+        return mismatchImpl(a, 0, a2, 0, a.length) < 0;
     }
 
     public static int mismatch(int[] a, int aFromIndex, int aToIndex, int[] b, int bFromIndex, int bToIndex) {
@@ -1369,9 +1351,9 @@ public class TArrays extends TObject {
         return aLength == bLength && mismatchImpl(a, aFromIndex, b, bFromIndex, aLength) < 0;
     }
 
-    private static int mismatchImpl(short[] a, short[] a2, int length) {
+    private static int mismatchImpl(short[] a, int aStart, short[] a2, int a2Start, int length) {
         for (int i = 0; i < length; ++i) {
-            if (a[i] != a2[i]) {
+            if (a[i + aStart] != a2[i + a2Start]) {
                 return i;
             }
         }
@@ -1384,7 +1366,7 @@ public class TArrays extends TObject {
             return -1;
         }
 
-        int mismatch = mismatchImpl(a, a2, length);
+        int mismatch = mismatchImpl(a, 0, a2, 0, length);
         return mismatch < 0 && a.length != a2.length ? length : mismatch;
     }
 
@@ -1395,16 +1377,7 @@ public class TArrays extends TObject {
         if (a == null || a2 == null || a.length != a2.length) {
             return false;
         }
-        return mismatchImpl(a, a2, a.length) < 0;
-    }
-
-    private static int mismatchImpl(short[] a, int aStart, short[] a2, int a2Start, int length) {
-        for (int i = 0; i < length; ++i) {
-            if (a[i + aStart] != a2[i + a2Start]) {
-                return i;
-            }
-        }
-        return -1;
+        return mismatchImpl(a, 0, a2, 0, a.length) < 0;
     }
 
     public static int mismatch(short[] a, int aFromIndex, int aToIndex, short[] b, int bFromIndex, int bToIndex) {
@@ -1427,9 +1400,9 @@ public class TArrays extends TObject {
         return aLength == bLength && mismatchImpl(a, aFromIndex, b, bFromIndex, aLength) < 0;
     }
 
-    private static int mismatchImpl(char[] a, char[] a2, int length) {
+    private static int mismatchImpl(char[] a, int aStart, char[] a2, int a2Start, int length) {
         for (int i = 0; i < length; ++i) {
-            if (a[i] != a2[i]) {
+            if (a[i + aStart] != a2[i + a2Start]) {
                 return i;
             }
         }
@@ -1442,7 +1415,7 @@ public class TArrays extends TObject {
             return -1;
         }
 
-        int mismatch = mismatchImpl(a, a2, length);
+        int mismatch = mismatchImpl(a, 0, a2, 0, length);
         return mismatch < 0 && a.length != a2.length ? length : mismatch;
     }
 
@@ -1453,16 +1426,7 @@ public class TArrays extends TObject {
         if (a == null || a2 == null || a.length != a2.length) {
             return false;
         }
-        return mismatchImpl(a, a2, a.length) < 0;
-    }
-
-    private static int mismatchImpl(char[] a, int aStart, char[] a2, int a2Start, int length) {
-        for (int i = 0; i < length; ++i) {
-            if (a[i + aStart] != a2[i + a2Start]) {
-                return i;
-            }
-        }
-        return -1;
+        return mismatchImpl(a, 0, a2, 0, a.length) < 0;
     }
 
     public static int mismatch(char[] a, int aFromIndex, int aToIndex, char[] b, int bFromIndex, int bToIndex) {
@@ -1485,9 +1449,9 @@ public class TArrays extends TObject {
         return aLength == bLength && mismatchImpl(a, aFromIndex, b, bFromIndex, aLength) < 0;
     }
 
-    private static int mismatchImpl(byte[] a, byte[] a2, int length) {
+    private static int mismatchImpl(byte[] a, int aStart, byte[] a2, int a2Start, int length) {
         for (int i = 0; i < length; ++i) {
-            if (a[i] != a2[i]) {
+            if (a[i + aStart] != a2[i + a2Start]) {
                 return i;
             }
         }
@@ -1500,7 +1464,7 @@ public class TArrays extends TObject {
             return -1;
         }
 
-        int mismatch = mismatchImpl(a, a2, length);
+        int mismatch = mismatchImpl(a, 0, a2, 0, length);
         return mismatch < 0 && a.length != a2.length ? length : mismatch;
     }
 
@@ -1511,16 +1475,7 @@ public class TArrays extends TObject {
         if (a == null || a2 == null || a.length != a2.length) {
             return false;
         }
-        return mismatchImpl(a, a2, a.length) < 0;
-    }
-
-    private static int mismatchImpl(byte[] a, int aStart, byte[] a2, int a2Start, int length) {
-        for (int i = 0; i < length; ++i) {
-            if (a[i + aStart] != a2[i + a2Start]) {
-                return i;
-            }
-        }
-        return -1;
+        return mismatchImpl(a, 0, a2, 0, a.length) < 0;
     }
 
     public static int mismatch(byte[] a, int aFromIndex, int aToIndex, byte[] b, int bFromIndex, int bToIndex) {
@@ -1543,9 +1498,9 @@ public class TArrays extends TObject {
         return aLength == bLength && mismatchImpl(a, aFromIndex, b, bFromIndex, aLength) < 0;
     }
 
-    private static int mismatchImpl(float[] a, float[] a2, int length) {
+    private static int mismatchImpl(float[] a, int aStart, float[] a2, int a2Start, int length) {
         for (int i = 0; i < length; ++i) {
-            if (a[i] != a2[i]) {
+            if (a[i + aStart] != a2[i + a2Start]) {
                 return i;
             }
         }
@@ -1558,7 +1513,7 @@ public class TArrays extends TObject {
             return -1;
         }
 
-        int mismatch = mismatchImpl(a, a2, length);
+        int mismatch = mismatchImpl(a, 0, a2, 0, length);
         return mismatch < 0 && a.length != a2.length ? length : mismatch;
     }
 
@@ -1569,16 +1524,7 @@ public class TArrays extends TObject {
         if (a == null || a2 == null || a.length != a2.length) {
             return false;
         }
-        return mismatchImpl(a, a2, a.length) < 0;
-    }
-
-    private static int mismatchImpl(float[] a, int aStart, float[] a2, int a2Start, int length) {
-        for (int i = 0; i < length; ++i) {
-            if (a[i + aStart] != a2[i + a2Start]) {
-                return i;
-            }
-        }
-        return -1;
+        return mismatchImpl(a, 0, a2, 0, a.length) < 0;
     }
 
     public static int mismatch(float[] a, int aFromIndex, int aToIndex, float[] b, int bFromIndex, int bToIndex) {
@@ -1601,9 +1547,9 @@ public class TArrays extends TObject {
         return aLength == bLength && mismatchImpl(a, aFromIndex, b, bFromIndex, aLength) < 0;
     }
 
-    private static int mismatchImpl(double[] a, double[] a2, int length) {
+    private static int mismatchImpl(double[] a, int aStart, double[] a2, int a2Start, int length) {
         for (int i = 0; i < length; ++i) {
-            if (a[i] != a2[i]) {
+            if (a[i + aStart] != a2[i + a2Start]) {
                 return i;
             }
         }
@@ -1616,7 +1562,7 @@ public class TArrays extends TObject {
             return -1;
         }
 
-        int mismatch = mismatchImpl(a, a2, length);
+        int mismatch = mismatchImpl(a, 0, a2, 0, length);
         return mismatch < 0 && a.length != a2.length ? length : mismatch;
     }
 
@@ -1627,16 +1573,7 @@ public class TArrays extends TObject {
         if (a == null || a2 == null || a.length != a2.length) {
             return false;
         }
-        return mismatchImpl(a, a2, a.length) < 0;
-    }
-
-    private static int mismatchImpl(double[] a, int aStart, double[] a2, int a2Start, int length) {
-        for (int i = 0; i < length; ++i) {
-            if (a[i + aStart] != a2[i + a2Start]) {
-                return i;
-            }
-        }
-        return -1;
+        return mismatchImpl(a, 0, a2, 0, a.length) < 0;
     }
 
     public static int mismatch(double[] a, int aFromIndex, int aToIndex, double[] b, int bFromIndex, int bToIndex) {
@@ -1717,9 +1654,9 @@ public class TArrays extends TObject {
         return aLength == bLength && mismatchImpl(a, aFromIndex, b, bFromIndex, aLength) < 0;
     }
 
-    private static int mismatchImpl(Object[] a, Object[] a2, int length) {
+    private static int mismatchImpl(Object[] a, int aStart, Object[] a2, int a2Start, int length) {
         for (int i = 0; i < length; ++i) {
-            if (!Objects.equals(a[i], a2[i])) {
+            if (!Objects.equals(a[i + aStart], a2[i + a2Start])) {
                 return i;
             }
         }
@@ -1732,7 +1669,7 @@ public class TArrays extends TObject {
             return -1;
         }
 
-        int mismatch = mismatchImpl(a, a2, length);
+        int mismatch = mismatchImpl(a, 0, a2, 0, length);
         return mismatch < 0 && a.length != a2.length ? length : mismatch;
     }
 
@@ -1743,16 +1680,7 @@ public class TArrays extends TObject {
         if (a == null || a2 == null || a.length != a2.length) {
             return false;
         }
-        return mismatchImpl(a, a2, a.length) < 0;
-    }
-
-    private static int mismatchImpl(Object[] a, int aStart, Object[] a2, int a2Start, int length) {
-        for (int i = 0; i < length; ++i) {
-            if (!Objects.equals(a[i + aStart], a2[i + a2Start])) {
-                return i;
-            }
-        }
-        return -1;
+        return mismatchImpl(a, 0, a2, 0, a.length) < 0;
     }
 
     public static int mismatch(Object[] a, int aFromIndex, int aToIndex, Object[] b, int bFromIndex, int bToIndex) {

--- a/tests/src/test/java/org/teavm/classlib/java/util/ArraysTest.java
+++ b/tests/src/test/java/org/teavm/classlib/java/util/ArraysTest.java
@@ -16,6 +16,8 @@
 package org.teavm.classlib.java.util;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -154,5 +156,50 @@ public class ArraysTest {
                 new Object[] { Optional.of(3), Optional.empty() },
                 6
         }));
+    }
+
+    @Test
+    public void testArrayEquals() {
+        int[] array = { 1, 2, 3 };
+        int[] equal = { 1, 2, 3 };
+        int[] shorter = { 1, 2 };
+        int[] different = { 3, 1, 2 };
+
+        // Simple equals
+        assertTrue(Arrays.equals(array, array));
+        assertTrue(Arrays.equals(array, equal));
+
+        // Equal to null
+        assertTrue(Arrays.equals((int[]) null, null));
+        assertFalse(Arrays.equals(null, array));
+        assertFalse(Arrays.equals(array, null));
+
+        // Not equal
+        assertFalse(Arrays.equals(array, shorter));
+        assertFalse(Arrays.equals(array, different));
+
+        // Slices
+        assertTrue(Arrays.equals(array, 0, 1, shorter, 0, 1));
+        assertTrue(Arrays.equals(array, 0, 1, different, 1, 2));
+    }
+
+    @Test
+    public void testMismatch() {
+        int[] array = { 1, 2, 3 };
+        int[] equal = { 1, 2, 3 };
+        int[] shorter = { 1, 2 };
+        int[] different = { 3, 1, 2 };
+
+        // Simple equals
+        assertEquals(-1, Arrays.mismatch(array, array));
+        assertEquals(-1, Arrays.mismatch(array, equal));
+
+        // Not equal
+        assertEquals(2, Arrays.mismatch(array, shorter));
+        assertEquals(0, Arrays.mismatch(array, different));
+
+        // Slices
+        assertEquals(-1, Arrays.mismatch(array, 0, 1, shorter, 0, 1));
+        assertEquals(-1, Arrays.mismatch(array, 0, 1, different, 1, 2));
     }
 }


### PR DESCRIPTION
This adds support for Java 9's ranged `Arrays.equals`, as well as the new `Arrays.mismatch` function.

The implementation is the same for every primitive, so hopefully this isn't as terrible to review as it looks. The duplication is a shame, but short of templating the file, I'm not sure there's a better solution here.