### PR TITLE
Initial implementation for native to_____Case

### DIFF
--- a/classlib/src/main/java/org/teavm/classlib/java/lang/StringNativeGenerator.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/lang/StringNativeGenerator.java
@@ -27,26 +27,35 @@ import org.teavm.model.MethodReference;
 public class StringNativeGenerator implements Generator, DependencyPlugin {
     @Override
     public void generate(GeneratorContext context, SourceWriter writer, MethodReference methodRef) throws IOException {
-        if (methodRef.getName().equals("intern")) {
-            writer.append("return $rt_intern(").append(context.getParameterName(0)).append(");").softNewLine();
-        }
-        if (methodRef.getName().equals("toLowerCaseNative")) {
-            writer.append("return $rt_str($rt_ustr(")
-                    .append(context.getParameterName(1)).append(").toLowerCase());").softNewLine();
-        }
-        if (methodRef.getName().equals("toLocaleLowerCaseNative")) {
-            writer.append("return $rt_str($rt_ustr(")
-                    .append(context.getParameterName(1)).append(").toLocaleLowerCase($rt_ustr(")
-                    .append(context.getParameterName(2)).append(")));").softNewLine();
-        }
-        if (methodRef.getName().equals("toUpperCaseNative")) {
-            writer.append("return $rt_str($rt_ustr(")
-                    .append(context.getParameterName(1)).append(").toUpperCase());").softNewLine();
-        }
-        if (methodRef.getName().equals("toLocaleUpperCaseNative")) {
-            writer.append("return $rt_str($rt_ustr(")
-                    .append(context.getParameterName(1)).append(").toLocaleUpperCase($rt_ustr(")
-                    .append(context.getParameterName(2)).append(")));").softNewLine();
+        switch (methodRef.getName()) {
+            case "intern":
+                writer.append("return").ws().appendFunction("$rt_intern")
+                        .append("(").append(context.getParameterName(0)).append(");").softNewLine();
+                break;
+            case "toLowerCaseNative":
+                writer.append("return").ws().appendFunction("$rt_str").append("(")
+                        .appendFunction("$rt_ustr").append("(")
+                        .append(context.getParameterName(1)).append(").toLowerCase());").softNewLine();
+                break;
+            case "toLocaleLowerCaseNative":
+                writer.append("return").ws().appendFunction("$rt_str").append("(")
+                        .appendFunction("$rt_ustr").append("(")
+                        .append(context.getParameterName(1)).append(").toLocaleLowerCase(")
+                        .appendFunction("$rt_ustr").append("(")
+                        .append(context.getParameterName(2)).append(")));").softNewLine();
+                break;
+            case "toUpperCaseNative":
+                writer.append("return").ws().appendFunction("$rt_str").append("(")
+                        .appendFunction("$rt_ustr").append("(")
+                        .append(context.getParameterName(1)).append(").toUpperCase());").softNewLine();
+                break;
+            case "toLocaleUpperCaseNative":
+                writer.append("return").ws().appendFunction("$rt_str").append("(")
+                        .appendFunction("$rt_ustr").append("(")
+                        .append(context.getParameterName(1)).append(").toLocaleUpperCase(")
+                        .appendFunction("$rt_ustr").append("(")
+                        .append(context.getParameterName(2)).append(")));").softNewLine();
+                break;
         }
     }
 

--- a/classlib/src/main/java/org/teavm/classlib/java/lang/StringNativeGenerator.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/lang/StringNativeGenerator.java
@@ -31,10 +31,10 @@ public class StringNativeGenerator implements Generator, DependencyPlugin {
             writer.append("return $rt_intern(").append(context.getParameterName(0)).append(");").softNewLine();
         }
         if (methodRef.getName().equals("toLowerCaseNative") && methodRef.parameterCount() == 1) {
-            writer.append("return ").append(context.getParameterName(1)).append(".toLowerCase();").softNewLine();
+            writer.append("return $rt_str($rt_ustr(").append(context.getParameterName(1)).append(").toLowerCase());").softNewLine();
         }
         if (methodRef.getName().equals("toUpperCaseNative") && methodRef.parameterCount() == 1) {
-            writer.append("return ").append(context.getParameterName(1)).append(".toUpperCase();").softNewLine();
+            writer.append("return $rt_str($rt_ustr(").append(context.getParameterName(1)).append(").toUpperCase());").softNewLine();
         }
     }
 

--- a/classlib/src/main/java/org/teavm/classlib/java/lang/StringNativeGenerator.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/lang/StringNativeGenerator.java
@@ -30,10 +30,10 @@ public class StringNativeGenerator implements Generator, DependencyPlugin {
         if (methodRef.getName().equals("intern")) {
             writer.append("return $rt_intern(").append(context.getParameterName(0)).append(");").softNewLine();
         }
-        if (methodRef.getName().equals("toLowerCaseNative") && methodRef.parameterCount() == 1) {
+        if (methodRef.getName().equals("toLowerCaseNative")) {
             writer.append("return $rt_str($rt_ustr(").append(context.getParameterName(1)).append(").toLowerCase());").softNewLine();
         }
-        if (methodRef.getName().equals("toUpperCaseNative") && methodRef.parameterCount() == 1) {
+        if (methodRef.getName().equals("toUpperCaseNative")) {
             writer.append("return $rt_str($rt_ustr(").append(context.getParameterName(1)).append(").toUpperCase());").softNewLine();
         }
     }
@@ -48,6 +48,10 @@ public class StringNativeGenerator implements Generator, DependencyPlugin {
                     .propagate(0, agent.getType("java.lang.String"))
                     .propagate(1, agent.getType("java.lang.String"))
                     .use();
+        }
+        if (method.getReference().getName().equals("toLowerCaseNative")
+                || method.getReference().getName().equals("toUpperCaseNative")) {
+            method.getResult().propagate(agent.getType("java.lang.String"));
         }
     }
 }

--- a/classlib/src/main/java/org/teavm/classlib/java/lang/StringNativeGenerator.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/lang/StringNativeGenerator.java
@@ -31,10 +31,22 @@ public class StringNativeGenerator implements Generator, DependencyPlugin {
             writer.append("return $rt_intern(").append(context.getParameterName(0)).append(");").softNewLine();
         }
         if (methodRef.getName().equals("toLowerCaseNative")) {
-            writer.append("return $rt_str($rt_ustr(").append(context.getParameterName(1)).append(").toLowerCase());").softNewLine();
+            writer.append("return $rt_str($rt_ustr(")
+                    .append(context.getParameterName(1)).append(").toLowerCase());").softNewLine();
+        }
+        if (methodRef.getName().equals("toLocaleLowerCaseNative")) {
+            writer.append("return $rt_str($rt_ustr(")
+                    .append(context.getParameterName(1)).append(").toLocaleLowerCase($rt_ustr(")
+                    .append(context.getParameterName(2)).append(")));").softNewLine();
         }
         if (methodRef.getName().equals("toUpperCaseNative")) {
-            writer.append("return $rt_str($rt_ustr(").append(context.getParameterName(1)).append(").toUpperCase());").softNewLine();
+            writer.append("return $rt_str($rt_ustr(")
+                    .append(context.getParameterName(1)).append(").toUpperCase());").softNewLine();
+        }
+        if (methodRef.getName().equals("toLocaleUpperCaseNative")) {
+            writer.append("return $rt_str($rt_ustr(")
+                    .append(context.getParameterName(1)).append(").toLocaleUpperCase($rt_ustr(")
+                    .append(context.getParameterName(2)).append(")));").softNewLine();
         }
     }
 
@@ -50,7 +62,9 @@ public class StringNativeGenerator implements Generator, DependencyPlugin {
                     .use();
         }
         if (method.getReference().getName().equals("toLowerCaseNative")
-                || method.getReference().getName().equals("toUpperCaseNative")) {
+                || method.getReference().getName().equals("toUpperCaseNative")
+                || method.getReference().getName().equals("toLocaleLowerCaseNative")
+                || method.getReference().getName().equals("toLocaleUpperCaseNative")) {
             method.getResult().propagate(agent.getType("java.lang.String"));
         }
     }

--- a/classlib/src/main/java/org/teavm/classlib/java/lang/StringNativeGenerator.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/lang/StringNativeGenerator.java
@@ -30,6 +30,12 @@ public class StringNativeGenerator implements Generator, DependencyPlugin {
         if (methodRef.getName().equals("intern")) {
             writer.append("return $rt_intern(").append(context.getParameterName(0)).append(");").softNewLine();
         }
+        if (methodRef.getName().equals("toLowerCaseNative") && methodRef.parameterCount() == 1) {
+            writer.append("return ").append(context.getParameterName(1)).append(".toLowerCase();").softNewLine();
+        }
+        if (methodRef.getName().equals("toUpperCaseNative") && methodRef.parameterCount() == 1) {
+            writer.append("return ").append(context.getParameterName(1)).append(".toUpperCase();").softNewLine();
+        }
     }
 
     @Override

--- a/classlib/src/main/java/org/teavm/classlib/java/lang/TString.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/lang/TString.java
@@ -642,6 +642,11 @@ public class TString extends TObject implements TSerializable, TComparable<TStri
     @NoSideEffects
     private static native TString toLowerCaseNative(TString str);
 
+    @GeneratedBy(StringNativeGenerator.class)
+    @PluggableDependency(StringNativeGenerator.class)
+    @NoSideEffects
+    private static native TString toLocaleLowerCaseNative(TString str, String localeTag);
+
     private static TString toLowerCaseImpl(char[] characters) {
         if (characters.length == 0) {
             return EMPTY;
@@ -669,6 +674,10 @@ public class TString extends TObject implements TSerializable, TComparable<TStri
     }
 
     public TString toLowerCase(TLocale locale) {
+        if (PlatformDetector.isJavaScript()) {
+            String tag = locale.toLanguageTag();
+            return tag.isEmpty() ? toLowerCaseNative(this) : toLocaleLowerCaseNative(this, tag);
+        }
         return toLowerCaseImpl(characters);
     }
 
@@ -676,6 +685,11 @@ public class TString extends TObject implements TSerializable, TComparable<TStri
     @PluggableDependency(StringNativeGenerator.class)
     @NoSideEffects
     private static native TString toUpperCaseNative(TString str);
+
+    @GeneratedBy(StringNativeGenerator.class)
+    @PluggableDependency(StringNativeGenerator.class)
+    @NoSideEffects
+    private static native TString toLocaleUpperCaseNative(TString str, String localeTag);
 
     private static TString toUpperCaseImpl(char[] characters) {
         if (characters.length == 0) {
@@ -704,6 +718,10 @@ public class TString extends TObject implements TSerializable, TComparable<TStri
     }
 
     public TString toUpperCase(TLocale locale) {
+        if (PlatformDetector.isJavaScript()) {
+            String tag = locale.toLanguageTag();
+            return tag.isEmpty() ? toUpperCaseNative(this) : toLocaleUpperCaseNative(this, tag);
+        }
         return toUpperCaseImpl(characters);
     }
 

--- a/classlib/src/main/java/org/teavm/classlib/java/lang/TString.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/lang/TString.java
@@ -638,6 +638,7 @@ public class TString extends TObject implements TSerializable, TComparable<TStri
     }
 
     @GeneratedBy(StringNativeGenerator.class)
+    @PluggableDependency(StringNativeGenerator.class)
     @NoSideEffects
     private static native TString toLowerCaseNative(TString str);
 
@@ -672,6 +673,7 @@ public class TString extends TObject implements TSerializable, TComparable<TStri
     }
 
     @GeneratedBy(StringNativeGenerator.class)
+    @PluggableDependency(StringNativeGenerator.class)
     @NoSideEffects
     private static native TString toUpperCaseNative(TString str);
 

--- a/classlib/src/main/java/org/teavm/classlib/java/lang/TString.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/lang/TString.java
@@ -17,6 +17,7 @@ package org.teavm.classlib.java.lang;
 
 import java.util.Locale;
 import org.teavm.backend.javascript.spi.GeneratedBy;
+import org.teavm.classlib.PlatformDetector;
 import org.teavm.classlib.java.io.TSerializable;
 import org.teavm.classlib.java.io.TUnsupportedEncodingException;
 import org.teavm.classlib.java.nio.TByteBuffer;
@@ -34,7 +35,7 @@ import org.teavm.interop.NoSideEffects;
 public class TString extends TObject implements TSerializable, TComparable<TString>, TCharSequence {
     private static final char[] EMPTY_CHARS = new char[0];
     private static final TString EMPTY = new TString();
-    public static final TComparator<TString> CASE_INSENSITIVE_ORDER = (o1, o2) -> o1.compareToIgnoreCase(o2);
+    public static final TComparator<TString> CASE_INSENSITIVE_ORDER = TString::compareToIgnoreCase;
     private char[] characters;
     private transient int hashCode;
 
@@ -636,9 +637,13 @@ public class TString extends TObject implements TSerializable, TComparable<TStri
         return hashCode;
     }
 
-    public TString toLowerCase() {
-        if (isEmpty()) {
-            return this;
+    @GeneratedBy(StringNativeGenerator.class)
+    @NoSideEffects
+    private static native TString toLowerCaseNative(TString str);
+
+    private static TString toLowerCaseImpl(char[] characters) {
+        if (characters.length == 0) {
+            return EMPTY;
         }
         int[] codePoints = new int[characters.length];
         int codePointCount = 0;
@@ -655,13 +660,24 @@ public class TString extends TObject implements TSerializable, TComparable<TStri
         return new TString(codePoints, 0, codePointCount);
     }
 
-    public TString toLowerCase(TLocale locale) {
-        return toLowerCase();
+    public TString toLowerCase() {
+        if (PlatformDetector.isJavaScript()) {
+            return toLowerCaseNative(this);
+        }
+        return toLowerCaseImpl(characters);
     }
 
-    public TString toUpperCase() {
-        if (isEmpty()) {
-            return this;
+    public TString toLowerCase(TLocale locale) {
+        return toLowerCaseImpl(characters);
+    }
+
+    @GeneratedBy(StringNativeGenerator.class)
+    @NoSideEffects
+    private static native TString toUpperCaseNative(TString str);
+
+    private static TString toUpperCaseImpl(char[] characters) {
+        if (characters.length == 0) {
+            return EMPTY;
         }
         int[] codePoints = new int[characters.length];
         int codePointCount = 0;
@@ -678,8 +694,15 @@ public class TString extends TObject implements TSerializable, TComparable<TStri
         return new TString(codePoints, 0, codePointCount);
     }
 
+    public TString toUpperCase() {
+        if (PlatformDetector.isJavaScript()) {
+            return toUpperCaseNative(this);
+        }
+        return toUpperCaseImpl(characters);
+    }
+
     public TString toUpperCase(TLocale locale) {
-        return toUpperCase();
+        return toUpperCaseImpl(characters);
     }
 
     @GeneratedBy(StringNativeGenerator.class)

--- a/classlib/src/main/java/org/teavm/classlib/java/util/TLocale.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/util/TLocale.java
@@ -88,7 +88,7 @@ public final class TLocale implements TCloneable, TSerializable {
         if (language == null || country == null || variant == null) {
             throw new NullPointerException();
         }
-        if (language.length() == 0 && country.length() == 0) {
+        if (language.isEmpty() && country.isEmpty()) {
             languageCode = "";
             countryCode = "";
             variantCode = variant;
@@ -200,18 +200,18 @@ public final class TLocale implements TCloneable, TSerializable {
     public String getDisplayName(TLocale locale) {
         int count = 0;
         StringBuilder buffer = new StringBuilder();
-        if (languageCode.length() > 0) {
+        if (!languageCode.isEmpty()) {
             buffer.append(getDisplayLanguage(locale));
             count++;
         }
-        if (countryCode.length() > 0) {
+        if (!countryCode.isEmpty()) {
             if (count == 1) {
                 buffer.append(" (");
             }
             buffer.append(getDisplayCountry(locale));
             count++;
         }
-        if (variantCode.length() > 0) {
+        if (!variantCode.isEmpty()) {
             if (count == 1) {
                 buffer.append(" (");
             } else if (count == 2) {
@@ -260,16 +260,30 @@ public final class TLocale implements TCloneable, TSerializable {
     public String toString() {
         StringBuilder result = new StringBuilder();
         result.append(languageCode);
-        if (countryCode.length() > 0) {
+        if (!countryCode.isEmpty()) {
             result.append('_');
             result.append(countryCode);
         }
-        if (variantCode.length() > 0 && result.length() > 0) {
-            if (0 == countryCode.length()) {
+        if (!variantCode.isEmpty() && result.length() > 0) {
+            if (countryCode.isEmpty()) {
                 result.append("__");
             } else {
                 result.append('_');
             }
+            result.append(variantCode);
+        }
+        return result.toString();
+    }
+
+    public String toLanguageTag() {
+        StringBuilder result = new StringBuilder();
+        result.append(languageCode);
+        if (!countryCode.isEmpty()) {
+            result.append('-');
+            result.append(countryCode);
+        }
+        if (!variantCode.isEmpty() && result.length() > 0) {
+            result.append('-');
             result.append(variantCode);
         }
         return result.toString();

--- a/tests/src/test/java/org/teavm/classlib/java/lang/StringTest.java
+++ b/tests/src/test/java/org/teavm/classlib/java/lang/StringTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import java.io.UnsupportedEncodingException;
+import java.util.Locale;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.teavm.junit.TeaVMTestRunner;
@@ -304,14 +305,24 @@ public class StringTest {
         assertEquals('d', str.charAt(8));
     }
 
+    private String common = "i̇stanbul";
+    private String turkish = "istanbul";
+
     @Test
     public void makesLowerCase() {
         assertEquals("foo bar", "FoO bAr".toLowerCase());
+        assertEquals(turkish, "İstanbul".toLowerCase(new Locale("tr", "TR")));
+        assertEquals(common, "İstanbul".toLowerCase(Locale.US));
+        assertNotEquals(turkish, common);
     }
 
     @Test
     public void makesUpperCase() {
         assertEquals("FOO BAR", "FoO bAr".toUpperCase());
+        assertEquals("İSTANBUL", common.toUpperCase(Locale.US));
+        assertEquals("İSTANBUL", turkish.toUpperCase(new Locale("tr", "TR")));
+        assertNotEquals(common.toUpperCase(Locale.US), turkish.toUpperCase(new Locale("tr", "TR")));
+        assertEquals(common.toUpperCase(Locale.US), common.toUpperCase(Locale.CANADA));
     }
 
     @Test

--- a/tests/src/test/java/org/teavm/classlib/java/lang/StringTest.java
+++ b/tests/src/test/java/org/teavm/classlib/java/lang/StringTest.java
@@ -310,6 +310,11 @@ public class StringTest {
     }
 
     @Test
+    public void makesUpperCase() {
+        assertEquals("FOO BAR", "FoO bAr".toUpperCase());
+    }
+
+    @Test
     public void interns() {
         assertSame("xabc".substring(1).intern(), "abcx".substring(0, 3).intern());
         assertSame("xabc".substring(1).intern(), "abc");

--- a/tests/src/test/java/org/teavm/classlib/java/util/LocaleTest.java
+++ b/tests/src/test/java/org/teavm/classlib/java/util/LocaleTest.java
@@ -59,4 +59,14 @@ public class LocaleTest {
         assertEquals("Соединенные Штаты", usEnglish.getDisplayCountry(russian));
         assertEquals("Россия", russian.getDisplayCountry(russian));
     }
+
+    @Test
+    public void testLanguageTag() {
+        assertEquals("fr-CA", Locale.CANADA_FRENCH.toLanguageTag());
+        assertEquals("zh", Locale.CHINESE.toLanguageTag());
+        assertEquals("zh-TW", Locale.TRADITIONAL_CHINESE.toLanguageTag());
+        assertEquals("zh-CN", Locale.SIMPLIFIED_CHINESE.toLanguageTag());
+        assertEquals("en-GB", Locale.UK.toLanguageTag());
+        assertEquals("en-US", Locale.US.toLanguageTag());
+    }
 }


### PR DESCRIPTION
@konsoletyper tried to implement native toUpperCase and toLowerCase methods for String.
There are few reasons to do this.
1. Performance of native call will probably be faster than emulated method.
2. Code JS size will be reduced.
3. Possible locale issues are automatically fixed.
Also for locale variable which is skipped now https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/toLocaleLowerCase can be used.

For some reason generated methods are not working. I checked that String -> JSString conversion is made just by `return str;`, so I assumed that variable in method is also native String. But for some reason it is not working.