### PR TITLE
#573: add TResourceBundle.containsKey

### DIFF
--- a/classlib/src/main/java/org/teavm/classlib/java/util/TResourceBundle.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/util/TResourceBundle.java
@@ -138,6 +138,18 @@ public abstract class TResourceBundle {
         throw new MissingResourceException("", last.getClass().getName(), key);
     }
 
+    public boolean containsKey(String key) {
+        TResourceBundle theParent = this;
+        do {
+            Object result = theParent.handleGetObject(key);
+            if (result != null) {
+                return true;
+            }
+            theParent = theParent.parent;
+        } while (theParent != null);
+        return false;
+    }
+    
     public final String getString(String key) {
         return (String) getObject(key);
     }


### PR DESCRIPTION
fixes #573 by adding method `containsKey` to `TResourceBundle` for JDK compatibility.