### PR TITLE
Speed up equals for Double and Float in JS

### DIFF
--- a/classlib/src/main/java/org/teavm/classlib/java/lang/TDouble.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/lang/TDouble.java
@@ -16,6 +16,7 @@
 package org.teavm.classlib.java.lang;
 
 import org.teavm.backend.javascript.spi.InjectedBy;
+import org.teavm.classlib.PlatformDetector;
 import org.teavm.classlib.impl.text.DoubleSynthesizer;
 import org.teavm.interop.Import;
 import org.teavm.interop.NoSideEffects;
@@ -201,7 +202,9 @@ public class TDouble extends TNumber implements TComparable<TDouble> {
         if (this == other) {
             return true;
         }
-        return other instanceof TDouble && doubleToLongBits(((TDouble) other).value) == doubleToLongBits(value);
+        return other instanceof TDouble && PlatformDetector.isJavaScript()
+                ? TDouble.compare(((TDouble) other).value, value) == 0
+                : doubleToLongBits(((TDouble) other).value) == doubleToLongBits(value);
     }
 
     @Override

--- a/classlib/src/main/java/org/teavm/classlib/java/lang/TFloat.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/lang/TFloat.java
@@ -15,6 +15,7 @@
  */
 package org.teavm.classlib.java.lang;
 
+import org.teavm.classlib.PlatformDetector;
 import org.teavm.classlib.impl.text.FloatSynthesizer;
 import org.teavm.interop.Import;
 import org.teavm.interop.NoSideEffects;
@@ -85,7 +86,9 @@ public class TFloat extends TNumber implements TComparable<TFloat> {
         if (this == other) {
             return true;
         }
-        return other instanceof TFloat && floatToIntBits(((TFloat) other).value) == floatToIntBits(value);
+        return other instanceof TFloat && PlatformDetector.isJavaScript()
+                ? TFloat.compare(((TFloat) other).value, value) == 0
+                : floatToIntBits(((TFloat) other).value) == floatToIntBits(value);
     }
 
     @Override


### PR DESCRIPTION
Explanation:
```java
public static void main(String[] args) {
        Double[] array = Stream.generate(() -> Double.longBitsToDouble(ThreadLocalRandom.current().nextLong()))
                .limit(10_000_000).toArray(Double[]::new);
        int counter = 0;
        for (int i = 0; i < array.length - 1; i++) {
            counter += array[i].equals(array[i + 1]) ? 0 : 1;
        }
        long time = System.currentTimeMillis();
        for (int i = 0; i < array.length - 1; i++) {
            counter += array[i].equals(array[i + 1]) ? 0 : 1;
        }
        System.out.println("Time " + (System.currentTimeMillis() - time) + " counter " + counter);
    }
```
this simple benchmark shows:
Chrome:
Old: Time 406 counter 15001524
New: Time 94 counter 14991638
Firefox:
Old: Time 2390 counter 14991538
New: Time 142 counter 14990878
So, in JS we got 4 to 15 speed improvement by this simple change.