### PR TITLE
Fix missing .shift() in ReferenceQueue.poll

### DIFF
--- a/classlib/src/main/resources/org/teavm/classlib/java/lang/ref/ReferenceQueue.js
+++ b/classlib/src/main/resources/org/teavm/classlib/java/lang/ref/ReferenceQueue.js
@@ -28,6 +28,6 @@ function init() {
 }
 
 function poll() {
-    var value = this[teavm_javaField("java.lang.ref.ReferenceQueue", "inner")];
+    var value = this[teavm_javaField("java.lang.ref.ReferenceQueue", "inner")].shift();
     return typeof value !== 'undefined' ? value : null;
 }


### PR DESCRIPTION
32ee8943c1060b4a196f1b2d3e6a15cabd6ec9ad ported some of the reference code from being generated in Java to a JS intrinsic. However, this missed a `.shift()`, causing runtime errors when using the result of `ReferenceQueue.poll`.

This commit just adds back the `.shift()`.