### PR TITLE
Widen byte/short to ints in ObjectMethods

### DIFF
--- a/classlib/src/main/java/org/teavm/classlib/impl/record/ObjectMethodsSubstitutor.java
+++ b/classlib/src/main/java/org/teavm/classlib/impl/record/ObjectMethodsSubstitutor.java
@@ -20,6 +20,7 @@ import org.teavm.dependency.BootstrapMethodSubstitutor;
 import org.teavm.dependency.DynamicCallSite;
 import org.teavm.model.BasicBlock;
 import org.teavm.model.MethodHandle;
+import org.teavm.model.PrimitiveType;
 import org.teavm.model.ValueType;
 import org.teavm.model.emit.ConditionEmitter;
 import org.teavm.model.emit.ConditionProducer;
@@ -177,7 +178,16 @@ public class ObjectMethodsSubstitutor implements BootstrapMethodSubstitutor {
             String fieldTitle = (index == 0 ? "" : ", ") + fieldName + "=";
             resultVar = resultVar.invokeVirtual("append", StringBuilder.class, pe.constant(fieldTitle));
             ValueEmitter thisField = InvokeDynamicUtil.invoke(pe, getter, thisVar);
-            if (!(getter.getValueType() instanceof ValueType.Primitive)) {
+            if (getter.getValueType() instanceof ValueType.Primitive) {
+                PrimitiveType primitive = ((ValueType.Primitive) getter.getValueType()).getKind();
+                switch (primitive) {
+                    case BYTE:
+                    case SHORT:
+                        thisField = thisField.cast(int.class);
+                        break;
+                    default:
+                }
+            } else {
                 thisField = thisField.cast(Object.class);
             }
             resultVar = resultVar.invokeVirtual("append", StringBuilder.class, thisField);

--- a/tests/src/test/java/org/teavm/vm/RecordTest.java
+++ b/tests/src/test/java/org/teavm/vm/RecordTest.java
@@ -42,7 +42,7 @@ public class RecordTest {
 
     @Test
     public void toStringMethod() {
-        String s = new B(2, "q", 3L).toString();
+        String s = new B(2, "q", 3L, (byte) 4, (short) 5).toString();
 
         int index = 0;
 
@@ -50,33 +50,28 @@ public class RecordTest {
         assertTrue(index >= 0);
         ++index;
 
-        index = s.indexOf("x", index);
+        index = checkRecordKey(s, "a", "2", index);
+        index = checkRecordKey(s, "b", "q", index);
+        index = checkRecordKey(s, "c", "3", index);
+        index = checkRecordKey(s, "d", "4", index);
+        checkRecordKey(s, "e", "5", index);
+    }
+
+    private static int checkRecordKey(String s, String key, String value, int index) {
+        index = s.indexOf(key, index);
         assertTrue(index > 0);
         ++index;
 
-        index = s.indexOf("2", index);
+        index = s.indexOf(value, index);
         assertTrue(index > 0);
         ++index;
 
-        index = s.indexOf("y", index);
-        assertTrue(index > 0);
-        ++index;
-
-        index = s.indexOf("q", index);
-        assertTrue(index > 0);
-        ++index;
-
-        index = s.indexOf("z", index);
-        assertTrue(index > 0);
-        ++index;
-
-        index = s.indexOf("3", index);
-        assertTrue(index > 0);
+        return index;
     }
 
     record A(int x, String y) {
     }
 
-    record B(int x, String y, Long z) {
+    record B(int a, String b, Long c, byte d, short e) {
     }
 }


### PR DESCRIPTION
If you have a record a `byte` (or `short`) field, TeaVM would generate a `toString` method which called the (non-existent) `StringBuilder.append(B)`. We need to do similar logic to [what `StringBuilderEmitter` does](https://github.com/konsoletyper/teavm/blob/8f8b33c0b1a78292dc4a438ff42ac42e75e59663/core/src/main/java/org/teavm/model/emit/StringBuilderEmitter.java#L32-L40) and convert byte/shorts to `int`s.