### PR TITLE
add scala compiler options. fix warnings

### DIFF
--- a/samples/scala/build.gradle.kts
+++ b/samples/scala/build.gradle.kts
@@ -29,3 +29,10 @@ teavm.js {
     addedToWebApp = true
     mainClass = "org.teavm.samples.scala.Client"
 }
+
+tasks.withType<ScalaCompile> {
+    scalaCompileOptions.additionalParameters = listOf(
+        "-feature",
+        "-deprecation",
+    )
+}

--- a/samples/scala/src/teavm/scala/org/teavm/samples/scala/Client.scala
+++ b/samples/scala/src/teavm/scala/org/teavm/samples/scala/Client.scala
@@ -6,7 +6,7 @@ import org.teavm.jso.dom.html._
 import org.teavm.samples.scala.Calculator.{eval, parse, print}
 
 object Client {
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     val doc = HTMLDocument.current
     val exprElem = doc.getElementById("expr").asInstanceOf[HTMLInputElement]
     val calcElem = doc.getElementById("calculate")

--- a/samples/scala/src/teavm/scala/org/teavm/samples/scala/Grammar.scala
+++ b/samples/scala/src/teavm/scala/org/teavm/samples/scala/Grammar.scala
@@ -17,11 +17,11 @@ trait Rule[T] {
 
   def |(other: => Rule[T]): Rule[T] = Rule.firstOf(this, other)
 
-  def *(): Rule[List[T]] = Rule.unlimited(this)
+  def * : Rule[List[T]] = Rule.unlimited(this)
 
   def >>[S](f: T => S): Rule[S] = Rule.andThen(this, f)
 
-  def ?(): Rule[Option[T]] = Rule.optional(this)
+  def ? : Rule[Option[T]] = Rule.optional(this)
 
   def debug(str: String) = Rule.rule { x =>
     val (result, rem) = parse(x)


### PR DESCRIPTION
fix following warnings


```
[Warn] my-teavm-path/samples/scala/src/teavm/scala/org/teavm/samples/scala/Calculator.scala:71:19: Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method *,
or remove the empty argument list from its definition (Java-defined methods are exempt).
In Scala 3, an unapplied method like this will be eta-expanded into a function.
[Warn] my-teavm-path/samples/scala/src/teavm/scala/org/teavm/samples/scala/Calculator.scala:49:72: Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method *,
or remove the empty argument list from its definition (Java-defined methods are exempt).
In Scala 3, an unapplied method like this will be eta-expanded into a function.
[Warn] my-teavm-path/samples/scala/src/teavm/scala/org/teavm/samples/scala/Calculator.scala:42:84: Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method *,
or remove the empty argument list from its definition (Java-defined methods are exempt).
In Scala 3, an unapplied method like this will be eta-expanded into a function.
[Warn] my-teavm-path/samples/scala/src/teavm/scala/org/teavm/samples/scala/Calculator.scala:56:40: Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method ?,
or remove the empty argument list from its definition (Java-defined methods are exempt).
In Scala 3, an unapplied method like this will be eta-expanded into a function.
[Warn] my-teavm-path/samples/scala/src/teavm/scala/org/teavm/samples/scala/Calculator.scala:65:61: Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method *,
or remove the empty argument list from its definition (Java-defined methods are exempt).
In Scala 3, an unapplied method like this will be eta-expanded into a function.
[Warn] my-teavm-path/samples/scala/src/teavm/scala/org/teavm/samples/scala/Client.scala:9:33: procedure syntax is deprecated: instead, add `: Unit =` to explicitly declare `main`'s return type
```