### PR TITLE
Fix `toLowerCase`/`toUpperCase` on `Locale.ROOT`

### DIFF
--- a/classlib/src/main/java/org/teavm/classlib/java/util/TLocale.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/util/TLocale.java
@@ -278,7 +278,7 @@ public final class TLocale implements TCloneable, TSerializable {
 
     public TString toLanguageTag() {
         StringBuilder result = new StringBuilder();
-        result.append(languageCode);
+        result.append(languageCode.isEmpty() ? "und" : languageCode);
         if (!countryCode.isEmpty()) {
             result.append('-');
             result.append(countryCode);

--- a/tests/src/test/java/org/teavm/classlib/java/lang/StringTest.java
+++ b/tests/src/test/java/org/teavm/classlib/java/lang/StringTest.java
@@ -328,6 +328,7 @@ public class StringTest {
         assertEquals("İSTANBUL", turkish.toUpperCase(new Locale("tr", "TR")));
         assertNotEquals(common.toUpperCase(Locale.US), turkish.toUpperCase(new Locale("tr", "TR")));
         assertEquals(common.toUpperCase(Locale.US), common.toUpperCase(Locale.CANADA));
+        assertEquals(common.toUpperCase(Locale.US), common.toUpperCase(Locale.ROOT));
     }
 
     @Test

--- a/tests/src/test/java/org/teavm/classlib/java/util/LocaleTest.java
+++ b/tests/src/test/java/org/teavm/classlib/java/util/LocaleTest.java
@@ -70,5 +70,6 @@ public class LocaleTest {
         assertEquals("zh-CN", Locale.SIMPLIFIED_CHINESE.toLanguageTag());
         assertEquals("en-GB", Locale.UK.toLanguageTag());
         assertEquals("en-US", Locale.US.toLanguageTag());
+        assertEquals("und", Locale.ROOT.toLanguageTag());
     }
 }


### PR DESCRIPTION
`Locale.ROOT.toLanguageTag()` currently evaluates to an empty string, rather than the expected "und", which errors when passed to `toLocaleLowerCase`.