### PR TITLE
Implement static nullOutputStream() of OutputStream

### DIFF
--- a/classlib/src/main/java/org/teavm/classlib/java/io/TOutputStream.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/io/TOutputStream.java
@@ -19,6 +19,36 @@ import java.io.IOException;
 import org.teavm.classlib.java.lang.TObject;
 
 public abstract class TOutputStream extends TObject implements TCloseable, TFlushable {
+    public static TOutputStream nullOutputStream() {
+        return new TOutputStream() {
+            private boolean isClosed;
+
+            @Override
+            public void write(int b) throws IOException {
+                if (isClosed) {
+                    throw new IOException("Stream closed");
+                }
+            }
+
+            @Override
+            public void write(byte[] b) throws IOException {
+                write(b, 0, b.length);
+            }
+
+            @Override
+            public void write(byte[] b, int off, int len) throws IOException {
+                if (isClosed) {
+                    throw new IOException("Stream closed");
+                }
+            }
+
+            @Override
+            public void close() throws IOException {
+                isClosed = true;
+            }
+        };
+    }
+
     public abstract void write(int b) throws IOException;
 
     public void write(byte[] b) throws IOException {


### PR DESCRIPTION
This PR adds the missing `static nullOutputStream()` method of `java.io.OutputStream`. This should bring the implementation of that class to 100% coverage.

This function creates a dummy `OutputStream` object that consumes the input and does nothing.