### PR TITLE
Fix/improve cloning of TreeMap and TreeSet objects

### DIFF
--- a/classlib/src/main/java/org/teavm/classlib/java/util/TTreeMap.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/util/TTreeMap.java
@@ -16,6 +16,7 @@
 package org.teavm.classlib.java.util;
 
 import org.teavm.classlib.java.io.TSerializable;
+import org.teavm.classlib.java.lang.TCloneNotSupportedException;
 import org.teavm.classlib.java.lang.TCloneable;
 
 public class TTreeMap<K, V> extends TAbstractMap<K, V> implements TCloneable, TSerializable, TNavigableMap<K, V> {
@@ -558,10 +559,19 @@ public class TTreeMap<K, V> extends TAbstractMap<K, V> implements TCloneable, TS
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public Object clone() {
-        TTreeMap<?, ?> copy = (TTreeMap<?, ?>) super.clone();
-        copy.cachedEntrySet = null;
-        return copy;
+        try {
+            TTreeMap<K, V> map = (TTreeMap<K, V>) super.clone();
+            map.root = null;
+            map.modCount = 0;
+            map.cachedEntrySet = null;
+            map.putAll(this);
+
+            return map;
+        } catch (TCloneNotSupportedException e) {
+            return null;
+        }
     }
 
     static class EntrySet<K, V> extends TAbstractSet<Entry<K, V>> implements TSequencedSet<Entry<K, V>> {

--- a/classlib/src/main/java/org/teavm/classlib/java/util/TTreeSet.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/util/TTreeSet.java
@@ -15,12 +15,17 @@
  */
 package org.teavm.classlib.java.util;
 
+import org.teavm.classlib.java.lang.TCloneNotSupportedException;
+import org.teavm.classlib.java.lang.TCloneable;
+import org.teavm.classlib.java.lang.TObject;
+import org.teavm.interop.Rename;
+
 /**
  *
  * @author Alexey Andreev
  * @param <E>
  */
-public class TTreeSet<E> extends TAbstractSet<E> implements TNavigableSet<E> {
+public class TTreeSet<E> extends TAbstractSet<E> implements TCloneable, TNavigableSet<E> {
     private static final Object VALUE = new Object();
     private TTreeMap<E, Object> map;
 
@@ -64,6 +69,25 @@ public class TTreeSet<E> extends TAbstractSet<E> implements TNavigableSet<E> {
     @Override
     public TIterator<E> iterator() {
         return map.keySet().iterator();
+    }
+
+    /**
+     * Returns a new {@code TreeSet} with the same elements and size as this
+     * {@code TreeSet}.
+     *
+     * @return a shallow copy of this {@code TreeSet}.
+     * @see java.lang.Cloneable
+     */
+    @Rename("clone")
+    @SuppressWarnings("unchecked")
+    public TObject clone0() {
+        try {
+            TTreeSet<E> clone = (TTreeSet<E>) super.clone();
+            clone.map = (TTreeMap<E, Object>) map.clone();
+            return clone;
+        } catch (TCloneNotSupportedException e) {
+            return null;
+        }
     }
 
     @Override
@@ -166,5 +190,10 @@ public class TTreeSet<E> extends TAbstractSet<E> implements TNavigableSet<E> {
     @Override
     public TNavigableSet<E> tailSet(E fromElement, boolean inclusive) {
         return map.tailMap(fromElement, inclusive).navigableKeySet();
+    }
+
+    @Override
+    public Object clone() {
+        return new TTreeSet<>(this);
     }
 }

--- a/tests/src/test/java/org/teavm/classlib/java/util/TreeMapTest.java
+++ b/tests/src/test/java/org/teavm/classlib/java/util/TreeMapTest.java
@@ -215,6 +215,10 @@ public class TreeMapTest {
         Set<Object> key2 = map2.keySet();
         assertTrue("keySet() is identical", key2 != keys);
         assertEquals("keySet() was not cloned", "key2", key2.iterator().next());
+        @SuppressWarnings("unchecked")
+        Map<Object, Object> map3 = (Map<Object, Object>) map.clone();
+        map3.put("key2", "value2");
+        assertFalse("Original map modified through clone", map.containsKey("key2"));
     }
 
     @Test


### PR DESCRIPTION
This PR fixes the shallow clone of `java.utils.TreeMap`. Previously, the clone kept the reference to the same root node and in turn the whole tree. Modifications to the clone incorrectly also modified the original TreeMap. This update generates new tree nodes while keeping the key and value references, correctly making the clone independent.

Additionally, this PR includes a `Clonable` implementation for `java.utils.TreeSet` that follows the same logic of `java.utils.HashSet`.