### PR TITLE
Extend BigInteger with xValueExact() and sqrt()

### DIFF
--- a/classlib/src/main/java/org/teavm/classlib/java/math/TBigInteger.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/math/TBigInteger.java
@@ -68,6 +68,11 @@ public class TBigInteger extends Number implements Comparable<TBigInteger>, Seri
     public static final TBigInteger ONE = new TBigInteger(1, 1);
 
     /**
+     * The {@code BigInteger} constant 2.
+     */
+    public static final TBigInteger TWO = new TBigInteger(1, 2);
+
+    /**
      * The {@code BigInteger} constant 10.
      */
     public static final TBigInteger TEN = new TBigInteger(1, 10);
@@ -85,7 +90,7 @@ public class TBigInteger extends Number implements Comparable<TBigInteger>, Seri
     static final int LESS = -1;
 
     /** All the {@code BigInteger} numbers in the range [0,10] are cached. */
-    static final TBigInteger[] SMALL_VALUES = { ZERO, ONE, new TBigInteger(1, 2), new TBigInteger(1, 3),
+    static final TBigInteger[] SMALL_VALUES = { ZERO, ONE, TWO, new TBigInteger(1, 3),
             new TBigInteger(1, 4), new TBigInteger(1, 5), new TBigInteger(1, 6), new TBigInteger(1, 7),
             new TBigInteger(1, 8), new TBigInteger(1, 9), TEN };
 

--- a/classlib/src/main/java/org/teavm/classlib/java/math/TBigInteger.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/math/TBigInteger.java
@@ -836,6 +836,20 @@ public class TBigInteger extends Number implements Comparable<TBigInteger>, Seri
         return TLogical.andNot(this, val);
     }
 
+    public byte byteValueExact() {
+        if (numberLength > 1 || bitLength() > 7) {
+            throw new ArithmeticException("BigInteger out of byte range");
+        }
+        return byteValue();
+    }
+
+    public short shortValueExact() {
+        if (numberLength > 1 || bitLength() > 15) {
+            throw new ArithmeticException("BigInteger out of short range");
+        }
+        return shortValue();
+    }
+
     /**
      * Returns this {@code BigInteger} as an int value. If {@code this} is too
      * big to be represented as an int, then {@code this} % 2^32 is returned.
@@ -845,6 +859,21 @@ public class TBigInteger extends Number implements Comparable<TBigInteger>, Seri
     @Override
     public int intValue() {
         return sign * digits[0];
+    }
+
+    /**
+     * Returns this {@code BigInter} as an int value.
+     *
+     * @return this {@code BigInteger} as an int value.
+     * @see #intValue
+     * @throws ArithmeticException
+     *             if {@code this} is too big to be represented as an int.
+     */
+    public int intValueExact() {
+        if (numberLength > 1 || bitLength() > 31) {
+            throw new ArithmeticException("BigInteger out of int range");
+        }
+        return intValue();
     }
 
     /**
@@ -858,6 +887,21 @@ public class TBigInteger extends Number implements Comparable<TBigInteger>, Seri
         long value = (numberLength > 1) ? (((long) digits[1]) << 32) | (digits[0] & 0xFFFFFFFFL)
                 : (digits[0] & 0xFFFFFFFFL);
         return sign * value;
+    }
+
+    /**
+     * Returns this {@code BigInter} as an long value.
+     *
+     * @return this {@code BigInteger} as a long value.
+     * @throws ArithmeticException
+     *             if {@code this} is too big to be represented as a long.
+     * @see #longValue
+     */
+    public long longValueExact() {
+        if (numberLength > 2 || bitLength() > 63) {
+            throw new ArithmeticException("BigInteger out of long range");
+        }
+        return longValue();
     }
 
     /**
@@ -1100,6 +1144,76 @@ public class TBigInteger extends Number implements Comparable<TBigInteger>, Seri
             return getPowerOfTwo(x * exp).multiply(this.shiftRight(x).pow(exp));
         }
         return TMultiplication.pow(this, exp);
+    }
+
+    /**
+     * Returns a new {@code BigInteger} whose value is the biggest integer
+     * {@code n} such that {@code n * n <= this}.
+     *
+     * @implNote This implementation follows the ideas in Henry S. Warren, Jr.,
+     * Hacker's Delight (2nd ed.) (Addison Wesley, 2013), 279-282.
+     *
+     * @return {@code floor(sqrt(this))}
+     * @throws ArithmeticException if {@code this} is negative.
+     */
+    public TBigInteger sqrt() {
+        if (sign < 0) {
+            throw new ArithmeticException("Negative BigInteger");
+        }
+
+        // Trivial cases
+        if (equals(ZERO)) {
+            return ZERO;
+        } else if (compareTo(valueOf(4)) < 0) {
+            return ONE;
+        }
+
+        // BigInteger fits into long, so do calculation directly
+        if (bitLength() < 64) {
+            // Estimate using existing sqrt implementation for double
+            long val = longValueExact();
+            long candidate = (long) Math.floor(Math.sqrt(val));
+
+            // Improve estimate using Newton's method
+            do {
+                long next = (candidate + val / candidate) >> 1;
+                if (next >= candidate) {
+                    // found convergence candidate if stopped to decrease
+                    return valueOf(candidate);
+                }
+
+                candidate = next;
+            } while (true);
+        }
+
+        // Shift BigInteger into long range to use existing sqrt implementation
+        // and then shift back into the initial range for a rough estimate
+
+        long shiftCount = bitLength() - 63;
+        if (shiftCount % 2 == 1) {
+            shiftCount += 1;
+        }
+
+        if ((shiftCount & 0xFFFFFFFF00000000L) > 0) {
+            throw new ArithmeticException("integer overflow");
+        }
+
+        double shiftedVal = shiftRight((int) shiftCount).doubleValue();
+        TBigInteger candidate = valueOf((long) Math.ceil(Math.sqrt(shiftedVal)));
+
+        candidate = candidate.shiftLeft((int) shiftCount >> 1);
+
+        // Improve estimate using Newton's method
+        do {
+            // next = (candidate + this/candidate) >> 1;
+            TBigInteger next = candidate.add(this.divide(candidate)).shiftRight(1);
+            if (next.compareTo(candidate) >= 0) {
+                // found convergence candidate if stopped to decrease
+                return candidate;
+            }
+
+            candidate = next;
+        } while (true);
     }
 
     /**

--- a/tests/src/test/java/org/teavm/classlib/java/math/BigIntegerSquareRootTest.java
+++ b/tests/src/test/java/org/teavm/classlib/java/math/BigIntegerSquareRootTest.java
@@ -1,0 +1,93 @@
+/*
+ *  Copyright 2023 Bernd Busse.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.teavm.classlib.java.math;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import java.math.BigInteger;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.teavm.junit.SkipPlatform;
+import org.teavm.junit.TeaVMTestRunner;
+import org.teavm.junit.TestPlatform;
+
+@RunWith(TeaVMTestRunner.class)
+@SkipPlatform(TestPlatform.WASI)
+public class BigIntegerSquareRootTest {
+    /**
+     * sqrt: negative value
+     */
+    @Test
+    public void testSqrtException() {
+        BigInteger aNumber = new BigInteger("-8");
+        try {
+            aNumber.sqrt();
+            fail("ArithmeticException has not been caught");
+        } catch (ArithmeticException e) {
+            assertEquals("Improper exception message", "Negative BigInteger", e.getMessage());
+        }
+    }
+
+    /**
+     * sqrt: special cases
+     */
+    @Test
+    public void testSpecialCases() {
+        BigInteger aNumber = new BigInteger("3");
+
+        assertEquals(BigInteger.ZERO, BigInteger.ZERO.sqrt());
+        assertEquals(BigInteger.ONE, BigInteger.ONE.sqrt());
+        assertEquals(BigInteger.ONE, aNumber.sqrt());
+    }
+
+    /**
+     * sqrt of small number
+     */
+    @Test
+    public void testSmallNumbers() {
+        byte[] aBytes = {39, -128, 127};
+        int aSign = 1;
+        byte[] rBytes = {6, 72};
+        BigInteger aNumber = new BigInteger(aSign, aBytes);
+        BigInteger result = aNumber.sqrt();
+        byte[] resBytes = new byte[rBytes.length];
+        resBytes = result.toByteArray();
+        for (int i = 0; i < resBytes.length; i++) {
+            assertTrue(resBytes[i] == rBytes[i]);
+        }
+        assertEquals("incorrect sign", 1, result.signum());
+    }
+
+    /**
+     * sqrt of large number
+     */
+    @Test
+    public void testBigNumbers() {
+        byte[] aBytes = {1, 100, 56, 7, 98, -1, 39, -128, 127, 5, 6, 7, 8, 9};
+        int aSign = 1;
+        byte[] rBytes = {18, -33, -82, -48, -58, 93, 37};
+        BigInteger aNumber = new BigInteger(aSign, aBytes);
+        BigInteger result = aNumber.sqrt();
+        byte[] resBytes = new byte[rBytes.length];
+        resBytes = result.toByteArray();
+        for (int i = 0; i < resBytes.length; i++) {
+            assertTrue(resBytes[i] == rBytes[i]);
+        }
+        assertEquals("incorrect sign", 1, result.signum());
+    }
+}


### PR DESCRIPTION
This PR improves the coverage of `java.math.BigInteger` by adding the missing `byteValueExact()`, `shortValueExact()`, `intValueExact()`, and `longValueExact()` methods, as well as an implementation for calculating the square root `sqrt()`.

In addition, the constant value `TWO` which has been added in Java 9, is added as well.