### PR TITLE
Implement (minimal) SecureRandom

### DIFF
--- a/classlib/src/main/java/org/teavm/classlib/java/security/TGeneralSecurityException.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/security/TGeneralSecurityException.java
@@ -1,0 +1,38 @@
+/*
+ *  Copyright 2023 Bernd Busse.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.teavm.classlib.java.security;
+
+import org.teavm.classlib.java.lang.TException;
+import org.teavm.classlib.java.lang.TThrowable;
+
+public class TGeneralSecurityException extends TException {
+
+    public TGeneralSecurityException() {
+        super();
+    }
+
+    public TGeneralSecurityException(String message) {
+        super(message);
+    }
+
+    public TGeneralSecurityException(String message, TThrowable cause) {
+        super(message, cause);
+    }
+
+    public TGeneralSecurityException(TThrowable cause) {
+        super(cause);
+    }
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/security/TNoSuchAlgorithmException.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/security/TNoSuchAlgorithmException.java
@@ -1,0 +1,37 @@
+/*
+ *  Copyright 2023 Bernd Busse.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.teavm.classlib.java.security;
+
+import org.teavm.classlib.java.lang.TThrowable;
+
+public class TNoSuchAlgorithmException extends TGeneralSecurityException {
+
+    public TNoSuchAlgorithmException() {
+        super();
+    }
+
+    public TNoSuchAlgorithmException(String message) {
+        super(message);
+    }
+
+    public TNoSuchAlgorithmException(String message, TThrowable cause) {
+        super(message, cause);
+    }
+
+    public TNoSuchAlgorithmException(TThrowable cause) {
+        super(cause);
+    }
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/security/TSecureRandom.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/security/TSecureRandom.java
@@ -1,0 +1,136 @@
+/*
+ *  Copyright 2023 Bernd Busse.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.teavm.classlib.java.security;
+
+import org.teavm.classlib.PlatformDetector;
+import org.teavm.classlib.java.util.TRandom;
+import org.teavm.jso.crypto.Crypto;
+import org.teavm.jso.typedarrays.Uint8Array;
+
+public class TSecureRandom extends TRandom {
+
+    /** stored instance for seed generation in getSeed() */
+    private static TSecureRandom seedGenerator;
+
+    public TSecureRandom() {
+    }
+
+    public TSecureRandom(@SuppressWarnings("unused") byte[] seed) {
+    }
+
+    public static TSecureRandom getInstance(String algorithm)
+            throws TNoSuchAlgorithmException {
+        if (!(algorithm.equals("NativePRNG")
+                || algorithm.equals("NativePRNGBlocking")
+                || algorithm.equals("NativePRNGNonBlocking"))) {
+            throw new TNoSuchAlgorithmException();
+        }
+        return new TSecureRandom();
+    }
+
+    public String getAlgorithm() {
+        if (PlatformDetector.isJavaScript() && Crypto.isSupported()) {
+            return "NativePRNG";
+        } else {
+            return "unknown";
+        }
+    }
+
+    @Override
+    public void setSeed(@SuppressWarnings("unused") long seed) {
+    }
+
+    public void setSeed(@SuppressWarnings("unused") byte[] seed) {
+    }
+
+    public void reseed() {
+    }
+
+    protected int next(int bits) {
+        int numBytes = (bits + 7) / 8;
+        byte[] bytes = new byte[numBytes];
+        nextBytes(bytes);
+
+        int val = 0;
+        for (int i = 0; i < numBytes; ++i) {
+            val = (val << 8) | (bytes[i] & 0xFF);
+        }
+
+        return val >>> (numBytes * 8 - bits);
+    }
+
+    @Override
+    public void nextBytes(byte[] bytes) {
+        if (PlatformDetector.isJavaScript() && Crypto.isSupported()) {
+            Uint8Array buffer = Uint8Array.create(bytes.length);
+            Crypto.current().getRandomValues(buffer);
+
+            for (int i = 0; i < bytes.length; ++i) {
+                bytes[i] = (byte) buffer.get(i);
+            }
+        } else {
+            // TODO: Implement wrapper to JavaScript (Crypto) for WASM backend
+            // TODO: Implement proper randomness source in C backend (/dev/urandom, etc.)
+            // Fall back to generic random implementation
+            super.nextBytes(bytes);
+        }
+    }
+
+    @Override
+    public int nextInt() {
+        return next(32);
+    }
+
+    @Override
+    public int nextInt(int n) {
+        if (n <= 0) {
+            throw new IllegalArgumentException();
+        }
+        return (int) (nextDouble() * n);
+    }
+
+    @Override
+    public long nextLong() {
+        return ((long) nextInt() << 32) | nextInt();
+    }
+
+    @Override
+    public float nextFloat() {
+        return (float) nextDouble();
+    }
+
+    @Override
+    public double nextDouble() {
+        return (((long) next(26) << 27) + next(27)) / (double) (1L << 53);
+    }
+
+    public static byte[] getSeed(int numBytes) {
+        if (seedGenerator == null) {
+            seedGenerator = new TSecureRandom();
+        }
+        return seedGenerator.generateSeed(numBytes);
+    }
+
+    public byte[] generateSeed(int numBytes) {
+        if (numBytes < 0) {
+            throw new IllegalArgumentException();
+        }
+
+        byte[] bytes = new byte[numBytes];
+        nextBytes(bytes);
+        return bytes;
+    }
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/util/TRandom.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/util/TRandom.java
@@ -15,15 +15,10 @@
  */
 package org.teavm.classlib.java.util;
 
-import org.teavm.backend.wasm.runtime.WasmSupport;
-import org.teavm.classlib.PlatformDetector;
 import org.teavm.classlib.impl.RandomUtils;
 import org.teavm.classlib.java.io.TSerializable;
 import org.teavm.classlib.java.lang.TObject;
 import org.teavm.classlib.java.util.random.TRandomGenerator;
-import org.teavm.interop.Import;
-import org.teavm.interop.Unmanaged;
-import org.teavm.jso.JSBody;
 
 public class TRandom extends TObject implements TRandomGenerator, TSerializable {
     /** A stored gaussian value for nextGaussian() */
@@ -66,18 +61,8 @@ public class TRandom extends TObject implements TRandomGenerator, TSerializable 
 
     @Override
     public double nextDouble() {
-        if (PlatformDetector.isC()) {
-            return crand();
-        } else if (PlatformDetector.isWebAssembly()) {
-            return WasmSupport.random();
-        } else {
-            return random();
-        }
+        return Math.random();
     }
-
-    @Import(name = "teavm_rand")
-    @Unmanaged
-    private static native double crand();
 
     /**
      * Generate a random number with Gaussian distribution:
@@ -101,9 +86,4 @@ public class TRandom extends TObject implements TRandomGenerator, TSerializable 
 
         return pair[0];
     }
-
-    @JSBody(script = "return Math.random();")
-    @Import(module = "teavmMath", name = "random")
-    @Unmanaged
-    private static native double random();
 }


### PR DESCRIPTION
Introduce a minimal working implementation of `java.security.SecureRandom` that uses `getRandomValues()` from the WebCrypto API when available. Otherwise and on non-supported platforms it falls back to the "normal insecure" random generator from `java.util.Random`.

The WASM backend would need a reference to the WebCrypto API in the JS runtime, the C backend could employ platform specific generators like `/dev/urandom` on UNIX-like systems or a random generator from the Win32 API. Both are not implemented yet.

Furthermore, this implementation **does not support the SPI framework with different JCE providers**. I am not sure, whether adding JCE support and putting the "native" implementation into an SPI is worth the effort in the current stage.

This PR also changes up `java.util.Random` to directly tap into the existing `random()` implementation of `java.lang.Math`. This reduces the duplicated code between both classes, as the resulting implementation is identical.