### PR TITLE
JSO: add interface for Promise

### DIFF
--- a/jso/apis/src/main/java/org/teavm/jso/core/JSPromise.java
+++ b/jso/apis/src/main/java/org/teavm/jso/core/JSPromise.java
@@ -1,0 +1,71 @@
+/*
+ *  Copyright 2023 Bernd Busse.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.teavm.jso.core;
+
+import org.teavm.interop.NoSideEffects;
+import org.teavm.jso.JSBody;
+import org.teavm.jso.JSByRef;
+import org.teavm.jso.JSFunctor;
+import org.teavm.jso.JSMethod;
+import org.teavm.jso.JSObject;
+
+public abstract class JSPromise implements JSObject {
+    private JSPromise() {
+    }
+
+    @JSFunctor
+    public interface Executor extends JSObject {
+        void onExecute(JSFunction resolveFunc, JSFunction rejectFunc);
+    }
+
+    @JSBody(params = "executor", script = "return new Promise(executor);")
+    @NoSideEffects
+    public static native JSPromise create(Executor executor);
+
+    @JSBody(params = "promises", script = "return Promise.any(promises);")
+    @NoSideEffects
+    public static native JSPromise any(@JSByRef JSArray promises);
+
+    @JSBody(params = "promises", script = "return Promise.all(promises);")
+    @NoSideEffects
+    public static native JSPromise all(@JSByRef JSArray promises);
+
+    @JSBody(params = "promises", script = "return Promise.allSettled(promises);")
+    @NoSideEffects
+    public static native JSPromise allSettled(@JSByRef JSArray promises);
+
+    @JSBody(params = "promises", script = "return Promise.race(promises);")
+    @NoSideEffects
+    public static native JSPromise race(@JSByRef JSArray promises);
+
+    @JSBody(params = "value", script = "return Promise.resolve(value);")
+    @NoSideEffects
+    public static native JSPromise resolve(JSObject value);
+
+    @JSBody(params = "reason", script = "return Promise.reject(reason);")
+    @NoSideEffects
+    public static native JSPromise reject(JSObject reason);
+
+    public abstract JSPromise then(JSFunction onFulfilled);
+
+    public abstract JSPromise then(JSFunction onFulfilled, JSFunction onRejected);
+
+    @JSMethod("catch")
+    public abstract JSPromise catch0(JSFunction onRejected);
+
+    @JSMethod("finally")
+    public abstract JSPromise finally0(JSFunction onFinally);
+}


### PR DESCRIPTION
This adds the `jso.core.JSPromise` interface to interact with native JavaScript `Promise`s.

I've added this to return Promises (and `async` computation results) back to the JavaScript context. Is there a built in way for asynchronous execution we can `await` on the JavaScript side? I like the `async/await` syntax with Promises more like completion callbacks (which are already possible in TeaVM).

<details>
<summary>Usage example:</summary>

I use this in my project by spawning a new thread and calling the `resolve` and `reject` methods after the inner thread has finished (or failed). The inner runner could be a simple function as well.

```java
import org.teavm.jso.JSObject;
import org.teavm.jso.core.JSFunction;
import org.teavm.jso.core.JSObjects;
import org.teavm.jso.core.JSPromise;
import org.teavm.jso.core.JSString;

/**
 * Thread executor that returns a JavaScript Promise which resolves/rejects depending on the execution result.
 */
static class ThreadExecutor extends Thread implements JSPromise.Executor {
    private Thread _thread;
    private int _timeout;

    private JSFunction _resolve;
    private JSFunction _reject;

    public ThreadExecutor(Thread thread, int timeout) {
        _thread = thread;
        _timeout = timeout;
    }

    /** Thread runner entry point */
    @Override
    public void run() {
        _thread.start();

        try {
            _thread.join();
        } catch (InterruptedException e) {
            e.printStackTrace();
            if (_reject != null && !JSObjects.isUndefined(_reject)) {
                _reject.call(this, JSString.valueOf("Interrupted"));
            }
        } catch (Exception e) {
            if (_reject != null && !JSObjects.isUndefined(_reject)) {
                _reject.call(this, JSString.valueOf(e.toString()));
            }
        } finally {
            if (_resolve != null && !JSObjects.isUndefined(_resolve)) {
                _resolve.call(this);
            }
        }
    }

    /** Promise runner entry point */
    @Override
    public void onExecute(JSFunction resolveFunc, JSFunction rejectFunc) {
        _resolve = resolveFunc;
        _reject = rejectFunc;

        this.start();
    }
}

/** Use it in a function */
public JSPromise execute(String code, JSNumber timeoutMs) {
    Thread runner = new Thread(() -> {}); // create Thread that does something with `code`
    int timeout = JSObjects.isUndefined(timeoutMs) ? 0 : timeoutMs.intValue();

    ThreadExecutor executor = new ThreadExecutor(runner, timeout);
    JSPromise promise = JSPromise.create(executor);

    return promise;
}
```

I think, this has quite a bit of boilerplate code, that would be the same for most use-cases. Maybe this can be abstracted away as well as part of the API?

</details>