### PR TITLE
JSO: make global objects available in WebWorker contexts

### DIFF
--- a/jso/apis/src/main/java/org/teavm/jso/browser/Window.java
+++ b/jso/apis/src/main/java/org/teavm/jso/browser/Window.java
@@ -190,9 +190,9 @@ public abstract class Window implements JSObject, WindowEventTarget, StorageProv
     @JSProperty
     public abstract double getDevicePixelRatio();
 
-    @JSBody(params = "s", script = "return window.atob(s);")
+    @JSBody(params = "s", script = "return atob(s);")
     public static native String atob(String s);
 
-    @JSBody(params = "s", script = "return window.btoa(s);")
+    @JSBody(params = "s", script = "return btoa(s);")
     public static native String btoa(String s);
 }

--- a/jso/apis/src/main/java/org/teavm/jso/crypto/Crypto.java
+++ b/jso/apis/src/main/java/org/teavm/jso/crypto/Crypto.java
@@ -25,10 +25,10 @@ import org.teavm.jso.typedarrays.Uint8Array;
 import org.teavm.jso.typedarrays.Uint8ClampedArray;
 
 public abstract class Crypto implements JSObject {
-    @JSBody(script = "return window.crypto != null;")
+    @JSBody(script = "return crypto != null;")
     public static native boolean isSupported();
 
-    @JSBody(script = "return window.crypto;")
+    @JSBody(script = "return crypto;")
     public static native Crypto current();
 
     public abstract String randomUUID();

--- a/jso/apis/src/main/java/org/teavm/jso/indexeddb/IDBFactory.java
+++ b/jso/apis/src/main/java/org/teavm/jso/indexeddb/IDBFactory.java
@@ -34,8 +34,7 @@ public abstract class IDBFactory implements JSObject {
         return factory;
     }
 
-    @JSBody(script = "return window.indexedDB || window.mozIndexedDB || window.webkitIndexedDB || "
-            + "window.msIndexedDB;")
+    @JSBody(script = "return indexedDB || mozIndexedDB || webkitIndexedDB || msIndexedDB;")
     static native IDBFactory getInstanceImpl();
 
     public abstract IDBOpenDBRequest open(String name, int version);


### PR DESCRIPTION
This removes the hardcoded `window` access in some globally available objects/function if they are also available in the WebWorker context (which has no `window` but `self`).

What do you think about changing these methods to instance-methods of `Window`? This would need a way to check between browser and worker context to select the proper function.
Alternatively, we could introduce a `teavm_globals` prefix to access the global scope in the `@JSBody` annotations if needed (like the runtime templates utilize).