### PR TITLE
classlib: fix javadoc warnings

### DIFF
--- a/classlib/src/main/java/org/teavm/classlib/java/math/TBigDecimal.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/math/TBigDecimal.java
@@ -2045,7 +2045,7 @@ public class TBigDecimal extends Number implements Comparable<TBigDecimal>, Seri
      * zero.
      * <p>
      * Note, that {@code movePointRight(0)} returns a result which is
-     * mathematically equivalent, but which has scale >= 0.
+     * mathematically equivalent, but which has scale &gt;= 0.
      *
      * @param n
      *            number of placed the decimal point has to be moved.
@@ -2127,8 +2127,8 @@ public class TBigDecimal extends Number implements Comparable<TBigDecimal>, Seri
     /**
      * Compares this {@code BigDecimal} with {@code val}. Returns one of the
      * three values {@code 1}, {@code 0}, or {@code -1}. The method behaves as
-     * if {@code this.subtract(val)} is computed. If this difference is > 0 then
-     * 1 is returned, if the difference is < 0 then -1 is returned, and if the
+     * if {@code this.subtract(val)} is computed. If this difference is &gt; 0 then
+     * 1 is returned, if the difference is &lt; 0 then -1 is returned, and if the
      * difference is 0 then 0 is returned. This means, that if two decimal
      * instances are compared which are equal in value but differ in scale, then
      * these two instances are considered as equal.
@@ -2307,7 +2307,7 @@ public class TBigDecimal extends Number implements Comparable<TBigDecimal>, Seri
      * If the scale is negative or if {@code scale - precision >= 6} then
      * engineering notation is used. Engineering notation is similar to the
      * scientific notation except that the exponent is made to be a multiple of
-     * 3 such that the integer part is >= 1 and < 1000.
+     * 3 such that the integer part is &gt;= 1 and &lt; 1000.
      *
      * @return a string representation of {@code this} in engineering notation
      *         if necessary.

--- a/classlib/src/main/java/org/teavm/classlib/java/math/TBigInteger.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/math/TBigInteger.java
@@ -117,7 +117,7 @@ public class TBigInteger extends Number implements Comparable<TBigInteger>, Seri
      * @param rnd
      *            is an optional random generator to be used.
      * @throws IllegalArgumentException
-     *             if {@code numBits} < 0.
+     *             if {@code numBits < 0}.
      */
     public TBigInteger(int numBits, Random rnd) {
         if (numBits < 0) {
@@ -152,7 +152,7 @@ public class TBigInteger extends Number implements Comparable<TBigInteger>, Seri
      * @param rnd
      *            is an optional random generator to be used.
      * @throws ArithmeticException
-     *             if {@code bitLength} < 2.
+     *             if {@code bitLength < 2}.
      */
     public TBigInteger(int bitLength, int certainty, Random rnd) {
         if (bitLength < 2) {
@@ -575,9 +575,9 @@ public class TBigInteger extends Number implements Comparable<TBigInteger>, Seri
 
     /**
      * Returns a new {@code BigInteger} whose value is {@code this << n}. The
-     * result is equivalent to {@code this * 2^n} if n >= 0. The shift distance
-     * may be negative which means that {@code this} is shifted right. The
-     * result then corresponds to {@code floor(this / 2^(-n))}.
+     * result is equivalent to {@code this * 2^n} if {@code n >= 0}. The shift
+     * distance may be negative which means that {@code this} is shifted right.
+     * The result then corresponds to {@code floor(this / 2^(-n))}.
      * <p>
      * <b>Implementation Note:</b> Usage of this method on negative values is
      * not recommended as the current implementation is not efficient.
@@ -1459,7 +1459,7 @@ public class TBigInteger extends Number implements Comparable<TBigInteger>, Seri
      * Tests whether this {@code BigInteger} is probably prime. If {@code true}
      * is returned, then this is prime with a probability beyond
      * (1-1/2^certainty). If {@code false} is returned, then this is definitely
-     * composite. If the argument {@code certainty} <= 0, then this method
+     * composite. If the argument {@code certainty <= 0}, then this method
      * returns true.
      *
      * @param certainty
@@ -1472,11 +1472,11 @@ public class TBigInteger extends Number implements Comparable<TBigInteger>, Seri
     }
 
     /**
-     * Returns the smallest integer x > {@code this} which is probably prime as
+     * Returns the smallest integer {@code x > this} which is probably prime as
      * a {@code BigInteger} instance. The probability that the returned
      * {@code BigInteger} is prime is beyond (1-1/2^80).
      *
-     * @return smallest integer > {@code this} which is robably prime.
+     * @return smallest integer &gt; {@code this} which is robably prime.
      * @throws ArithmeticException
      *             if {@code this < 0}.
      */

--- a/classlib/src/main/java/org/teavm/classlib/java/math/TMathContext.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/math/TMathContext.java
@@ -144,7 +144,7 @@ public final class TMathContext implements Serializable {
      *            new {@code MathContext}.
      * @throws IllegalArgumentException
      *             if the string is not in the correct format or if the
-     *             precision specified is < 0.
+     *             precision specified is &lt; 0.
      */
     public TMathContext(String val) {
         char[] charVal = val.toCharArray();


### PR DESCRIPTION
Fixes warnings about "invalid" characters in html context. Most notably the `<`.