### PR TITLE
Fix variable of catch-statement not being properly minimized in JS runtime

### DIFF
--- a/core/src/main/java/org/teavm/backend/javascript/rendering/AstWriter.java
+++ b/core/src/main/java/org/teavm/backend/javascript/rendering/AstWriter.java
@@ -460,7 +460,7 @@ public class AstWriter {
         print(node.getTryBlock());
         for (CatchClause cc : node.getCatchClauses()) {
             writer.ws().append("catch").ws().append('(');
-            writer.append(cc.getVarName().getIdentifier());
+            print(cc.getVarName());
             if (cc.getCatchCondition() != null) {
                 writer.append(" if ");
                 print(cc.getCatchCondition());


### PR DESCRIPTION
The JavaScript backend did not properly handle the catch-variable (the `e` in `try {} catch (e) {}`) when outputting in minifying mode.

(The use of `e` in the catch block was minified however. This led to `xy is undefined` exceptions being thrown in the runtime exception handler and tests silently failing without ever completing.)