### PR TITLE
Disabled idle

### DIFF
--- a/tools/browser-runner/src/main/java/org/teavm/browserrunner/BrowserRunner.java
+++ b/tools/browser-runner/src/main/java/org/teavm/browserrunner/BrowserRunner.java
@@ -107,6 +107,7 @@ public class BrowserRunner {
     private void runServer() {
         server = new Server();
         var connector = new ServerConnector(server);
+        connector.setIdleTimeout(0);
         server.addConnector(connector);
 
         var context = new ServletContextHandler(ServletContextHandler.SESSIONS);

--- a/tools/chrome-rdp/src/main/java/org/teavm/chromerdp/ChromeRDPServer.java
+++ b/tools/chrome-rdp/src/main/java/org/teavm/chromerdp/ChromeRDPServer.java
@@ -55,6 +55,7 @@ public class ChromeRDPServer {
         server = new Server();
         ServerConnector connector = new ServerConnector(server);
         connector.setPort(port);
+        connector.setIdleTimeout(0);
         server.addConnector(connector);
 
         ServletContextHandler context = new ServletContextHandler(ServletContextHandler.SESSIONS);

--- a/tools/devserver/src/main/java/org/teavm/devserver/DevServer.java
+++ b/tools/devserver/src/main/java/org/teavm/devserver/DevServer.java
@@ -120,6 +120,7 @@ public class DevServer {
         server = new Server();
         ServerConnector connector = new ServerConnector(server);
         connector.setPort(port);
+        connector.setIdleTimeout(0);
         server.addConnector(connector);
 
         ServletContextHandler context = new ServletContextHandler(ServletContextHandler.SESSIONS);


### PR DESCRIPTION
Exaplanation: when I'm developing due to proxying everytihng, TeaVM intercepts everything and drops connection when it's idle. In my case it's websocket (which is closed after 5 mins).