### PR TITLE
Add missing implementation of java.lang.Appendable interface to TeaVM java.io.PrintStream class

### DIFF
--- a/classlib/src/main/java/org/teavm/classlib/java/io/TPrintStream.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/io/TPrintStream.java
@@ -18,8 +18,6 @@ package org.teavm.classlib.java.io;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Locale;
-import org.teavm.classlib.java.lang.TAppendable;
-import org.teavm.classlib.java.lang.TCharSequence;
 import org.teavm.classlib.java.lang.TMath;
 import org.teavm.classlib.java.lang.TObject;
 import org.teavm.classlib.java.lang.TStringBuilder;
@@ -33,7 +31,7 @@ import org.teavm.classlib.java.nio.charset.TUnsupportedCharsetException;
 import org.teavm.classlib.java.nio.charset.impl.TUTF8Charset;
 import org.teavm.classlib.java.util.TFormatter;
 
-public class TPrintStream extends TFilterOutputStream implements TAppendable {
+public class TPrintStream extends TFilterOutputStream implements Appendable {
     private boolean autoFlush;
     private boolean errorState;
     private TStringBuilder sb = new TStringBuilder();
@@ -271,34 +269,6 @@ public class TPrintStream extends TFilterOutputStream implements TAppendable {
         print('\n');
     }
 
-    @Override
-    public TPrintStream append(char c) {
-        print(c);
-        return this;
-    }
-
-    @Override
-    public TPrintStream append(TCharSequence csq) {
-        if (null == csq) {
-            sb.append("null");
-            printSB();
-        } else {
-            append(csq, 0, csq.length());
-        }
-        return this;
-    }
-
-    @Override
-    public TPrintStream append(TCharSequence csq, int start, int end) {
-        if (null == csq) {
-            sb.append("null");
-        } else {
-            sb.append(csq, start, end);
-        }
-        printSB();
-        return this;
-    }
-
     public TPrintStream printf(String format, Object... args) {
         return format(format, args);
     }
@@ -315,7 +285,7 @@ public class TPrintStream extends TFilterOutputStream implements TAppendable {
         if (args == null) {
             args = new Object[1];
         }
-        try (var formatter = new TFormatter(getAppendable(), locale)) {
+        try (var formatter = new TFormatter(this, locale)) {
             formatter.format(format, args);
             if (formatter.ioException() != null) {
                 errorState = true;
@@ -331,30 +301,21 @@ public class TPrintStream extends TFilterOutputStream implements TAppendable {
         sb.setLength(0);
     }
 
-    private Appendable appendable;
+    @Override
+    public Appendable append(CharSequence csq) {
+        print(csq, 0, csq.length());
+        return this;
+    }
 
-    private Appendable getAppendable() {
-        if (appendable == null) {
-            appendable = new Appendable() {
-                @Override
-                public Appendable append(CharSequence csq) {
-                    print(csq, 0, csq.length());
-                    return this;
-                }
+    @Override
+    public Appendable append(CharSequence csq, int start, int end) {
+        print(csq, start, end);
+        return this;
+    }
 
-                @Override
-                public Appendable append(CharSequence csq, int start, int end) {
-                    print(csq, start, end);
-                    return this;
-                }
-
-                @Override
-                public Appendable append(char c) {
-                    print(c);
-                    return this;
-                }
-            };
-        }
-        return appendable;
+    @Override
+    public Appendable append(char c) {
+        print(c);
+        return this;
     }
 }

--- a/classlib/src/main/java/org/teavm/classlib/java/io/TPrintStream.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/io/TPrintStream.java
@@ -145,33 +145,15 @@ public class TPrintStream extends TFilterOutputStream implements Appendable {
         print(s, 0, s.length);
     }
 
-    private void print(char[] s, int begin, int end) {
-        TCharBuffer src = TCharBuffer.wrap(s, begin, end - begin);
-        byte[] destBytes = new byte[TMath.max(16, TMath.min(end - begin, 1024))];
-        TByteBuffer dest = TByteBuffer.wrap(destBytes);
-        TCharsetEncoder encoder = charset.newEncoder()
-                .onMalformedInput(TCodingErrorAction.REPLACE)
-                .onUnmappableCharacter(TCodingErrorAction.REPLACE);
-        while (true) {
-            boolean overflow = encoder.encode(src, dest, true).isOverflow();
-            write(destBytes, 0, dest.position());
-            dest.clear();
-            if (!overflow) {
-                break;
-            }
-        }
-        while (true) {
-            boolean overflow = encoder.flush(dest).isOverflow();
-            write(destBytes, 0, dest.position());
-            dest.clear();
-            if (!overflow) {
-                break;
-            }
-        }
+    private void print(CharSequence s, int begin, int end) {
+        printCharBuffer(TCharBuffer.wrap(s, begin, end), begin, end);
     }
 
-    private void print(CharSequence s, int begin, int end) {
-        TCharBuffer src = TCharBuffer.wrap(s, begin, end - begin);
+    private void print(char[] s, int begin, int end) {
+        printCharBuffer(TCharBuffer.wrap(s, begin, end - begin), begin, end);
+    }
+
+    private void printCharBuffer(TCharBuffer src, int begin, int end) {
         byte[] destBytes = new byte[TMath.max(16, TMath.min(end - begin, 1024))];
         TByteBuffer dest = TByteBuffer.wrap(destBytes);
         TCharsetEncoder encoder = charset.newEncoder()
@@ -302,7 +284,7 @@ public class TPrintStream extends TFilterOutputStream implements Appendable {
     }
 
     @Override
-    public Appendable append(CharSequence csq) {
+    public TPrintStream append(CharSequence csq) {
         if (csq != null) {
             print(csq, 0, csq.length());
         } else {
@@ -312,13 +294,13 @@ public class TPrintStream extends TFilterOutputStream implements Appendable {
     }
 
     @Override
-    public Appendable append(CharSequence csq, int start, int end) {
+    public TPrintStream append(CharSequence csq, int start, int end) {
         print(csq == null ? "null" : csq, start, end);
         return this;
     }
 
     @Override
-    public Appendable append(char c) {
+    public TPrintStream append(char c) {
         print(c);
         return this;
     }

--- a/classlib/src/main/java/org/teavm/classlib/java/io/TPrintStream.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/io/TPrintStream.java
@@ -18,6 +18,8 @@ package org.teavm.classlib.java.io;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Locale;
+import org.teavm.classlib.java.lang.TAppendable;
+import org.teavm.classlib.java.lang.TCharSequence;
 import org.teavm.classlib.java.lang.TMath;
 import org.teavm.classlib.java.lang.TObject;
 import org.teavm.classlib.java.lang.TStringBuilder;
@@ -31,7 +33,7 @@ import org.teavm.classlib.java.nio.charset.TUnsupportedCharsetException;
 import org.teavm.classlib.java.nio.charset.impl.TUTF8Charset;
 import org.teavm.classlib.java.util.TFormatter;
 
-public class TPrintStream extends TFilterOutputStream {
+public class TPrintStream extends TFilterOutputStream implements TAppendable {
     private boolean autoFlush;
     private boolean errorState;
     private TStringBuilder sb = new TStringBuilder();
@@ -267,6 +269,34 @@ public class TPrintStream extends TFilterOutputStream {
 
     public void println() {
         print('\n');
+    }
+
+    @Override
+    public TPrintStream append(char c) {
+        print(c);
+        return this;
+    }
+
+    @Override
+    public TPrintStream append(TCharSequence csq) {
+        if (null == csq) {
+            sb.append("null");
+            printSB();
+        } else {
+            append(csq, 0, csq.length());
+        }
+        return this;
+    }
+
+    @Override
+    public TPrintStream append(TCharSequence csq, int start, int end) {
+        if (null == csq) {
+            sb.append("null");
+        } else {
+            sb.append(csq, start, end);
+        }
+        printSB();
+        return this;
     }
 
     public TPrintStream printf(String format, Object... args) {

--- a/classlib/src/main/java/org/teavm/classlib/java/io/TPrintStream.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/io/TPrintStream.java
@@ -303,13 +303,17 @@ public class TPrintStream extends TFilterOutputStream implements Appendable {
 
     @Override
     public Appendable append(CharSequence csq) {
-        print(csq, 0, csq.length());
+        if (csq != null) {
+            print(csq, 0, csq.length());
+        } else {
+            print("null");
+        }
         return this;
     }
 
     @Override
     public Appendable append(CharSequence csq, int start, int end) {
-        print(csq, start, end);
+        print(csq == null ? "null" : csq, start, end);
         return this;
     }
 

--- a/tests/src/test/java/org/teavm/classlib/java/io/PrintStreamTest.java
+++ b/tests/src/test/java/org/teavm/classlib/java/io/PrintStreamTest.java
@@ -34,4 +34,28 @@ public class PrintStreamTest {
         stream.flush();
         assertEquals("n=23; s=null", bytes.toString(StandardCharsets.UTF_8));
     }
+
+    @org.junit.Test
+    public void append() {
+        var bytes = new ByteArrayOutputStream();
+        var stream = new PrintStream(bytes, false, StandardCharsets.UTF_8);
+
+        stream.append('H');
+        stream.append("el");
+        stream.append("Hello", 3, 5);
+        stream.flush();
+        assertEquals("Hello", bytes.toString(StandardCharsets.UTF_8));
+    }
+
+    @org.junit.Test
+    public void append_null() {
+        var bytes = new ByteArrayOutputStream();
+        var stream = new PrintStream(bytes, false, StandardCharsets.UTF_8);
+
+        stream.append(null);
+        stream.append(null, 1, 2);
+        stream.flush();
+        assertEquals("nullu", bytes.toString(StandardCharsets.UTF_8));
+    }
+
 }

--- a/tests/src/test/java/org/teavm/classlib/java/io/PrintStreamTest.java
+++ b/tests/src/test/java/org/teavm/classlib/java/io/PrintStreamTest.java
@@ -35,7 +35,7 @@ public class PrintStreamTest {
         assertEquals("n=23; s=null", bytes.toString(StandardCharsets.UTF_8));
     }
 
-    @org.junit.Test
+    @Test
     public void append() {
         var bytes = new ByteArrayOutputStream();
         var stream = new PrintStream(bytes, false, StandardCharsets.UTF_8);
@@ -47,7 +47,7 @@ public class PrintStreamTest {
         assertEquals("Hello", bytes.toString(StandardCharsets.UTF_8));
     }
 
-    @org.junit.Test
+    @Test
     public void append_null() {
         var bytes = new ByteArrayOutputStream();
         var stream = new PrintStream(bytes, false, StandardCharsets.UTF_8);


### PR DESCRIPTION
java.io.PrintStream is supposed to implement java.lang.Appendable (https://docs.oracle.com/javase/8/docs/api/java/io/PrintStream.html). But TeaVM's emulation is missing its implementation.

This fix solves the problem.