### PR TITLE
Element fix

### DIFF
--- a/jso/apis/src/main/java/org/teavm/jso/dom/html/HTMLElement.java
+++ b/jso/apis/src/main/java/org/teavm/jso/dom/html/HTMLElement.java
@@ -135,12 +135,6 @@ public abstract class HTMLElement implements Element, ElementCSSInlineStyle, Eve
     public abstract HTMLCollection getChildren();
 
     @JSProperty
-    public abstract String getInnerHTML();
-
-    @JSProperty
-    public abstract void setInnerHTML(String content);
-
-    @JSProperty
     public abstract String getInnerText();
 
     @JSProperty

--- a/jso/apis/src/main/java/org/teavm/jso/dom/html/HTMLElement.java
+++ b/jso/apis/src/main/java/org/teavm/jso/dom/html/HTMLElement.java
@@ -24,7 +24,6 @@ import org.teavm.jso.dom.events.KeyboardEventTarget;
 import org.teavm.jso.dom.events.LoadEventTarget;
 import org.teavm.jso.dom.events.MouseEventTarget;
 import org.teavm.jso.dom.events.WheelEventTarget;
-import org.teavm.jso.dom.types.DOMTokenList;
 import org.teavm.jso.dom.xml.Element;
 import org.teavm.jso.dom.xml.Node;
 import org.teavm.jso.dom.xml.NodeList;
@@ -86,34 +85,10 @@ public abstract class HTMLElement implements Element, ElementCSSInlineStyle, Eve
     public abstract String getAccessKeyLabel();
 
     @JSProperty
-    public abstract int getClientWidth();
-
-    @JSProperty
-    public abstract int getClientHeight();
-
-    @JSProperty
     public abstract int getAbsoluteLeft();
 
     @JSProperty
     public abstract int getAbsoluteTop();
-
-    @JSProperty
-    public abstract int getScrollLeft();
-
-    @JSProperty
-    public abstract void setScrollLeft(int scrollLeft);
-
-    @JSProperty
-    public abstract int getScrollTop();
-
-    @JSProperty
-    public abstract void setScrollTop(int scrollTop);
-
-    @JSProperty
-    public abstract int getScrollWidth();
-
-    @JSProperty
-    public abstract int getScrollHeight();
 
     @JSProperty
     public abstract int getOffsetWidth();
@@ -132,24 +107,10 @@ public abstract class HTMLElement implements Element, ElementCSSInlineStyle, Eve
     public abstract HTMLDocument getOwnerDocument();
 
     @JSProperty
-    public abstract HTMLCollection getChildren();
-
-    @JSProperty
     public abstract String getInnerText();
 
     @JSProperty
     public abstract void setInnerText(String content);
-
-    public abstract TextRectangle getBoundingClientRect();
-
-    @JSProperty
-    public abstract String getClassName();
-
-    @JSProperty
-    public abstract void setClassName(String className);
-
-    @JSProperty
-    public abstract DOMTokenList getClassList();
 
     public final HTMLElement withAttr(String name, String value) {
         setAttribute(name, value);

--- a/jso/apis/src/main/java/org/teavm/jso/dom/xml/Element.java
+++ b/jso/apis/src/main/java/org/teavm/jso/dom/xml/Element.java
@@ -16,6 +16,9 @@
 package org.teavm.jso.dom.xml;
 
 import org.teavm.jso.JSProperty;
+import org.teavm.jso.dom.html.HTMLCollection;
+import org.teavm.jso.dom.html.TextRectangle;
+import org.teavm.jso.dom.types.DOMTokenList;
 
 public interface Element extends Node {
     String getAttribute(String name);
@@ -62,10 +65,48 @@ public interface Element extends Node {
     String getTagName();
 
     @JSProperty
+    String getClassName();
+
+    @JSProperty
+    void setClassName(String className);
+
+    @JSProperty
+    DOMTokenList getClassList();
+
+    @JSProperty
+    HTMLCollection getChildren();
+
+    @JSProperty
     String getInnerHTML();
 
     @JSProperty
     void setInnerHTML(String content);
 
+    @JSProperty
+    int getClientWidth();
+
+    @JSProperty
+    int getClientHeight();
+
+    @JSProperty
+    int getScrollLeft();
+
+    @JSProperty
+    void setScrollLeft(int scrollLeft);
+
+    @JSProperty
+    int getScrollTop();
+
+    @JSProperty
+    void setScrollTop(int scrollTop);
+
+    @JSProperty
+    int getScrollWidth();
+
+    @JSProperty
+    int getScrollHeight();
+
     void scrollIntoView();
+
+    TextRectangle getBoundingClientRect();
 }

--- a/jso/apis/src/main/java/org/teavm/jso/dom/xml/Element.java
+++ b/jso/apis/src/main/java/org/teavm/jso/dom/xml/Element.java
@@ -61,5 +61,11 @@ public interface Element extends Node {
     @JSProperty
     String getTagName();
 
+    @JSProperty
+    String getInnerHTML();
+
+    @JSProperty
+    void setInnerHTML(String content);
+
     void scrollIntoView();
 }


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/Element/innerHTML
InnerHTML and other properties are a properties of Element, but not HTMLElement. This API mismatch caused inproper usage of JSO api which caused working incorrect code https://github.com/konsoletyper/teavm/issues/916 
Incorrect code is fixed now, so properties should be moved to correct place.