### PR TITLE
jso: fix JSSymbol implementation

### DIFF
--- a/jso/apis/src/main/java/org/teavm/jso/core/JSSymbol.java
+++ b/jso/apis/src/main/java/org/teavm/jso/core/JSSymbol.java
@@ -15,24 +15,24 @@
  */
 package org.teavm.jso.core;
 
-import org.teavm.interop.NoSideEffects;
 import org.teavm.jso.JSBody;
-import org.teavm.jso.JSIndexer;
 import org.teavm.jso.JSObject;
 import org.teavm.jso.JSPrimitiveType;
 
 @JSPrimitiveType("symbol")
-public class JSSymbol<T> implements JSObject {
+public abstract class JSSymbol<T> implements JSObject {
     private JSSymbol() {
     }
 
     @JSBody(params = "name", script = "return Symbol(name);")
     public static native <T> JSSymbol<T> create(String name);
 
-    @JSIndexer
+    @JSBody(params = "obj", script = "return obj[this];")
     public native T get(Object obj);
 
-    @JSIndexer
-    @NoSideEffects
+    @JSBody(params = {"obj", "value"}, script = "obj[this] = value;")
     public native void set(Object obj, T value);
+
+    @JSBody(params = "obj", script = "return obj[this] != null;")
+    public native boolean has(Object obj);
 }

--- a/tests/src/test/java/org/teavm/jso/test/JSWrapperTest.java
+++ b/tests/src/test/java/org/teavm/jso/test/JSWrapperTest.java
@@ -32,6 +32,7 @@ import org.teavm.jso.JSObject;
 import org.teavm.jso.core.JSNumber;
 import org.teavm.jso.core.JSObjects;
 import org.teavm.jso.core.JSString;
+import org.teavm.jso.core.JSSymbol;
 import org.teavm.jso.core.JSUndefined;
 import org.teavm.junit.EachTestCompiledSeparately;
 import org.teavm.junit.OnlyPlatform;
@@ -329,6 +330,28 @@ public class JSWrapperTest {
 
         Object b = createWithToString("bar");
         assertEquals("bar", b.toString());
+    }
+
+    @Test
+    public void jsSymbol() {
+
+        var stringSymbol = JSSymbol.create("customString");
+        var o1 = JSObjects.create();
+
+        assertFalse(stringSymbol.has(o1));
+        stringSymbol.set(o1, "foo");
+        assertTrue(stringSymbol.has(o1));
+        assertEquals("foo", stringSymbol.get(o1));
+        stringSymbol.set(o1, "bar");
+        assertEquals("bar", stringSymbol.get(o1));
+
+        var javaListSymbol = JSSymbol.create("customJavaList");
+
+        assertFalse(javaListSymbol.has(o1));
+        javaListSymbol.set(o1, new ArrayList<>());
+        assertTrue(javaListSymbol.has(o1));
+
+        assertTrue(javaListSymbol.get(o1) instanceof ArrayList);
     }
 
     private void callSetProperty(Object instance, Object o) {


### PR DESCRIPTION
I think some test code made it into the `JSSymbol` class in commit a6fb67817c5bd57c19df2ed1e18fd9831a9d30d6, because suddenly it lost its `abstract` status, and its method had the wrong annotations, causing projects to no longer compile when using a JSSymbol instance.

This basically restores that, and adds some basic tests.

I don't know if you still want to use the `@NoSideEffects` annotation though.