### PR TITLE
Send beacon

### DIFF
--- a/jso/apis/src/main/java/org/teavm/jso/browser/Navigator.java
+++ b/jso/apis/src/main/java/org/teavm/jso/browser/Navigator.java
@@ -47,4 +47,10 @@ public final class Navigator implements JSObject {
 
     @JSBody(script = "return navigator.hardwareConcurrency")
     public static native int hardwareConcurrency();
+
+    public static native boolean sendBeacon(String url);
+
+    public static native boolean sendBeacon(String url, String data);
+
+    public static native boolean sendBeacon(String url, JSObject data);
 }


### PR DESCRIPTION
Hi @konsoletyper . This PR adds navigator.sendBeacon function. Still, when I looked at navigator class, I noticed that all its methods are static. This is very different from Window or Document, which are abstract, but are instantiated using Window.current() or HTMLDocument.current(). Is it made for a reason and is it working or it is just a mistake that happened during the refactoring?