### PR TITLE
Update Navigator.java, getGamepads is a function, not a property

### DIFF
--- a/jso/apis/src/main/java/org/teavm/jso/browser/Navigator.java
+++ b/jso/apis/src/main/java/org/teavm/jso/browser/Navigator.java
@@ -42,7 +42,6 @@ public final class Navigator implements JSObject {
     @JSProperty
     public static native String[] getLanguages();
     
-    @JSProperty
     public static native Gamepad[] getGamepads();
 
     @JSBody(script = "return navigator.hardwareConcurrency")


### PR DESCRIPTION
getGamepads does not work now, because of this issue. It works correctly after removing the property annotation.