### PR TITLE
WASM GC: Fix backwards array copy function

### DIFF
--- a/core/src/main/java/org/teavm/backend/wasm/generate/gc/classes/WasmGCClassGenerator.java
+++ b/core/src/main/java/org/teavm/backend/wasm/generate/gc/classes/WasmGCClassGenerator.java
@@ -876,8 +876,8 @@ public class WasmGCClassGenerator implements WasmGCClassInfoProvider, WasmGCInit
         var targetArrayData = new WasmStructGet(arrayStruct, targetArray, ARRAY_DATA_FIELD_OFFSET);
 
         function.getBody().add(new WasmArrayCopy(
-                arrayDataType, targetArrayData, new WasmGetLocal(sourceIndexLocal),
-                arrayDataType, sourceArrayData, new WasmGetLocal(targetIndexLocal),
+                arrayDataType, targetArrayData, new WasmGetLocal(targetIndexLocal),
+                arrayDataType, sourceArrayData, new WasmGetLocal(sourceIndexLocal),
                 new WasmGetLocal(countLocal)));
         return function;
     }


### PR DESCRIPTION
The source and target offset parameters in the `System.arraycopy` implementation are passed to `array.copy` in the wrong order