### PR TITLE
WASM GC: Add support for string pools over 10,000 strings

### DIFF
--- a/core/src/main/java/org/teavm/backend/wasm/generate/gc/strings/WasmGCStringPool.java
+++ b/core/src/main/java/org/teavm/backend/wasm/generate/gc/strings/WasmGCStringPool.java
@@ -93,11 +93,17 @@ public class WasmGCStringPool implements WasmGCStringProvider, WasmGCInitializer
                     void.class));
             function.getBody().add(new WasmCall(internInit));
         }
-        var array = new WasmArrayNewFixed(stringsArray);
-        for (var str : stringMap.values()) {
-            array.getElements().add(new WasmGetGlobal(str.global));
+        var stringIterator = stringMap.values().iterator();
+        while (stringIterator.hasNext()) {
+            var elementCount = 0;
+            var array = new WasmArrayNewFixed(stringsArray);
+            // WasmArrayNewFixed cannot be larger than 10000 elements
+            while (elementCount < 10000 && stringIterator.hasNext()) {
+                array.getElements().add(new WasmGetGlobal(stringIterator.next().global));
+                ++elementCount;
+            }
+            function.getBody().add(new WasmCall(initStringsFunction, array));
         }
-        function.getBody().add(new WasmCall(initStringsFunction, array));
     }
 
     @Override


### PR DESCRIPTION
Fixes #971, I've tested this on my app with 17000 strings and it works.

Would you like it if I also added a unit test with 10,001 string constants in it to test this, or would that be excessive?