### PR TITLE
WASM: Intrinsify numberOfLeadingZeros, numberOfTrailingZeros, and bitCount

### DIFF
--- a/core/src/main/java/org/teavm/backend/wasm/WasmTarget.java
+++ b/core/src/main/java/org/teavm/backend/wasm/WasmTarget.java
@@ -115,6 +115,7 @@ import org.teavm.backend.wasm.render.WasmBinaryWriter;
 import org.teavm.backend.wasm.render.WasmCRenderer;
 import org.teavm.backend.wasm.render.WasmRenderer;
 import org.teavm.backend.wasm.runtime.WasmSupport;
+import org.teavm.backend.wasm.transformation.BaseClassesTransformation;
 import org.teavm.backend.wasm.transformation.IndirectCallTraceTransformation;
 import org.teavm.backend.wasm.transformation.MemoryAccessTraceTransformation;
 import org.teavm.backend.wasm.transformation.WasiFileSystemProviderTransformer;
@@ -241,6 +242,7 @@ public class WasmTarget implements TeaVMTarget, TeaVMWasmHost {
     public List<ClassHolderTransformer> getTransformers() {
         List<ClassHolderTransformer> transformers = new ArrayList<>();
         transformers.add(new ClassPatch());
+        transformers.add(new BaseClassesTransformation());
         transformers.add(new WasmDependencyListener());
         if (runtimeType == WasmRuntimeType.WASI) {
             transformers.add(new WasiSupportClassTransformer());

--- a/core/src/main/java/org/teavm/backend/wasm/intrinsics/IntegerIntrinsic.java
+++ b/core/src/main/java/org/teavm/backend/wasm/intrinsics/IntegerIntrinsic.java
@@ -22,6 +22,8 @@ import org.teavm.backend.wasm.model.expression.WasmExpression;
 import org.teavm.backend.wasm.model.expression.WasmIntBinary;
 import org.teavm.backend.wasm.model.expression.WasmIntBinaryOperation;
 import org.teavm.backend.wasm.model.expression.WasmIntType;
+import org.teavm.backend.wasm.model.expression.WasmIntUnary;
+import org.teavm.backend.wasm.model.expression.WasmIntUnaryOperation;
 import org.teavm.model.MethodReference;
 
 public class IntegerIntrinsic implements WasmIntrinsic {
@@ -38,6 +40,9 @@ public class IntegerIntrinsic implements WasmIntrinsic {
             case "divideUnsigned":
             case "remainderUnsigned":
             case "compareUnsigned":
+            case "numberOfLeadingZeros":
+            case "numberOfTrailingZeros":
+            case "bitCount":
                 return true;
             default:
                 return false;
@@ -59,6 +64,15 @@ public class IntegerIntrinsic implements WasmIntrinsic {
                 return new WasmCall(manager.getFunctions().forStaticMethod(COMPARE_UNSIGNED),
                         manager.generate(invocation.getArguments().get(0)),
                         manager.generate(invocation.getArguments().get(1)));
+            case "numberOfLeadingZeros":
+                return new WasmIntUnary(WasmIntType.INT32, WasmIntUnaryOperation.CLZ,
+                        manager.generate(invocation.getArguments().get(0)));
+            case "numberOfTrailingZeros":
+                return new WasmIntUnary(WasmIntType.INT32, WasmIntUnaryOperation.CTZ,
+                        manager.generate(invocation.getArguments().get(0)));
+            case "bitCount":
+                return new WasmIntUnary(WasmIntType.INT32, WasmIntUnaryOperation.POPCNT,
+                        manager.generate(invocation.getArguments().get(0)));
             default:
                 throw new AssertionError();
         }

--- a/core/src/main/java/org/teavm/backend/wasm/intrinsics/LongIntrinsic.java
+++ b/core/src/main/java/org/teavm/backend/wasm/intrinsics/LongIntrinsic.java
@@ -22,6 +22,8 @@ import org.teavm.backend.wasm.model.expression.WasmExpression;
 import org.teavm.backend.wasm.model.expression.WasmIntBinary;
 import org.teavm.backend.wasm.model.expression.WasmIntBinaryOperation;
 import org.teavm.backend.wasm.model.expression.WasmIntType;
+import org.teavm.backend.wasm.model.expression.WasmIntUnary;
+import org.teavm.backend.wasm.model.expression.WasmIntUnaryOperation;
 import org.teavm.model.MethodReference;
 
 public class LongIntrinsic implements WasmIntrinsic {
@@ -38,6 +40,9 @@ public class LongIntrinsic implements WasmIntrinsic {
             case "divideUnsigned":
             case "remainderUnsigned":
             case "compareUnsigned":
+            case "numberOfLeadingZeros":
+            case "numberOfTrailingZeros":
+            case "bitCount":
                 return true;
             default:
                 return false;
@@ -59,6 +64,15 @@ public class LongIntrinsic implements WasmIntrinsic {
                 return new WasmCall(manager.getFunctions().forStaticMethod(COMPARE_UNSIGNED),
                         manager.generate(invocation.getArguments().get(0)),
                         manager.generate(invocation.getArguments().get(1)));
+            case "numberOfLeadingZeros":
+                return new WasmIntUnary(WasmIntType.INT64, WasmIntUnaryOperation.CLZ,
+                        manager.generate(invocation.getArguments().get(0)));
+            case "numberOfTrailingZeros":
+                return new WasmIntUnary(WasmIntType.INT64, WasmIntUnaryOperation.CTZ,
+                        manager.generate(invocation.getArguments().get(0)));
+            case "bitCount":
+                return new WasmIntUnary(WasmIntType.INT64, WasmIntUnaryOperation.POPCNT,
+                        manager.generate(invocation.getArguments().get(0)));
             default:
                 throw new AssertionError();
         }

--- a/core/src/main/java/org/teavm/backend/wasm/intrinsics/LongIntrinsic.java
+++ b/core/src/main/java/org/teavm/backend/wasm/intrinsics/LongIntrinsic.java
@@ -17,7 +17,9 @@ package org.teavm.backend.wasm.intrinsics;
 
 import org.teavm.ast.InvocationExpr;
 import org.teavm.backend.wasm.WasmRuntime;
+import org.teavm.backend.wasm.model.WasmNumType;
 import org.teavm.backend.wasm.model.expression.WasmCall;
+import org.teavm.backend.wasm.model.expression.WasmConversion;
 import org.teavm.backend.wasm.model.expression.WasmExpression;
 import org.teavm.backend.wasm.model.expression.WasmIntBinary;
 import org.teavm.backend.wasm.model.expression.WasmIntBinaryOperation;
@@ -65,16 +67,20 @@ public class LongIntrinsic implements WasmIntrinsic {
                         manager.generate(invocation.getArguments().get(0)),
                         manager.generate(invocation.getArguments().get(1)));
             case "numberOfLeadingZeros":
-                return new WasmIntUnary(WasmIntType.INT64, WasmIntUnaryOperation.CLZ,
-                        manager.generate(invocation.getArguments().get(0)));
+                return castToInt(new WasmIntUnary(WasmIntType.INT64, WasmIntUnaryOperation.CLZ,
+                        manager.generate(invocation.getArguments().get(0))));
             case "numberOfTrailingZeros":
-                return new WasmIntUnary(WasmIntType.INT64, WasmIntUnaryOperation.CTZ,
-                        manager.generate(invocation.getArguments().get(0)));
+                return castToInt(new WasmIntUnary(WasmIntType.INT64, WasmIntUnaryOperation.CTZ,
+                        manager.generate(invocation.getArguments().get(0))));
             case "bitCount":
-                return new WasmIntUnary(WasmIntType.INT64, WasmIntUnaryOperation.POPCNT,
-                        manager.generate(invocation.getArguments().get(0)));
+                return castToInt(new WasmIntUnary(WasmIntType.INT64, WasmIntUnaryOperation.POPCNT,
+                        manager.generate(invocation.getArguments().get(0))));
             default:
                 throw new AssertionError();
         }
+    }
+
+    private WasmExpression castToInt(WasmExpression expr) {
+        return new WasmConversion(WasmNumType.INT64, WasmNumType.INT32, false, expr);
     }
 }

--- a/core/src/main/java/org/teavm/backend/wasm/intrinsics/gc/IntNumIntrinsic.java
+++ b/core/src/main/java/org/teavm/backend/wasm/intrinsics/gc/IntNumIntrinsic.java
@@ -17,7 +17,9 @@ package org.teavm.backend.wasm.intrinsics.gc;
 
 import org.teavm.ast.InvocationExpr;
 import org.teavm.backend.wasm.WasmRuntime;
+import org.teavm.backend.wasm.model.WasmNumType;
 import org.teavm.backend.wasm.model.expression.WasmCall;
+import org.teavm.backend.wasm.model.expression.WasmConversion;
 import org.teavm.backend.wasm.model.expression.WasmExpression;
 import org.teavm.backend.wasm.model.expression.WasmIntBinary;
 import org.teavm.backend.wasm.model.expression.WasmIntBinaryOperation;
@@ -51,16 +53,24 @@ public class IntNumIntrinsic implements WasmGCIntrinsic {
                         context.generate(invocation.getArguments().get(0)),
                         context.generate(invocation.getArguments().get(1)));
             case "numberOfLeadingZeros":
-                return new WasmIntUnary(wasmType, WasmIntUnaryOperation.CLZ,
-                        context.generate(invocation.getArguments().get(0)));
+                return castToInt(new WasmIntUnary(wasmType, WasmIntUnaryOperation.CLZ,
+                        context.generate(invocation.getArguments().get(0))));
             case "numberOfTrailingZeros":
-                return new WasmIntUnary(wasmType, WasmIntUnaryOperation.CTZ,
-                        context.generate(invocation.getArguments().get(0)));
+                return castToInt(new WasmIntUnary(wasmType, WasmIntUnaryOperation.CTZ,
+                        context.generate(invocation.getArguments().get(0))));
             case "bitCount":
-                return new WasmIntUnary(wasmType, WasmIntUnaryOperation.POPCNT,
-                        context.generate(invocation.getArguments().get(0)));
+                return castToInt(new WasmIntUnary(wasmType, WasmIntUnaryOperation.POPCNT,
+                        context.generate(invocation.getArguments().get(0))));
             default:
                 throw new AssertionError();
+        }
+    }
+
+    private WasmExpression castToInt(WasmExpression expr) {
+        if (wasmType == WasmIntType.INT64) {
+            return new WasmConversion(WasmNumType.INT64, WasmNumType.INT32, false, expr);
+        } else {
+            return expr;
         }
     }
 }

--- a/core/src/main/java/org/teavm/backend/wasm/intrinsics/gc/IntNumIntrinsic.java
+++ b/core/src/main/java/org/teavm/backend/wasm/intrinsics/gc/IntNumIntrinsic.java
@@ -22,6 +22,8 @@ import org.teavm.backend.wasm.model.expression.WasmExpression;
 import org.teavm.backend.wasm.model.expression.WasmIntBinary;
 import org.teavm.backend.wasm.model.expression.WasmIntBinaryOperation;
 import org.teavm.backend.wasm.model.expression.WasmIntType;
+import org.teavm.backend.wasm.model.expression.WasmIntUnary;
+import org.teavm.backend.wasm.model.expression.WasmIntUnaryOperation;
 import org.teavm.model.MethodReference;
 
 public class IntNumIntrinsic implements WasmGCIntrinsic {
@@ -48,6 +50,15 @@ public class IntNumIntrinsic implements WasmGCIntrinsic {
                 return new WasmCall(context.functions().forStaticMethod(compareUnsigned),
                         context.generate(invocation.getArguments().get(0)),
                         context.generate(invocation.getArguments().get(1)));
+            case "numberOfLeadingZeros":
+                return new WasmIntUnary(wasmType, WasmIntUnaryOperation.CLZ,
+                        context.generate(invocation.getArguments().get(0)));
+            case "numberOfTrailingZeros":
+                return new WasmIntUnary(wasmType, WasmIntUnaryOperation.CTZ,
+                        context.generate(invocation.getArguments().get(0)));
+            case "bitCount":
+                return new WasmIntUnary(wasmType, WasmIntUnaryOperation.POPCNT,
+                        context.generate(invocation.getArguments().get(0)));
             default:
                 throw new AssertionError();
         }

--- a/core/src/main/java/org/teavm/backend/wasm/intrinsics/gc/WasmGCIntrinsics.java
+++ b/core/src/main/java/org/teavm/backend/wasm/intrinsics/gc/WasmGCIntrinsics.java
@@ -126,6 +126,9 @@ public class WasmGCIntrinsics implements WasmGCIntrinsicProvider {
         add(new MethodReference(wrapperClass, "divideUnsigned", javaClass, javaClass, javaClass), intrinsic);
         add(new MethodReference(wrapperClass, "remainderUnsigned", javaClass, javaClass, javaClass), intrinsic);
         add(new MethodReference(wrapperClass, "compareUnsigned", javaClass, javaClass, int.class), intrinsic);
+        add(new MethodReference(wrapperClass, "numberOfLeadingZeros", javaClass, int.class), intrinsic);
+        add(new MethodReference(wrapperClass, "numberOfTrailingZeros", javaClass, int.class), intrinsic);
+        add(new MethodReference(wrapperClass, "bitCount", javaClass, int.class), intrinsic);
     }
 
     private void fillFloat() {

--- a/core/src/main/java/org/teavm/backend/wasm/transformation/BaseClassesTransformation.java
+++ b/core/src/main/java/org/teavm/backend/wasm/transformation/BaseClassesTransformation.java
@@ -1,0 +1,41 @@
+/*
+ *  Copyright 2024 Alexey Andreev.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.teavm.backend.wasm.transformation;
+
+import org.teavm.model.ClassHolder;
+import org.teavm.model.ClassHolderTransformer;
+import org.teavm.model.ClassHolderTransformerContext;
+import org.teavm.model.ElementModifier;
+
+public class BaseClassesTransformation implements ClassHolderTransformer {
+
+    @Override
+    public void transformClass(ClassHolder cls, ClassHolderTransformerContext context) {
+        if (cls.getName().equals("java.lang.Integer") || cls.getName().equals("java.lang.Long")) {
+            for (var method : cls.getMethods()) {
+                switch (method.getName()) {
+                case "numberOfLeadingZeros":
+                case "numberOfTrailingZeros":
+                case "bitCount":
+                    method.setProgram(null);
+                    method.getModifiers().add(ElementModifier.NATIVE);
+                    break;
+                }
+            }
+        }
+    }
+
+}

--- a/core/src/main/java/org/teavm/backend/wasm/transformation/gc/BaseClassesTransformation.java
+++ b/core/src/main/java/org/teavm/backend/wasm/transformation/gc/BaseClassesTransformation.java
@@ -121,6 +121,17 @@ public class BaseClassesTransformation implements ClassHolderTransformer {
             var clear = cls.getMethod(new MethodDescriptor("clear", void.class));
             clear.getModifiers().add(ElementModifier.NATIVE);
             clear.setProgram(null);
+        } else if (cls.getName().equals("java.lang.Integer") || cls.getName().equals("java.lang.Long")) {
+            for (var method : cls.getMethods()) {
+                switch (method.getName()) {
+                case "numberOfLeadingZeros":
+                case "numberOfTrailingZeros":
+                case "bitCount":
+                    method.setProgram(null);
+                    method.getModifiers().add(ElementModifier.NATIVE);
+                    break;
+                }
+            }
         }
     }
 

--- a/tests/src/test/java/org/teavm/classlib/java/lang/LongTest.java
+++ b/tests/src/test/java/org/teavm/classlib/java/lang/LongTest.java
@@ -87,6 +87,35 @@ public class LongTest {
     }
 
     @Test
+    public void numberOfLeadingZerosComputed() {
+        assertEquals(0,  Long.numberOfLeadingZeros(-1L));
+        assertEquals(1,  Long.numberOfLeadingZeros(0x4000000000000000L));
+        assertEquals(1,  Long.numberOfLeadingZeros(0x4000000000000123L));
+        assertEquals(1,  Long.numberOfLeadingZeros(0x7FFFFFFFFFFFFFFFL));
+        assertEquals(63, Long.numberOfLeadingZeros(1L));
+        assertEquals(62, Long.numberOfLeadingZeros(2L));
+        assertEquals(62, Long.numberOfLeadingZeros(3L));
+        assertEquals(0,  Long.numberOfLeadingZeros(0x8000000000000000L));
+        assertEquals(0,  Long.numberOfLeadingZeros(0x8000000000000123L));
+        assertEquals(0,  Long.numberOfLeadingZeros(0xFFFFFFFFFFFFFFFFL));
+        assertEquals(64, Long.numberOfLeadingZeros(0L));
+    }
+
+    @Test
+    public void numberOfTrailingZerosComputed() {
+        assertEquals(1,  Long.numberOfTrailingZeros(0xFFFFFFFFFFFFFFFEL));
+        assertEquals(1,  Long.numberOfTrailingZeros(0x4000000000000002L));
+        assertEquals(1,  Long.numberOfTrailingZeros(0x0000000000000002L));
+        assertEquals(63, Long.numberOfTrailingZeros(0x8000000000000000L));
+        assertEquals(62, Long.numberOfTrailingZeros(0x4000000000000000L));
+        assertEquals(62, Long.numberOfTrailingZeros(0xC000000000000000L));
+        assertEquals(0,  Long.numberOfTrailingZeros(0x0000000000000001L));
+        assertEquals(0,  Long.numberOfTrailingZeros(0x1230000000000003L));
+        assertEquals(0,  Long.numberOfTrailingZeros(0xFFFFFFFFFFFFFFFFL));
+        assertEquals(64, Long.numberOfTrailingZeros(0L));
+    }
+
+    @Test
     public void highestOneBit() {
         assertEquals(1L << 63, Long.highestOneBit(-1L));
         assertEquals(1L << 63, Long.highestOneBit(Long.MIN_VALUE));


### PR DESCRIPTION
I implemented intrinsic functions for `numberOfLeadingZeros`, `numberOfTrailingZeros`, and `bitCount` using the `clz`, `ctz`, and `popcnt` instructions in the WASM and WASM GC backends.

The classlib unit tests pass and my app still works, I make use of the leading and trailing zero functions in my direct buffer malloc/free implementation so I actually do have a reason to optimize them.