### PR TITLE
Fix warnings about wrong/missing javadoc tags

### DIFF
--- a/classlib/src/main/java/org/teavm/classlib/java/math/TBigInteger.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/math/TBigInteger.java
@@ -1150,7 +1150,7 @@ public class TBigInteger extends Number implements Comparable<TBigInteger>, Seri
      * Returns a new {@code BigInteger} whose value is the biggest integer
      * {@code n} such that {@code n * n <= this}.
      *
-     * @implNote This implementation follows the ideas in Henry S. Warren, Jr.,
+     * This implementation follows the ideas in Henry S. Warren, Jr.,
      * Hacker's Delight (2nd ed.) (Addison Wesley, 2013), 279-282.
      *
      * @return {@code floor(sqrt(this))}

--- a/jso/apis/src/main/java/org/teavm/jso/core/JSPromise.java
+++ b/jso/apis/src/main/java/org/teavm/jso/core/JSPromise.java
@@ -104,7 +104,7 @@ public class JSPromise<T> implements JSObject {
     @JSMethod("finally")
     public native JSPromise<T> onSettled(JSSupplier<Object> onFinally);
 
-    /** Interface for the return values of {@ref #allSettled()}. */
+    /** Interface for the return values of {@link #allSettled(JsArrayReader)}. */
     public interface FulfillmentValue<T> extends JSObject {
         @JSProperty
         @NoSideEffects


### PR DESCRIPTION
Code previously contributed by me apparently uses unknown javadoc tags which leads to warnings when building teavm. :upside_down_face: 

This should be fixed with this PR by either removing the offending tags or replacing them with the proper one.