### PR TITLE
Fix TByte.decode() value range check

### DIFF
--- a/classlib/src/main/java/org/teavm/classlib/java/lang/TByte.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/lang/TByte.java
@@ -135,7 +135,7 @@ public class TByte extends TNumber implements TComparable<TByte> {
 
     public static TByte decode(String nm) throws TNumberFormatException {
         TInteger value = TInteger.decode(nm);
-        if (value.intValue() < MIN_VALUE || value.intValue() >= MAX_VALUE) {
+        if (value.intValue() < MIN_VALUE || value.intValue() > MAX_VALUE) {
             throw new TNumberFormatException();
         }
         return TByte.valueOf((byte) value.intValue());


### PR DESCRIPTION
In particular, throws an exception for `Byte.decode("0x7F")` code.