### PR TITLE
WASI VirtualSocket interface and Java networking classes implementation

### DIFF
--- a/classlib/src/main/java/org/teavm/classlib/java/net/TInet4Address.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/net/TInet4Address.java
@@ -1,0 +1,83 @@
+/*
+ *  Copyright 2025 Maksim Tiushev.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.teavm.classlib.java.net;
+
+public final class TInet4Address extends TInetAddress {
+    static final int INADDRSZ = 4;
+
+    TInet4Address(byte[] addr, String hostname) {
+        super(addr, hostname, IPv4);
+        validateIPv4Address(addr);
+    }
+
+    private static void validateIPv4Address(byte[] addr) {
+        if (addr.length != INADDRSZ) {
+            throw new IllegalArgumentException("IPv4 address must be exactly 4 bytes long.");
+        }
+    }
+
+    @Override
+    public boolean isAnyLocalAddress() {
+        return address[0] == 0 && address[1] == 0 && address[2] == 0 && address[3] == 0;
+    }
+
+    @Override
+    public boolean isLoopbackAddress() {
+        return address[0] == 127;
+    }
+
+    @Override
+    public boolean isLinkLocalAddress() {
+        return (address[0] & 0xFF) == 169 && (address[1] & 0xFF) == 254;
+    }
+
+    @Override
+    public boolean isMCGlobal() {
+        return (address[0] & 0xFF) >= 224
+                && (address[0] & 0xFF) <= 238
+                && !(address[0] == 224 && address[1] == 0 && address[2] == 0);
+    }
+
+    @Override
+    public boolean isMCLinkLocal() {
+        return (address[0] & 0xFF) == 224 && (address[1] & 0xFF) == 0;
+    }
+
+    @Override
+    public boolean isMCOrgLocal() {
+        return (address[0] & 0xFF) == 239 && (address[1] & 0xFF) >= 192;
+    }
+
+    @Override
+    public boolean isMCSiteLocal() {
+        return (address[0] & 0xFF) == 239 && (address[1] & 0xFF) == 255;
+    }
+
+    @Override
+    public boolean isMulticastAddress() {
+        return (address[0] & 0xFF) >= 224 && (address[0] & 0xFF) <= 239;
+    }
+
+    @Override
+    public boolean isSiteLocalAddress() {
+        int firstOctet = address[0] & 0xFF;
+        int secondOctet = address[1] & 0xFF;
+
+        return (firstOctet == 10)
+                || (firstOctet == 172 && secondOctet >= 16 && secondOctet <= 31)
+                || (firstOctet == 192 && secondOctet == 168);
+    }
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/net/TInet6Address.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/net/TInet6Address.java
@@ -1,0 +1,154 @@
+/*
+ *  Copyright 2025 Maksim Tiushev.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.teavm.classlib.java.net;
+
+public final class TInet6Address extends TInetAddress {
+    static final int INADDRSZ = 16;
+
+    TInet6Address(byte[] addr, String hostname) {
+        super(addr, hostname, IPv6);
+        validateIPv6Address(addr);
+    }
+
+    private static void validateIPv6Address(byte[] addr) {
+        if (addr.length != INADDRSZ) {
+            throw new IllegalArgumentException("IPv6 address must be exactly 16 bytes long.");
+        }
+    }
+
+    @Override
+    public String getHostAddress() {
+        StringBuilder sb = new StringBuilder();
+        int[] segments = new int[8];
+
+        for (int i = 0; i < 8; i++) {
+            segments[i] = ((address[i * 2] & 0xFF) << 8) | (address[i * 2 + 1] & 0xFF);
+        }
+
+        int startZero = -1;
+        int maxZeroLength = 0;
+        int zeroLength = 0;
+        int currentStart = -1;
+        for (int i = 0; i < segments.length; i++) {
+            if (segments[i] == 0) {
+                if (currentStart == -1) {
+                    currentStart = i;
+                }
+                zeroLength++;
+            } else {
+                if (zeroLength > maxZeroLength) {
+                    maxZeroLength = zeroLength;
+                    startZero = currentStart;
+                }
+                zeroLength = 0;
+                currentStart = -1;
+            }
+        }
+        if (zeroLength > maxZeroLength) {
+            maxZeroLength = zeroLength;
+            startZero = currentStart;
+        }
+
+        for (int i = 0; i < segments.length; i++) {
+            if (startZero == i && maxZeroLength > 1) {
+                if (i == 0) {
+                    sb.append("::");
+                } else {
+                    sb.append(':');
+                }
+                i += maxZeroLength - 1;
+                continue;
+            }
+            sb.append(Integer.toHexString(segments[i]));
+            if (i < segments.length - 1) {
+                sb.append(':');
+            }
+        }
+        return sb.toString();
+    }
+
+    @Override
+    public boolean isAnyLocalAddress() {
+        for (byte b : address) {
+            if (b != 0) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public boolean isIPv4CompatibleAddress() {
+        for (int i = 0; i < 12; i++) {
+            if (address[i] != 0) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public boolean isLinkLocalAddress() {
+        return (address[0] & 0xFF) == 0xFE && (address[1] & 0xC0) == 0x80;
+    }
+
+    @Override
+    public boolean isLoopbackAddress() {
+        if (address[15] != 1) {
+            return false;
+        }
+        for (int i = 0; i < 15; i++) {
+            if (address[i] != 0) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public boolean isMCGlobal() {
+        return (address[0] & 0xFF) == 0xFF && (address[1] & 0x0F) == 0x0E;
+    }
+
+    @Override
+    public boolean isMCLinkLocal() {
+        return (address[0] & 0xFF) == 0xFF && (address[1] & 0x0F) == 0x02;
+    }
+
+    @Override
+    public boolean isMCNodeLocal() {
+        return (address[0] & 0xFF) == 0xFF && (address[1] & 0x0F) == 0x01;
+    }
+
+    @Override
+    public boolean isMCOrgLocal() {
+        return (address[0] & 0xFF) == 0xFF && (address[1] & 0x0F) == 0x08;
+    }
+
+    @Override
+    public boolean isMCSiteLocal() {
+        return (address[0] & 0xFF) == 0xFF && (address[1] & 0x0F) == 0x05;
+    }
+
+    @Override
+    public boolean isMulticastAddress() {
+        return (address[0] & 0xFF) == 0xFF;
+    }
+
+    @Override
+    public boolean isSiteLocalAddress() {
+        return (address[0] & 0xFF) == 0xFE && (address[1] & 0xC0) == 0xC0;
+    }
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/net/TInetAddress.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/net/TInetAddress.java
@@ -1,0 +1,182 @@
+/*
+ *  Copyright 2025 Maksim Tiushev.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.teavm.classlib.java.net;
+
+import static org.teavm.backend.wasm.wasi.Wasi.INET4;
+import static org.teavm.backend.wasm.wasi.Wasi.INET6;
+import static org.teavm.backend.wasm.wasi.Wasi.INET_UNSPEC;
+import static org.teavm.backend.wasm.wasi.Wasi.SOCK_ANY;
+import org.teavm.backend.wasm.runtime.net.impl.SockAddrInet4;
+import org.teavm.backend.wasm.runtime.net.impl.SockAddrInet6;
+import org.teavm.runtime.net.SockAddr;
+import org.teavm.runtime.net.VirtualSocket;
+import org.teavm.runtime.net.VirtualSocketProvider;
+
+public class TInetAddress {
+    protected String hostname;
+    protected byte[] address;
+    protected int family;
+
+    static final int IPv4 = 1;
+    static final int IPv6 = 2;
+
+    private static VirtualSocket vs() {
+        return VirtualSocketProvider.getInstance();
+    }
+
+    protected TInetAddress() {
+    }
+
+    protected TInetAddress(byte[] address, String hostname, int family) {
+        this.address = address;
+        this.hostname = hostname;
+        this.family = family;
+    }
+
+    public byte[] getAddress() {
+        return address;
+    }
+
+    public int getFamily() {
+        return family;
+    }
+
+    public static TInetAddress[] getAllByName(String host) throws TUnknownHostException {
+        if (host == null || host.isEmpty()) {
+            TInetAddress[] ret = new TInetAddress[1];
+            ret[0] = getLoopbackAddress();
+            return ret;
+        }
+        try {
+            SockAddr[] addresses = vs().getAddrInfo(host, null, INET_UNSPEC, SOCK_ANY, 0);
+            if (addresses == null || addresses.length == 0) {
+                throw new TUnknownHostException("No addresses found for host: " + host);
+            }
+
+            TInetAddress[] result = new TInetAddress[addresses.length];
+            for (int i = 0; i < addresses.length; i++) {
+                SockAddr addr = addresses[i];
+                if (addr.sockFamily() == INET4) {
+                    result[i] = new TInet4Address(((SockAddrInet4) addr).getAddr(), host);
+                } else if (addr.sockFamily() == INET6) {
+                    result[i] = new TInet6Address(((SockAddrInet6) addr).getAddr(), host);
+                }
+            }
+            return result;
+        } catch (Exception e) {
+            throw new TUnknownHostException(
+                    "Failed to resolve host: " + host + " " + e.getMessage());
+        }
+    }
+
+    public static TInetAddress getByAddress(byte[] addr) throws TUnknownHostException {
+        return getByAddress(null, addr);
+    }
+
+    public static TInetAddress getByAddress(String host, byte[] addr) throws TUnknownHostException {
+        if (addr != null) {
+            if (addr.length == TInet4Address.INADDRSZ) {
+                return new TInet4Address(addr, host);
+            } else if (addr.length == TInet6Address.INADDRSZ) {
+                return new TInet6Address(addr, host);
+            }
+        }
+        throw new TUnknownHostException("Addr is of illegal length");
+    }
+
+    public static TInetAddress getByName(String host) throws TUnknownHostException {
+        TInetAddress[] addresses = getAllByName(host);
+        return addresses[0];
+    }
+
+    public String getCanonicalHostName() {
+        return hostname != null ? hostname : getHostAddress();
+    }
+
+    public String getHostAddress() {
+        StringBuilder sb = new StringBuilder();
+        for (byte b : address) {
+            sb.append(b & 0xFF).append('.');
+        }
+        sb.setLength(sb.length() - 1);
+        return sb.toString();
+    }
+
+    public String getHostName() {
+        return hostname != null ? hostname : getHostAddress();
+    }
+
+    public static TInetAddress getLocalHost() throws TUnknownHostException {
+        return new TInetAddress(new byte[] {127, 0, 0, 1}, "localhost", IPv4);
+    }
+
+    public static TInetAddress getLoopbackAddress() {
+        return new TInetAddress(new byte[] {127, 0, 0, 1}, "localhost", IPv4);
+    }
+
+    public boolean isAnyLocalAddress() {
+        return false;
+    }
+
+    public boolean isLinkLocalAddress() {
+        return false;
+    }
+
+    public boolean isLoopbackAddress() {
+        return false;
+    }
+
+    public boolean isMulticastAddress() {
+        return false;
+    }
+
+    public boolean isReachable(int timeout) {
+        return false;
+    }
+
+    public boolean isReachable(TNetworkInterface netif, int ttl, int timeout) {
+        return false;
+    }
+
+    public boolean isSiteLocalAddress() {
+        return false;
+    }
+
+    public boolean isMCGlobal() {
+        return false;
+    }
+
+    public boolean isMCNodeLocal() {
+        return false;
+    }
+
+    public boolean isMCLinkLocal() {
+        return false;
+    }
+
+    public boolean isMCSiteLocal() {
+        return false;
+    }
+
+    public boolean isMCOrgLocal() {
+        return false;
+    }
+
+    @Override
+    public String toString() {
+        return (hostname != null ? hostname : "") + "/" + getHostAddress();
+    }
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/net/TInetSocketAddress.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/net/TInetSocketAddress.java
@@ -1,0 +1,100 @@
+/*
+ *  Copyright 2025 Maksim Tiushev.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.teavm.classlib.java.net;
+
+import java.io.Serializable;
+
+public class TInetSocketAddress extends TSocketAddress implements Serializable {
+    private TInetAddress address;
+    private String hostname;
+    private int port;
+    private boolean unresolved;
+
+    public TInetSocketAddress(TInetAddress addr, int port) {
+        validatePort(port);
+        this.address = addr;
+        this.port = port;
+        this.unresolved = addr == null;
+    }
+
+    public TInetSocketAddress(int port) {
+        this((String) null, port);
+    }
+
+    public TInetSocketAddress(String hostname, int port) {
+        validatePort(port);
+        this.hostname = hostname;
+        this.port = port;
+        try {
+            this.address = TInetAddress.getByName(hostname);
+            this.unresolved = false;
+        } catch (TUnknownHostException e) {
+            this.address = null;
+            this.unresolved = true;
+        }
+    }
+
+    public static TInetSocketAddress createUnresolved(String host, int port) {
+        validatePort(port);
+        TInetSocketAddress socketAddress = new TInetSocketAddress(host, port);
+        socketAddress.unresolved = true;
+        return socketAddress;
+    }
+
+    public TInetAddress getAddress() {
+        return address;
+    }
+
+    public String getHostName() {
+        return hostname;
+    }
+
+    public String getHostString() {
+        if (hostname != null) {
+            return hostname;
+        }
+        return address != null ? address.getHostAddress() : null;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public boolean isUnresolved() {
+        return unresolved;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        if (hostname != null) {
+            sb.append(hostname);
+        } else if (address != null) {
+            sb.append(address.getHostAddress());
+        } else {
+            sb.append("<unresolved>");
+        }
+        sb.append(":").append(port);
+        return sb.toString();
+    }
+
+    private static int validatePort(int port) {
+        if (port < 0 || port > 65535) {
+            throw new IllegalArgumentException("Port number out of range: " + port);
+        }
+        return port;
+    }
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/net/TNetworkInterface.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/net/TNetworkInterface.java
@@ -1,0 +1,23 @@
+/*
+ *  Copyright 2025 Maksim Tiushev.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.teavm.classlib.java.net;
+
+/**
+ * This is a placeholder class required only to maintain type compatibility.
+ * The actual implementation will be provided later.
+ */
+public class TNetworkInterface {
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/net/TProxy.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/net/TProxy.java
@@ -1,0 +1,32 @@
+/*
+ *  Copyright 2025 Maksim Tiushev.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.teavm.classlib.java.net;
+
+/**
+ * This is a placeholder class required only to maintain type compatibility.
+ * The actual implementation will be provided later.
+ */
+public class TProxy {
+
+    public enum Type {
+        DIRECT,
+        HTTP,
+        SOCKS
+    };
+
+    public TProxy(Type type, TSocketAddress sa) {
+    }
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/net/TServerSocket.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/net/TServerSocket.java
@@ -1,0 +1,155 @@
+/*
+ *  Copyright 2025 Maksim Tiushev.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.teavm.classlib.java.net;
+
+import java.io.IOException;
+import org.teavm.runtime.net.VirtualSocket;
+import org.teavm.runtime.net.VirtualSocketProvider;
+
+public class TServerSocket {
+    private TSocket socket;
+    private boolean bound;
+
+    private static final int FD_CLOSED = -1;
+
+    private static VirtualSocket vs() {
+        return VirtualSocketProvider.getInstance();
+    }
+    
+    public TServerSocket() throws IOException {
+        this.socket = new TSocket();
+        this.bound = false;
+    }
+
+    public TServerSocket(int port) throws IOException {
+        this();
+        bind(new TInetSocketAddress(port));
+    }
+
+    public TServerSocket(int port, int backlog) throws IOException {
+        this();
+        bind(new TInetSocketAddress(port), backlog);
+    }
+
+    public TServerSocket(int port, int backlog, TInetAddress bindAddr) throws IOException {
+        this();
+        bind(new TInetSocketAddress(bindAddr, port), backlog);
+    }
+
+    public void bind(TSocketAddress endpoint) throws IOException {
+        bind(endpoint, 50);
+    }
+
+    public void bind(TSocketAddress endpoint, int backlog) throws IOException {
+        if (bound) {
+            throw new IOException("Socket is already bound");
+        }
+        if (!(endpoint instanceof TInetSocketAddress)) {
+            throw new IllegalArgumentException("Unsupported address type");
+        }
+        socket.bind(endpoint);
+        vs().listen(socket.getFd(), backlog);
+        this.bound = true;
+    }
+
+    public TSocket accept() throws IOException {
+        ensureSocketOpen();
+        ensureSocketBound();
+        int clientFd = vs().accept(socket.getFd(), 0);
+        return new TSocket(clientFd);
+    }
+
+    public void close() throws IOException {
+        if (!isClosed()) {
+            socket.close();
+        }
+    }
+
+    public boolean isBound() {
+        return bound;
+    }
+
+    public boolean isClosed() {
+        return socket.isClosed();
+    }
+
+    public TInetAddress getInetAddress() throws IOException {
+        return socket.getInetAddress();
+    }
+
+    public int getLocalPort() throws IOException {
+        return socket.getLocalPort();    }
+
+    public TSocketAddress getLocalSocketAddress() throws IOException {
+        return socket.getLocalSocketAddress();
+    }
+
+    public void setReuseAddress(boolean on) throws IOException {
+        socket.setReuseAddress(on);
+    }
+
+    public boolean getReuseAddress() throws IOException {
+        return socket.getReuseAddress();
+    }
+
+    public void setSoTimeout(int timeout) throws IOException {
+        socket.setSoTimeout(timeout);
+    }
+
+    public int getSoTimeout() throws IOException {
+        return socket.getSoTimeout();
+    }
+
+    public int getReceiveBufferSize() throws IOException {
+        return socket.getReceiveBufferSize();
+    }
+
+    public void setReceiveBufferSize(int size) throws IOException {
+        socket.setReceiveBufferSize(size);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("ServerSocket[");
+
+        if (!socket.isConnected()) {
+            sb.append("unconnected");
+        } else {
+            try {
+                sb.append("addr=").append(getInetAddress());
+                sb.append(",port=").append(getLocalPort());
+            } catch (IOException e) {
+                sb.append("error while retrieving socket information");
+            }
+        }
+
+        sb.append("]");
+        return sb.toString();
+    }
+
+    private void ensureSocketOpen() throws IOException {
+        if (isClosed()) {
+            throw new IOException("Socket is closed");
+        }
+    }
+
+    private void ensureSocketBound() throws IOException {
+        if (!isBound()) {
+            throw new IOException("Socket is not bound");
+        }
+    }
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/net/TSocket.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/net/TSocket.java
@@ -1,0 +1,521 @@
+/*
+ *  Copyright 2025 Maksim Tiushev.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.teavm.classlib.java.net;
+
+import static org.teavm.backend.wasm.wasi.Wasi.INET4;
+import static org.teavm.backend.wasm.wasi.Wasi.INET6;
+import static org.teavm.backend.wasm.wasi.Wasi.INET_UNSPEC;
+import static org.teavm.backend.wasm.wasi.Wasi.SHUT_RD;
+import static org.teavm.backend.wasm.wasi.Wasi.SHUT_RDWR;
+import static org.teavm.backend.wasm.wasi.Wasi.SHUT_WR;
+import static org.teavm.backend.wasm.wasi.Wasi.SOCK_DGRAM;
+import static org.teavm.backend.wasm.wasi.Wasi.SOCK_STREAM;
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import org.teavm.backend.wasm.runtime.net.impl.SockAddrInet4;
+import org.teavm.backend.wasm.runtime.net.impl.SockAddrInet6;
+import org.teavm.runtime.net.SockAddr;
+import org.teavm.runtime.net.VirtualSocket;
+import org.teavm.runtime.net.VirtualSocketProvider;
+
+public class TSocket implements Closeable {
+    protected int fd;
+    protected boolean created;
+
+    private static final int FD_CLOSED = -1;
+
+    private static VirtualSocket vs() {
+        return VirtualSocketProvider.getInstance();
+    }
+
+    public TSocket(int fd) {
+        this.fd = fd;
+        this.created = true;
+    }
+
+    public int getFd() {
+        return fd;
+    }
+
+    public TSocket() throws IOException {
+        this.fd = vs().socket(INET_UNSPEC, SOCK_STREAM);
+        this.created = true;
+    }
+
+    public TSocket(TInetAddress address, int port) throws IOException {
+        this(address, port, true);
+    }
+
+    public TSocket(TInetAddress host, int port, boolean stream) throws IOException {
+        this(host != null ? new TInetSocketAddress(host, port) : null,
+            (TSocketAddress) null, stream);
+    }
+
+    public TSocket(TInetAddress address, int port, TInetAddress localAddr, int localPort)
+            throws IOException {
+        this(address != null ? new TInetSocketAddress(address, port) : null,
+            new TInetSocketAddress(localAddr, localPort), true);
+    }
+
+    public TSocket(TProxy proxy) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    public TSocket(String host, int port) throws IOException {
+        this(host, port, true);
+    }
+
+    public TSocket(String host, int port, boolean stream) throws IOException {
+        this(host != null ? new TInetSocketAddress(host, port)
+                : new TInetSocketAddress(TInetAddress.getByName(null), port),
+                (TSocketAddress) null, stream);
+    }
+
+    public TSocket(String host, int port, TInetAddress localAddr, int localPort)
+            throws IOException {
+        this(host != null ? new TInetSocketAddress(host, port)
+                : new TInetSocketAddress(TInetAddress.getByName(null), port),
+                new TInetSocketAddress(localAddr, localPort), true);
+    }
+
+    private TSocket(TSocketAddress addr, TSocketAddress localAddr, boolean stream)
+            throws IOException {
+        assert addr instanceof TInetSocketAddress;
+        int sotype = stream ? SOCK_STREAM : SOCK_DGRAM;
+
+        SockAddr sa = getSockAddr(addr);
+        int family = sa.sockFamily();
+        this.fd = vs().socket(family, sotype);
+        this.created = true;
+
+        if (localAddr != null) {
+            bind(localAddr);
+        }
+        connect(sa);
+    }
+
+    private SockAddr getSockAddr(TSocketAddress addr) throws TSocketException {
+        assert addr instanceof TInetSocketAddress;
+        TInetSocketAddress isa = (TInetSocketAddress) addr;
+        return getSockAddr(isa.getAddress(), isa.getPort());
+    }
+
+    private SockAddr getSockAddr(TInetAddress addr, int port) throws TSocketException {
+        if (addr.getFamily() == TInetAddress.IPv4) {
+            return new SockAddrInet4(addr.getAddress(), port);
+        } else if (addr.getFamily() == TInetAddress.IPv6) {
+            return new SockAddrInet6(addr.getAddress(), port);
+        }
+        throw new TSocketException("Unknown address family");
+    }
+
+    public void bind(TSocketAddress bindpoint) throws IOException {
+        SockAddr sa = getSockAddr(bindpoint);
+        vs().bind(fd, sa);
+    }
+
+    private void connect(SockAddr sa) throws IOException {
+        vs().connect(fd, sa);
+    }
+
+    public void connect(TSocketAddress sa) throws IOException {
+        assert sa instanceof TInetSocketAddress;
+        SockAddr sAddr = getSockAddr(sa);
+        connect(sAddr);
+    }
+
+    public void connect(TSocketAddress endpoint, int timeout) throws IOException {
+        connect(endpoint);
+        setSoTimeout(timeout);
+    }
+
+    public void close() throws IOException {
+        ensureSocketOpen();
+        vs().shutdown(fd, SHUT_RDWR);
+        this.fd = FD_CLOSED;
+    }
+
+    public TInetAddress getInetAddress() throws IOException {
+        ensureSocketOpen();
+        SockAddr remoteAddress = vs().getSockName(fd);
+
+        if (remoteAddress.sockFamily() == INET4) {
+            SockAddrInet4 ipv4Address = (SockAddrInet4) remoteAddress;
+            return new TInet4Address(ipv4Address.getAddr(), (String) null);
+        } else if (remoteAddress.sockFamily() == INET6) {
+            SockAddrInet6 ipv6Address = (SockAddrInet6) remoteAddress;
+            return new TInet6Address(ipv6Address.getAddr(), (String) null);
+        }
+        throw new TSocketException("Unsupported address type: " + remoteAddress.sockFamily());
+    }
+
+    public TInetAddress getLocalAddress() throws IOException {
+        ensureSocketOpen();
+        SockAddr localAddress = vs().getSockName(fd);
+
+        if (localAddress.sockFamily() == INET4) {
+            SockAddrInet4 ipv4Address = (SockAddrInet4) localAddress;
+            return new TInet4Address(ipv4Address.getAddr(), (String) null);
+        } else if (localAddress.sockFamily() == INET6) {
+            SockAddrInet6 ipv6Address = (SockAddrInet6) localAddress;
+            return new TInet6Address(ipv6Address.getAddr(), (String) null);
+        }
+        throw new TSocketException("Unsupported address type: " + localAddress.sockFamily());
+    }
+
+    public int getLocalPort() throws IOException {
+        ensureSocketOpen();
+        SockAddr localAddress = vs().getSockName(fd);
+        return localAddress.sockPort();
+    }
+
+    public TSocketAddress getLocalSocketAddress() throws IOException {
+        ensureSocketOpen();
+        SockAddr localAddress = vs().getSockName(fd);
+
+        TInetAddress inetAddress;
+        if (localAddress.sockFamily() == INET4) {
+            SockAddrInet4 ipv4Address = (SockAddrInet4) localAddress;
+            inetAddress = new TInet4Address(ipv4Address.getAddr(), (String) null);
+        } else if (localAddress.sockFamily() == INET6) {
+            SockAddrInet6 ipv6Address = (SockAddrInet6) localAddress;
+            inetAddress = new TInet6Address(ipv6Address.getAddr(), (String) null);
+        } else {
+            throw new TSocketException("Unsupported address type: " + localAddress.sockFamily());
+        }
+        return new TInetSocketAddress(inetAddress, localAddress.sockPort());
+    }
+
+    public int getPort() throws IOException {
+        ensureSocketOpen();
+        SockAddr remoteAddress = vs().getPeerName(fd);
+        return remoteAddress.sockPort();
+    }
+
+    public TSocketAddress getRemoteSocketAddress() throws IOException {
+        ensureSocketOpen();
+        SockAddr remoteAddress = vs().getPeerName(fd);
+
+        TInetAddress inetAddress;
+        if (remoteAddress.sockFamily() == INET4) {
+            SockAddrInet4 ipv4Address = (SockAddrInet4) remoteAddress;
+            inetAddress = new TInet4Address(ipv4Address.getAddr(), (String) null);
+        } else if (remoteAddress.sockFamily() == INET6) {
+            SockAddrInet6 ipv6Address = (SockAddrInet6) remoteAddress;
+            inetAddress = new TInet6Address(ipv6Address.getAddr(), (String) null);
+        } else {
+            throw new TSocketException("Unsupported address type: " + remoteAddress.sockFamily());
+        }
+        return new TInetSocketAddress(inetAddress, remoteAddress.sockPort());
+    }
+
+    public InputStream getInputStream() throws IOException {
+        ensureSocketOpen();
+        final SockAddr remoteAddress = vs().getPeerName(fd);
+
+        return new InputStream() {
+            private static final int MAX_LENGTH = 8192;
+            private final byte[] buffer = new byte[MAX_LENGTH];
+
+            @Override
+            public int read() throws IOException {
+                int bytesRead = read(buffer, 0, 1);
+                return (bytesRead == -1) ? -1 : (buffer[0] & 0xFF);
+            }
+
+            @Override
+            public int read(byte[] b, int off, int len) throws IOException {
+                if (b == null) {
+                    throw new NullPointerException("Buffer is null");
+                }
+                if (off < 0 || len < 0 || off + len > b.length) {
+                    throw new IndexOutOfBoundsException("Invalid offset or length");
+                }
+                if (len == 0) {
+                    return 0;
+                }
+
+                try {
+                    int bytesRead = vs().recvFrom(fd, buffer, len, remoteAddress);
+                    if (bytesRead <= 0) {
+                        return -1;
+                    }
+
+                    System.arraycopy(buffer, 0, b, off, bytesRead);
+                    return bytesRead;
+                } catch (Exception e) {
+                    throw new IOException("Error reading from socket", e);
+                }
+            }
+        };
+    }
+
+    public OutputStream getOutputStream() throws IOException {
+        ensureSocketOpen();
+        final SockAddr remoteAddress = vs().getPeerName(fd);
+
+        return new OutputStream() {
+            @Override
+            public void write(int b) throws IOException {
+                byte[] singleByte = {(byte) b};
+                write(singleByte, 0, 1);
+            }
+
+            @Override
+            public void write(byte[] b, int off, int len) throws IOException {
+                if (b == null) {
+                    throw new NullPointerException("Buffer is null");
+                }
+                if (off < 0 || len < 0 || off + len > b.length) {
+                    throw new IndexOutOfBoundsException("Invalid offset or length");
+                }
+                if (len == 0) {
+                    return;
+                }
+
+                try {
+                    int bytesSent = vs().sendTo(fd, b, len, remoteAddress);
+                    if (bytesSent != len) {
+                        throw new IOException("Failed to send all data to socket");
+                    }
+                } catch (Exception e) {
+                    throw new IOException("Error writing to socket", e);
+                }
+            }
+        };
+    }
+
+    public boolean getKeepAlive() throws IOException {
+        ensureSocketOpen();
+        return vs().getSockKeepAlive(fd) == 1;
+    }
+
+    public void setKeepAlive(boolean on) throws IOException {
+        ensureSocketOpen();
+        vs().setSockKeepAlive(fd, on ? 1 : 0);
+    }
+
+    public boolean isBound() {
+        return fd > 0 && created;
+    }
+
+    public boolean isClosed() {
+        return fd == FD_CLOSED || !created;
+    }
+
+    public boolean isConnected() {
+        try {
+            return isBound() && !isAddressZero(vs().getPeerName(fd));
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    public boolean isInputShutdown() {
+        if (isClosed()) {
+            return true;
+        }
+        try {
+            return vs().recvFrom(fd, new byte[1], 0, null) == -1;
+        } catch (Exception e) {
+            return true;
+        }
+    }
+
+    public boolean isOutputShutdown() {
+        if (isClosed()) {
+            return true;
+        }
+        try {
+            SockAddr remoteAddress = vs().getPeerName(fd);
+            vs().sendTo(fd, new byte[0], 0, remoteAddress);
+            return false;
+        } catch (Exception e) {
+            return true;
+        }
+    }
+
+    public void shutdownInput() throws IOException {
+        if (!isClosed()) {
+            vs().shutdown(fd, SHUT_RD);
+        }
+    }
+
+    public void shutdownOutput() throws IOException {
+        if (!isClosed()) {
+            vs().shutdown(fd, SHUT_WR);
+        }
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Socket[");
+
+        if (!isConnected()) {
+            sb.append("unconnected");
+        } else {
+            try {
+                sb.append("addr=").append(getInetAddress());
+                sb.append(",port=").append(getPort());
+                sb.append(",localport=").append(getLocalPort());
+            } catch (IOException e) {
+                sb.append("error while retrieving socket information");
+            }
+        }
+
+        sb.append("]");
+        return sb.toString();
+    }
+
+    public void setReuseAddress(boolean on) throws IOException {
+        ensureSocketOpen();
+        vs().setSockReuseAddr(fd, on ? 1 : 0);
+    }
+
+    public boolean getReuseAddress() throws IOException {
+        ensureSocketOpen();
+        return vs().getSockReuseAddr(fd) == 1;
+    }
+
+    public int getReceiveBufferSize() throws IOException {
+        ensureSocketOpen();
+        return vs().getSockRecvBufSize(fd);
+    }
+
+    public void setReceiveBufferSize(int size) throws IOException {
+        if (size <= 0) {
+            throw new IllegalArgumentException("invalid receive size");
+        }
+        ensureSocketOpen();
+        vs().setSockRecvBufSize(fd, size);
+    }
+
+    public int getSendBufferSize() throws IOException {
+        ensureSocketOpen();
+        return vs().getSockSendBufSize(fd);
+    }
+
+    public void setSendBufferSize(int size) throws IOException {
+        if (size <= 0) {
+            throw new IllegalArgumentException("invalid receive size");
+        }
+        ensureSocketOpen();
+        vs().setSockSendBufSize(fd, size);
+    }
+
+    public int getSoLinger() throws IOException {
+        ensureSocketOpen();
+        return vs().getSockLinger(fd);
+    }
+
+    public void setSoLinger(boolean on, int linger) throws IOException {
+        ensureSocketOpen();
+        if (linger < 0) {
+            throw new IllegalArgumentException("invalid value for SO_LINGER");
+        }
+        if (linger > 65535) {
+            linger = 65535;
+        }
+        vs().setSockLinger(fd, on ? 1 : 0, linger);
+    }
+
+    public int getSoTimeout() throws IOException {
+        ensureSocketOpen();
+        return vs().getSockRecvTimeout(fd);
+    }
+
+    public void setSoTimeout(int timeout) throws IOException {
+        if (timeout <= 0) {
+            throw new IllegalArgumentException("invalid timeout");
+        }
+        ensureSocketOpen();
+        vs().setSockRecvTimeout(fd, timeout);
+    }
+
+    public boolean getTcpNoDelay() throws IOException {
+        ensureSocketOpen();
+        return vs().getSockTcpNoDelay(fd) == 1;
+    }
+
+    public void setTcpNoDelay(boolean on) throws IOException {
+        ensureSocketOpen();
+        vs().setSockTcpNoDelay(fd, on ? 1 : 0);
+    }
+
+    /**
+     * Sends a single byte of data on the socket. This method is intended to simulate the behavior
+     * of sending urgent data but does not implement true TCP Urgent Data (out-of-band data with the
+     * URG flag) due to limitations in the WASI environment.
+     *
+     * <p>Note: True TCP Urgent Data requires support for the URG flag in the TCP header, which is
+     * not currently available in WASI. This implementation simply sends the byte as normal in-band
+     * data.
+     */
+    public void sendUrgentData(int data) throws IOException {
+        ensureSocketOpen();
+        if (data < 0 || data > 255) {
+            throw new IllegalArgumentException("Data must be a single byte (0-255).");
+        }
+        SockAddr remoteAddress = vs().getPeerName(fd);
+        byte[] b = new byte[] {(byte) data};
+        int len = 1;
+        int bytesSent = vs().sendTo(fd, b, len, remoteAddress);
+        if (bytesSent != len) {
+            throw new IOException("Failed to send all data to socket");
+        }
+    }
+
+    public static void printByteArrayAsChars(byte[] data) {
+        if (data == null) {
+            throw new IllegalArgumentException("Data must not be null.");
+        }
+
+        for (byte b : data) {
+            System.out.print((char) b);
+        }
+        System.out.println();
+    }
+
+    private static boolean isAddressZero(SockAddr addr) {
+        if (addr instanceof SockAddrInet4) {
+            SockAddrInet4 inet4 = (SockAddrInet4) addr;
+            byte[] address = inet4.getAddr();
+            for (byte b : address) {
+                if (b != 0) {
+                    return false;
+                }
+            }
+        } else if (addr instanceof SockAddrInet6) {
+            SockAddrInet6 inet6 = (SockAddrInet6) addr;
+            byte[] address = inet6.getAddr();
+            for (byte s : address) {
+                if (s != 0) {
+                    return false;
+                }
+            }
+        }
+        return addr.sockPort() == 0;
+    }
+
+    private void ensureSocketOpen() throws TSocketException {
+        if (isClosed()) {
+            throw new TSocketException("Socket is closed");
+        }
+    }
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/net/TSocketAddress.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/net/TSocketAddress.java
@@ -1,0 +1,26 @@
+/*
+ *  Copyright 2025 Maksim Tiushev.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.teavm.classlib.java.net;
+
+import java.io.Serializable;
+
+public abstract class TSocketAddress implements Serializable {
+    /**
+     * Constructor for subclasses to call.
+     */
+    public TSocketAddress() {
+    }
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/net/TSocketException.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/net/TSocketException.java
@@ -1,0 +1,35 @@
+/*
+ *  Copyright 2025 Maksim Tiushev.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.teavm.classlib.java.net;
+
+import java.io.IOException;
+
+public class TSocketException extends IOException {
+    public TSocketException(String msg) {
+        super(msg);
+    }
+
+    public TSocketException() {
+    }
+
+    public TSocketException(String msg, Throwable cause) {
+        super(msg, cause);
+    }
+
+    public TSocketException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/net/TUnknownHostException.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/net/TUnknownHostException.java
@@ -1,0 +1,27 @@
+/*
+ *  Copyright 2025 Maksim Tiushev.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.teavm.classlib.java.net;
+
+import java.io.IOException;
+
+public class TUnknownHostException extends IOException {
+    public TUnknownHostException(String message) {
+        super(message);
+    }
+
+    public TUnknownHostException() {
+    }
+}

--- a/core/src/main/java/org/teavm/backend/wasm/WasmTarget.java
+++ b/core/src/main/java/org/teavm/backend/wasm/WasmTarget.java
@@ -119,6 +119,7 @@ import org.teavm.backend.wasm.transformation.BaseClassesTransformation;
 import org.teavm.backend.wasm.transformation.IndirectCallTraceTransformation;
 import org.teavm.backend.wasm.transformation.MemoryAccessTraceTransformation;
 import org.teavm.backend.wasm.transformation.WasiFileSystemProviderTransformer;
+import org.teavm.backend.wasm.transformation.WasiSocketProviderTransformer;
 import org.teavm.backend.wasm.transformation.WasiSupportClassTransformer;
 import org.teavm.backend.wasm.transformation.WasmExceptionHandlingTransform;
 import org.teavm.common.ServiceRepository;
@@ -247,6 +248,7 @@ public class WasmTarget implements TeaVMTarget, TeaVMWasmHost {
         if (runtimeType == WasmRuntimeType.WASI) {
             transformers.add(new WasiSupportClassTransformer());
             transformers.add(new WasiFileSystemProviderTransformer());
+            transformers.add(new WasiSocketProviderTransformer());
         }
         if (exceptionsUsed) {
             transformers.add(new WasmExceptionHandlingTransform());

--- a/core/src/main/java/org/teavm/backend/wasm/runtime/net/WasiVirtualSocket.java
+++ b/core/src/main/java/org/teavm/backend/wasm/runtime/net/WasiVirtualSocket.java
@@ -1,0 +1,428 @@
+/*
+ *  Copyright 2025 Maksim Tiushev.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.teavm.backend.wasm.runtime.net;
+
+import static org.teavm.backend.wasm.wasi.Wasi.AF_INET;
+import static org.teavm.backend.wasm.wasi.Wasi.AF_INET6;
+import static org.teavm.backend.wasm.wasi.Wasi.AF_UNIX;
+import static org.teavm.backend.wasm.wasi.Wasi.SOCK_ANY;
+import static org.teavm.backend.wasm.wasi.Wasi.SOCK_DGRAM;
+import static org.teavm.backend.wasm.wasi.Wasi.SOCK_STREAM;
+import java.net.SocketException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import org.teavm.backend.wasm.runtime.net.impl.*;
+import org.teavm.backend.wasm.wasi.Wasi;
+import org.teavm.interop.Address;
+import org.teavm.runtime.net.SockAddr;
+import org.teavm.runtime.net.VirtualSocket;
+
+public class WasiVirtualSocket implements VirtualSocket {
+
+    private static final int MAX_RESOLVED_ADDRESSES = 16;
+    private static final int ADDR_SIZE = 22;
+    private static final int BUFFER_SIZE = 8;
+    private static final int IPV4_ADDR_SIZE = 4;
+    private static final int IPV6_ADDR_SIZE = 8;
+    private static final int ADDR_INFO_BUFFER_SIZE = AddrInfo.getBufferSize();
+    private static final int ADDR_INFO_ADDR_BUFFER_SIZE = AddrInfo.getAddrBufferSize();
+    public static final int HINTS_ENABLED = 1;
+    public static final int HINTS_DISABLED = 2;
+
+    @Override
+    public int socket(int proto, int sotype) throws SocketException {
+        validateProto(proto);
+        validateSotype(sotype);
+
+        int[] newFd = new int[1];
+        int errno = Wasi.sockOpen(0, proto, sotype, Address.ofData(newFd));
+        if (errno != 0) {
+            throw new SocketException("socket: " + errno);
+        }
+        return newFd[0];
+    }
+
+    @Override
+    public void connect(int fd, SockAddr sa) throws SocketException {
+        try {
+            Address rawAddr = sa.sockAddr();
+            int errno = Wasi.sockConnect(fd, rawAddr);
+            if (errno != 0) {
+                throw new SocketException("сonnect: " + errno);
+            }
+        } catch (Exception e) {
+            throw new SocketException("Failed to get SockAddr: " + e.getMessage());
+        }
+    }
+
+    @Override
+    public void bind(int fd, SockAddr sa) throws SocketException {
+        try {
+            Address rawAddr = sa.sockAddr();
+            int errno = Wasi.sockBind(fd, rawAddr);
+            if (errno != 0) {
+                throw new SocketException("bind: " + errno);
+            }
+        } catch (Exception e) {
+            throw new SocketException("Failed to get SockAddr: " + e.getMessage());
+        }
+    }
+
+    @Override
+    public void listen(int fd, int backlog) throws SocketException {
+        int errno = Wasi.sockListen(fd, backlog);
+        if (errno != 0) {
+            throw new SocketException("listen: " + errno);
+        }
+    }
+
+    @Override
+    public int sendTo(int fd, byte[] buf, int len, SockAddr sa) throws SocketException {
+        Address rawAddr;
+
+        try {
+            rawAddr = sa.sockAddr();
+        } catch (Exception e) {
+            throw new SocketException("Failed to get SockAddr: " + e.getMessage());
+        }
+
+        ByteBuffer buffer = ByteBuffer.allocate(BUFFER_SIZE);
+        buffer.order(ByteOrder.nativeOrder());
+        buffer.putInt((int) Address.ofData(buf).toLong());
+        buffer.putInt(len);
+
+        int[] dataLen = new int[1];
+        int errno =
+                Wasi.sockSendTo(
+                        fd, Address.ofData(buffer.array()), 1, 0, rawAddr, Address.ofData(dataLen));
+
+        if (errno != 0) {
+            throw new SocketException("send_to: " + errno);
+        }
+        return dataLen[0];
+    }
+
+    @Override
+    public int recvFrom(int fd, byte[] buf, int len, SockAddr sa) throws SocketException {
+        byte[] addr = new byte[ADDR_SIZE];
+        Address rawAddr = Address.ofData(addr);
+
+        ByteBuffer buffer = ByteBuffer.allocate(BUFFER_SIZE);
+        buffer.order(ByteOrder.nativeOrder());
+        buffer.putInt((int) Address.ofData(buf).toLong());
+        buffer.putInt(len);
+
+        int[] dataLen = new int[1];
+
+        int errno =
+                Wasi.sockRecvFrom(
+                        fd, Address.ofData(buffer.array()), 1, 0, rawAddr, Address.ofData(dataLen));
+        if (errno != 0) {
+            throw new SocketException("recv_from: " + errno);
+        }
+        return dataLen[0];
+    }
+
+    @Override
+    public void shutdown(int fd, int how) throws SocketException {
+        int errno = Wasi.sockShutdown(fd, how);
+        if (errno != 0) {
+            throw new SocketException("shutdown: " + errno);
+        }
+    }
+
+    @Override
+    public int accept(int fd, int flags) throws SocketException {
+        int[] newFd = new int[1];
+        int errno = Wasi.sockAccept(fd, flags, Address.ofData(newFd));
+        if (errno != 0) {
+            throw new SocketException("accept: " + errno);
+        }
+        return newFd[0];
+    }
+
+    @Override
+    public SockAddr getSockName(int fd) throws SocketException {
+        byte[] addr = new byte[ADDR_SIZE];
+        int errno = Wasi.sockAddrLocal(fd, Address.ofData(addr));
+        if (errno != 0) {
+            throw new SocketException("get_sock_name: " + errno);
+        }
+        return parseSockAddr(addr);
+    }
+
+    @Override
+    public SockAddr getPeerName(int fd) throws SocketException {
+        byte[] addr = new byte[ADDR_SIZE];
+        int errno = Wasi.sockAddrRemote(fd, Address.ofData(addr));
+        if (errno != 0) {
+            throw new SocketException("get_peer_name: " + errno);
+        }
+        return parseSockAddr(addr);
+    }
+
+    @Override
+    public void setSockBroadcast(int fd, int value) throws SocketException {
+        int errno = Wasi.sockSetBroadcast(fd, value);
+        if (errno != 0) {
+            throw new SocketException("sockopt_set_broadcast: " + errno);
+        }
+    }
+
+    public SockAddr[] getAddrInfo(
+            String name, String service, int proto, int sotype, int hintsEnabled)
+            throws SocketException {
+        byte[] nameNT = toByteArrayWithNullTerminator(name);
+        byte[] serviceNT = toByteArrayWithNullTerminator(service);
+
+        if (hintsEnabled == HINTS_ENABLED) {
+            validateProto(proto);
+            validateSotype(sotype);
+        }
+
+        AddrInfoHints hints = new AddrInfoHints(sotype, proto, hintsEnabled);
+        byte[] resultBuffer = new byte[ADDR_INFO_BUFFER_SIZE * MAX_RESOLVED_ADDRESSES];
+        int[] resolvedCount = new int[1];
+
+        int errno =
+                Wasi.sockAddrResolve(
+                        Address.ofData(nameNT),
+                        Address.ofData(serviceNT),
+                        hints.getAddress(),
+                        Address.ofData(resultBuffer),
+                        resultBuffer.length,
+                        Address.ofData(resolvedCount));
+
+        if (errno != 0) {
+            throw new SocketException("get_addr_info: " + errno);
+        }
+
+        SockAddr[] addresses = new SockAddr[resolvedCount[0]];
+
+        for (int i = 0; i < resolvedCount[0]; i++) {
+            ByteBuffer buffer =
+                    ByteBuffer.wrap(resultBuffer, i * ADDR_INFO_BUFFER_SIZE, ADDR_INFO_BUFFER_SIZE)
+                            .order(ByteOrder.nativeOrder());
+
+            int sockKind = buffer.getInt();
+            byte[] addrBuf = new byte[ADDR_INFO_ADDR_BUFFER_SIZE];
+            buffer.get(addrBuf);
+            int sockType = buffer.getInt();
+
+            AddrInfo addrInfo = new AddrInfo(sockKind, addrBuf, sockType);
+            addresses[i] = parseSockAddr(addrInfoToRaw(addrInfo));
+        }
+
+        return addresses;
+    }
+
+    @Override
+    public int getSockKeepAlive(int fd) throws SocketException {
+        int[] res = new int[1];
+        int errno = Wasi.sockGetKeepAlive(fd, Address.ofData(res));
+        if (errno != 0) {
+            throw new SocketException("sock_get_keep_alive: " + errno);
+        }
+        return res[0];
+    }
+
+    @Override
+    public void setSockKeepAlive(int fd, int value) throws SocketException {
+        int errno = Wasi.sockSetKeepAlive(fd, value);
+        if (errno != 0) {
+            throw new SocketException("sock_set_keep_alive: " + errno);
+        }
+    }
+
+    @Override
+    public int getSockReuseAddr(int fd) throws SocketException {
+        int[] res = new int[1];
+        int errno = Wasi.sockGetReuseAddr(fd, Address.ofData(res));
+        if (errno != 0) {
+            throw new SocketException("sock_get_reuse_addr: " + errno);
+        }
+        return res[0];
+    }
+
+    @Override
+    public void setSockReuseAddr(int fd, int value) throws SocketException {
+        int errno = Wasi.sockSetReuseAddr(fd, value);
+        if (errno != 0) {
+            throw new SocketException("sockopt_set_reuse_addr: " + errno);
+        }
+    }
+
+    @Override
+    public int getSockRecvBufSize(int fd) throws SocketException {
+        int[] res = new int[1];
+        int errno = Wasi.sockGetRecvBufSize(fd, Address.ofData(res));
+        if (errno != 0) {
+            throw new SocketException("sock_get_recv_buf_size: " + errno);
+        }
+        return res[0];
+    }
+
+    @Override
+    public void setSockRecvBufSize(int fd, int size) throws SocketException {
+        int errno = Wasi.sockSetRecvBufSize(fd, size);
+        if (errno != 0) {
+            throw new SocketException("sock_set_recv_buf_size: " + errno);
+        }
+    }
+
+    @Override
+    public int getSockSendBufSize(int fd) throws SocketException {
+        int[] res = new int[1];
+        int errno = Wasi.sockGetSendBufSize(fd, Address.ofData(res));
+        if (errno != 0) {
+            throw new SocketException("sock_get_send_buf_size: " + errno);
+        }
+        return res[0];
+    }
+
+    @Override
+    public void setSockSendBufSize(int fd, int size) throws SocketException {
+        int errno = Wasi.sockSetSendBufSize(fd, size);
+        if (errno != 0) {
+            throw new SocketException("sock_set_send_buf_size: " + errno);
+        }
+    }
+
+    @Override
+    public int getSockLinger(int fd) throws SocketException {
+        int[] isEnabled = new int[1];
+        int[] linger = new int[1];
+        int errno = Wasi.sockGetLinger(fd, Address.ofData(isEnabled), Address.ofData(linger));
+        if (errno != 0) {
+            throw new SocketException("sock_get_linger: " + errno);
+        }
+        if (isEnabled[0] == 0) {
+            return linger[0];
+        }
+        return -1;
+    }
+
+    @Override
+    public void setSockLinger(int fd, int value, int linger) throws SocketException {
+        int errno = Wasi.sockSetLinger(fd, value, linger);
+        if (errno != 0) {
+            throw new SocketException("sock_set_linger: " + errno);
+        }
+    }
+
+    @Override
+    public int getSockRecvTimeout(int fd) throws SocketException {
+        int[] res = new int[1];
+        int errno = Wasi.sockGetRecvTimeout(fd, Address.ofData(res));
+        if (errno != 0) {
+            throw new SocketException("sock_get_recv_timeout: " + errno);
+        }
+        return res[0] / 1000;
+    }
+
+    @Override
+    public void setSockRecvTimeout(int fd, int value) throws SocketException {
+        int errno = Wasi.sockSetRecvTimeout(fd, value * 1000);
+        if (errno != 0) {
+            throw new SocketException("sock_set_recv_timeout: " + errno);
+        }
+    }
+
+    @Override
+    public int getSockTcpNoDelay(int fd) throws SocketException {
+        int[] res = new int[1];
+        int errno = Wasi.sockGetTcpNoDelay(fd, Address.ofData(res));
+        if (errno != 0) {
+            throw new SocketException("sock_get_tcp_no_delay: " + errno);
+        }
+        return res[0];
+    }
+
+    @Override
+    public void setSockTcpNoDelay(int fd, int value) throws SocketException {
+        int errno = Wasi.sockSetTcpNoDelay(fd, value);
+        if (errno != 0) {
+            throw new SocketException("sock_set_tcp_no_delay: " + errno);
+        }
+    }
+
+    // ============================== Helpers ==============================
+
+    private void validateProto(int proto) throws SocketException {
+        if (!isValidProto(proto)) {
+            throw new SocketException("Invalid protocol type: " + proto);
+        }
+    }
+
+    private void validateSotype(int sotype) throws SocketException {
+        if (!isValidSotype(sotype)) {
+            throw new SocketException("Invalid socket type: " + sotype);
+        }
+    }
+
+    private boolean isValidProto(int proto) {
+        return proto == AF_INET || proto == AF_INET6 || proto == AF_UNIX;
+    }
+
+    private boolean isValidSotype(int sotype) {
+        return sotype == SOCK_ANY || sotype == SOCK_DGRAM || sotype == SOCK_STREAM;
+    }
+
+    public static byte[] toByteArrayWithNullTerminator(String input) {
+        if (input == null) {
+            return new byte[] {0};
+        }
+
+        byte[] originalBytes = input.getBytes();
+        byte[] result = new byte[originalBytes.length + 1];
+        System.arraycopy(originalBytes, 0, result, 0, originalBytes.length);
+        result[result.length - 1] = 0;
+        return result;
+    }
+
+    private static SockAddr parseSockAddr(byte[] data) throws SocketException {
+        if (data.length != ADDR_SIZE) {
+            throw new SocketException(
+                    "Expected " + ADDR_SIZE + " bytes of data, but got " + data.length);
+        }
+
+        ByteBuffer buffer = ByteBuffer.wrap(data).order(ByteOrder.nativeOrder());
+        int kind = buffer.getInt();
+
+        if (kind == AF_INET) {
+            byte[] addr = new byte[IPV4_ADDR_SIZE];
+            buffer.get(addr);
+            short port = buffer.getShort();
+            return new SockAddrInet4(addr, port);
+        } else if (kind == AF_INET6) {
+            short[] addr = new short[IPV6_ADDR_SIZE];
+            for (int i = 0; i < IPV6_ADDR_SIZE; i++) {
+                addr[i] = buffer.getShort();
+            }
+            short port = buffer.getShort();
+            return new SockAddrInet6(addr, port);
+        } else {
+            throw new SocketException("Unknown address family: " + kind);
+        }
+    }
+
+    private byte[] addrInfoToRaw(AddrInfo addrInfo) {
+        ByteBuffer buffer = ByteBuffer.allocate(ADDR_SIZE).order(ByteOrder.nativeOrder());
+        buffer.putInt(addrInfo.getSockKind());
+        buffer.put(addrInfo.getAddrBuf());
+        return buffer.array();
+    }
+}

--- a/core/src/main/java/org/teavm/backend/wasm/runtime/net/impl/AddrInfo.java
+++ b/core/src/main/java/org/teavm/backend/wasm/runtime/net/impl/AddrInfo.java
@@ -1,0 +1,88 @@
+/*
+ *  Copyright 2025 Maksim Tiushev.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.teavm.backend.wasm.runtime.net.impl;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import org.teavm.interop.Address;
+
+public class AddrInfo {
+    private static final int BUFFER_SIZE = 28;
+    private static final int ADDR_BUF_SIZE = 18;
+    private final int sockKind;
+    private final byte[] addrBuf;
+    private final int sockType;
+    private final ByteBuffer buffer;
+
+    public AddrInfo() {
+        this(0, new byte[ADDR_BUF_SIZE], 0);
+    }
+
+    public AddrInfo(int sockKind, byte[] addrBuf, int sockType) {
+        if (addrBuf == null || addrBuf.length != ADDR_BUF_SIZE) {
+            throw new IllegalArgumentException(
+                    "addrBuf must be exactly " + ADDR_BUF_SIZE + " bytes long.");
+        }
+        this.sockKind = sockKind;
+        this.addrBuf = addrBuf.clone();
+        this.sockType = sockType;
+        this.buffer = createBuffer(sockKind, addrBuf, sockType);
+    }
+
+    private static ByteBuffer createBuffer(int sockKind, byte[] addrBuf, int sockType) {
+        ByteBuffer buffer = ByteBuffer.allocate(BUFFER_SIZE);
+        buffer.order(ByteOrder.nativeOrder());
+        buffer.putInt(sockKind);
+        buffer.put(addrBuf);
+        buffer.putInt(sockType);
+        return buffer;
+    }
+
+    public static int getBufferSize() {
+        return BUFFER_SIZE;
+    }
+
+    public static int getAddrBufferSize() {
+        return ADDR_BUF_SIZE;
+    }
+
+    public int getSockKind() {
+        return sockKind;
+    }
+
+    public byte[] getAddrBuf() {
+        return addrBuf.clone();
+    }
+
+    public int getSockType() {
+        return sockType;
+    }
+
+    public Address getAddress() {
+        return Address.ofData(buffer.array());
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder addrBufString = new StringBuilder();
+        for (byte b : addrBuf) {
+            addrBufString.append(String.format("%02X", b)).append(" ");
+        }
+        return String.format(
+                "AddrInfo{sockKind=%d, addrBuf=[%s], sockType=%d}",
+                sockKind, addrBufString.toString().trim(), sockType);
+    }
+}

--- a/core/src/main/java/org/teavm/backend/wasm/runtime/net/impl/AddrInfoHints.java
+++ b/core/src/main/java/org/teavm/backend/wasm/runtime/net/impl/AddrInfoHints.java
@@ -1,0 +1,66 @@
+/*
+ *  Copyright 2025 Maksim Tiushev.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.teavm.backend.wasm.runtime.net.impl;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import org.teavm.interop.Address;
+
+public class AddrInfoHints {
+    private static final int BUFFER_SIZE = 12;
+    private final int type;
+    private final int family;
+    private final int hintsEnabled;
+    private final ByteBuffer buffer;
+
+    public AddrInfoHints(int type, int family, int hintsEnabled) {
+        this.type = type;
+        this.family = family;
+        this.hintsEnabled = hintsEnabled;
+        this.buffer = createBuffer(type, family, hintsEnabled);
+    }
+
+    private static ByteBuffer createBuffer(int type, int family, int hintsEnabled) {
+        ByteBuffer buffer = ByteBuffer.allocate(BUFFER_SIZE);
+        buffer.order(ByteOrder.nativeOrder());
+        buffer.putInt(type);
+        buffer.putInt(family);
+        buffer.putInt(hintsEnabled);
+        return buffer;
+    }
+
+    public int getType() {
+        return type;
+    }
+
+    public int getFamily() {
+        return family;
+    }
+
+    public int getHintsEnabled() {
+        return hintsEnabled;
+    }
+
+    public Address getAddress() {
+        return Address.ofData(buffer.array());
+    }
+
+    @Override
+    public String toString() {
+        return String.format(
+                "AddrInfoHints{type=%d, family=%d, hintsEnabled=%d}", type, family, hintsEnabled);
+    }
+}

--- a/core/src/main/java/org/teavm/backend/wasm/runtime/net/impl/SockAddrInet4.java
+++ b/core/src/main/java/org/teavm/backend/wasm/runtime/net/impl/SockAddrInet4.java
@@ -1,0 +1,137 @@
+/*
+ *  Copyright 2025 Maksim Tiushev.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.teavm.backend.wasm.runtime.net.impl;
+
+import static org.teavm.backend.wasm.wasi.Wasi.INET4;
+import java.nio.ByteBuffer;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.teavm.interop.Address;
+import org.teavm.runtime.net.SockAddr;
+
+public class SockAddrInet4 implements SockAddr {
+    private static final int BUFFER_SIZE = 10;
+    private final byte[] addr;
+    private final int port;
+    private final ByteBuffer buffer;
+
+    public SockAddrInet4(byte[] addr, int port) {
+        validateIPv4Address(addr);
+        this.addr = addr;
+        this.port = validatePort(port & 0xFFFF);
+        this.buffer = createBuffer(addr, port);
+    }
+
+    public SockAddrInet4(int addr, int port) {
+        this.addr = intToIPv4(addr);
+        this.port = validatePort(port & 0xFFFF);
+        this.buffer = createBuffer(this.addr, port);
+    }
+
+    public SockAddrInet4(String addrPort) {
+        String[] parts = parseAddrPort(addrPort);
+        this.addr = parseIPv4(parts[0]);
+        this.port = validatePort(Integer.parseInt(parts[1]) & 0xFFFF);
+        this.buffer = createBuffer(this.addr, this.port);
+    }
+
+    private static void validateIPv4Address(byte[] addr) {
+        if (addr.length != 4) {
+            throw new IllegalArgumentException("IPv4 address must be exactly 4 bytes long.");
+        }
+    }
+
+    private static int validatePort(int port) {
+        if (port < 0 || port > 65535) {
+            throw new IllegalArgumentException("Port number out of range: " + port);
+        }
+        return port;
+    }
+
+    private static byte[] intToIPv4(int addr) {
+        return new byte[] {
+            (byte) ((addr >> 24) & 0xFF),
+            (byte) ((addr >> 16) & 0xFF),
+            (byte) ((addr >> 8) & 0xFF),
+            (byte) (addr & 0xFF)
+        };
+    }
+
+    private static String[] parseAddrPort(String addrPort) {
+        Pattern pattern = Pattern.compile("^(\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}):(\\d+)$");
+        Matcher matcher = pattern.matcher(addrPort);
+        if (!matcher.matches()) {
+            throw new IllegalArgumentException("Invalid format. Expected format: 'ip:port'.");
+        }
+        return new String[] {matcher.group(1), matcher.group(2)};
+    }
+
+    private static byte[] parseIPv4(String ip) {
+        String[] segments = ip.split("\\.");
+        if (segments.length != 4) {
+            throw new IllegalArgumentException("Invalid IPv4 address.");
+        }
+        byte[] addr = new byte[4];
+        for (int i = 0; i < 4; i++) {
+            int segment = Integer.parseInt(segments[i]);
+            if (segment < 0 || segment > 255) {
+                throw new IllegalArgumentException("Invalid IPv4 address segment: " + segment);
+            }
+            addr[i] = (byte) segment;
+        }
+        return addr;
+    }
+
+    private static ByteBuffer createBuffer(byte[] addr, int port) {
+        ByteBuffer buffer = ByteBuffer.allocate(BUFFER_SIZE);
+        buffer.putInt(0, INET4);
+        for (int i = 0; i < 4; i++) {
+            buffer.put(4 + i, addr[i]);
+        }
+        buffer.putShort(8, (short) ntohs((short) port));
+        return buffer;
+    }
+
+    private static int ntohs(short port) {
+        return Short.reverseBytes(port) & 0xFFFF;
+    }
+
+    public byte[] getAddr() {
+        return addr;
+    }
+
+    @Override
+    public Address sockAddr() {
+        return Address.ofData(buffer.array());
+    }
+
+    @Override
+    public int sockPort() {
+        return port;
+    }
+
+    @Override
+    public int sockFamily() {
+        return INET4;
+    }
+
+    @Override
+    public String toString() {
+        return String.format(
+                "%d.%d.%d.%d:%d",
+                addr[0] & 0xFF, addr[1] & 0xFF, addr[2] & 0xFF, addr[3] & 0xFF, port);
+    }
+}

--- a/core/src/main/java/org/teavm/backend/wasm/runtime/net/impl/SockAddrInet6.java
+++ b/core/src/main/java/org/teavm/backend/wasm/runtime/net/impl/SockAddrInet6.java
@@ -1,0 +1,140 @@
+/*
+ *  Copyright 2025 Maksim Tiushev.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.teavm.backend.wasm.runtime.net.impl;
+
+import static org.teavm.backend.wasm.wasi.Wasi.INET6;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import org.teavm.interop.Address;
+import org.teavm.runtime.net.SockAddr;
+
+public class SockAddrInet6 implements SockAddr {
+    private static final int BUFFER_SIZE = 22;
+    private final short[] addr;
+    private final int port;
+    private final ByteBuffer buffer;
+
+    public SockAddrInet6(short[] addr, int port) {
+        validateIPv6Address(addr);
+        this.addr = addr;
+        this.port = validatePort(port & 0xFFFF);
+        this.buffer = createBuffer(addr, port);
+    }
+
+    public SockAddrInet6(String addrPort) {
+        String[] parts = parseAddrPort(addrPort);
+        this.addr = parseIPv6(parts[0]);
+        this.port = validatePort(Integer.parseInt(parts[1]) & 0xFFFF);
+        this.buffer = createBuffer(this.addr, this.port);
+    }
+
+    public SockAddrInet6(byte[] addr, int port) {
+        if (addr == null || addr.length != 16) {
+            throw new IllegalArgumentException("Invalid IPv6 address. Expected a 16-byte array.");
+        }
+        short[] shortAddr = new short[8];
+        for (int i = 0; i < 8; i++) {
+            shortAddr[i] = (short) (((addr[2 * i] & 0xFF) << 8) | (addr[2 * i + 1] & 0xFF));
+        }
+        validateIPv6Address(shortAddr);
+        this.addr = shortAddr;
+        this.port = validatePort(port & 0xFFFF);
+        this.buffer = createBuffer(shortAddr, port);
+    }
+
+    private static void validateIPv6Address(short[] addr) {
+        if (addr.length != 8) {
+            throw new IllegalArgumentException("IPv6 address must be exactly 16 bytes long.");
+        }
+    }
+
+    private static int validatePort(int port) {
+        if (port < 0 || port > 65535) {
+            throw new IllegalArgumentException("Port number out of range: " + port);
+        }
+        return port;
+    }
+
+    private static String[] parseAddrPort(String addrPort) {
+        if (!addrPort.contains("[") || !addrPort.contains("]")) {
+            throw new IllegalArgumentException("Invalid format. Expected format: '[ipv6]:port'.");
+        }
+        String[] parts = addrPort.split("]:\");");
+        if (parts.length != 2) {
+            throw new IllegalArgumentException("Invalid format. Expected format: '[ipv6]:port'.");
+        }
+        return new String[] {parts[0].substring(1), parts[1]};
+    }
+
+    private static short[] parseIPv6(String ip) {
+        String[] segments = ip.split(":");
+        if (segments.length != 8) {
+            throw new IllegalArgumentException("Invalid IPv6 address.");
+        }
+        short[] addr = new short[8];
+        for (int i = 0; i < 8; i++) {
+            addr[i] = (short) Integer.parseInt(segments[i], 16);
+        }
+        return addr;
+    }
+
+    private static ByteBuffer createBuffer(short[] addr, int port) {
+        ByteBuffer buffer = ByteBuffer.allocate(BUFFER_SIZE);
+        buffer.order(ByteOrder.nativeOrder());
+        buffer.putInt(INET6);
+        for (int i = 0; i < 8; i++) {
+            buffer.putShort(4 + 2 * i, addr[i]);
+        }
+        buffer.putShort(20, (short) port);
+        return buffer;
+    }
+
+    public byte[] getAddr() {
+        byte[] byteArray = new byte[addr.length * 2];
+        for (int i = 0; i < addr.length; i++) {
+            byteArray[i * 2] = (byte) ((addr[i] >> 8) & 0xFF);
+            byteArray[i * 2 + 1] = (byte) (addr[i] & 0xFF);
+        }
+        return byteArray;
+    }
+
+    @Override
+    public Address sockAddr() {
+        return Address.ofData(buffer.array());
+    }
+
+    @Override
+    public int sockPort() {
+        return port;
+    }
+
+    @Override
+    public int sockFamily() {
+        return INET6;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder ipBuilder = new StringBuilder();
+        for (int i = 0; i < addr.length; i++) {
+            ipBuilder.append(String.format("%04X", addr[i] & 0xFFFF));
+            if (i < addr.length - 1) {
+                ipBuilder.append(":");
+            }
+        }
+        return String.format("[%s]:%d", ipBuilder, sockPort());
+    }
+}

--- a/core/src/main/java/org/teavm/backend/wasm/transformation/WasiSocketProviderTransformer.java
+++ b/core/src/main/java/org/teavm/backend/wasm/transformation/WasiSocketProviderTransformer.java
@@ -1,0 +1,30 @@
+/*
+ *  Copyright 2022 Alexey Andreev.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.teavm.backend.wasm.transformation;
+
+import org.teavm.backend.wasm.runtime.net.WasiVirtualSocket;
+import org.teavm.model.ClassHolderTransformerContext;
+import org.teavm.model.MethodHolder;
+import org.teavm.model.emit.ProgramEmitter;
+import org.teavm.runtime.net.VirtualSocketProviderTransformer;
+
+public class WasiSocketProviderTransformer extends VirtualSocketProviderTransformer {
+    @Override
+    protected void transformCreateMethod(MethodHolder method, ClassHolderTransformerContext context) {
+        ProgramEmitter pe = ProgramEmitter.create(method, context.getHierarchy());
+        pe.construct(WasiVirtualSocket.class).returnValue();
+    }
+}

--- a/core/src/main/java/org/teavm/backend/wasm/wasi/Wasi.java
+++ b/core/src/main/java/org/teavm/backend/wasm/wasi/Wasi.java
@@ -56,6 +56,22 @@ public final class Wasi {
     public static final byte WHENCE_CURRENT = 1;
     public static final byte WHENCE_END = 2;
 
+    public static final int AF_INET = 0;
+    public static final int AF_INET6 = 1;
+    public static final int AF_UNIX = 2;
+
+    public static final int INET4 = 0;
+    public static final int INET6 = 1;
+    public static final int INET_UNSPEC = 2;
+
+    public static final int SOCK_ANY = -1;
+    public static final int SOCK_DGRAM = 0;
+    public static final int SOCK_STREAM = 1;
+
+    public static final int SHUT_RD = 0;
+    public static final int SHUT_WR = 1;
+    public static final int SHUT_RDWR = 2;
+
     private Wasi() {
     }
 
@@ -132,4 +148,84 @@ public final class Wasi {
     @Import(name = "random_get", module = "wasi_snapshot_preview1")
     public static native short randomGet(Address buffer, int bufferLength);
 
+    @Import(name = "sock_open", module = "wasi_snapshot_preview1")
+    public static native int sockOpen(int fd, int af, int socktype, Address sockfd);
+
+    @Import(name = "sock_bind", module = "wasi_snapshot_preview1")
+    public static native int sockBind(int fd, Address addr);
+
+    @Import(name = "sock_listen", module = "wasi_snapshot_preview1")
+    public static native int sockListen(int fd, int backlog);
+
+    @Import(name = "sock_connect", module = "wasi_snapshot_preview1")
+    public static native int sockConnect(int fd, Address addr);
+
+    @Import(name = "sock_set_reuse_addr", module = "wasi_snapshot_preview1")
+    public static native int sockSetReuseAddr(int fd, int reuse);
+
+    @Import(name = "sock_set_broadcast", module = "wasi_snapshot_preview1")
+    public static native int sockSetBroadcast(int fd, int option);
+
+    @Import(name = "sock_addr_local", module = "wasi_snapshot_preview1")
+    public static native int sockAddrLocal(int fd, Address addr);
+
+    @Import(name = "sock_addr_remote", module = "wasi_snapshot_preview1")
+    public static native int sockAddrRemote(int fd, Address addr);
+
+    @Import(name = "sock_recv_from", module = "wasi_snapshot_preview1")
+    public static native int sockRecvFrom(int fd, Address riData, int riDataLen,
+            int riFlags, Address srcAddr, Address addrLen);
+
+    @Import(name = "sock_send_to", module = "wasi_snapshot_preview1")
+    public static native int sockSendTo(int fd, Address siData, int siDataLen,
+            int siFlags, Address destAddr, Address addrLen);
+
+    @Import(name = "sock_addr_resolve", module = "wasi_snapshot_preview1")
+    public static native int sockAddrResolve(Address node, Address service, Address hints,
+            Address res, int maxResLen, Address resLen);
+
+    @Import(name = "sock_shutdown", module = "wasi_snapshot_preview1")
+    public static native int sockShutdown(int fd, int how);
+
+    @Import(name = "sock_accept", module = "wasi_snapshot_preview1")
+    public static native int sockAccept(int fd, int flags, Address fdNew);
+
+    @Import(name = "sock_get_keep_alive", module = "wasi_snapshot_preview1")
+    public static native int sockGetKeepAlive(int fd, Address option);
+
+    @Import(name = "sock_set_keep_alive", module = "wasi_snapshot_preview1")
+    public static native int sockSetKeepAlive(int fd, int option);
+
+    @Import(name = "sock_get_reuse_addr", module = "wasi_snapshot_preview1")
+    public static native int sockGetReuseAddr(int fd, Address option);
+
+    @Import(name = "sock_get_recv_buf_size", module = "wasi_snapshot_preview1")
+    public static native int sockGetRecvBufSize(int fd, Address size);
+
+    @Import(name = "sock_set_recv_buf_size", module = "wasi_snapshot_preview1")
+    public static native int sockSetRecvBufSize(int fd, int size);
+
+    @Import(name = "sock_get_send_buf_size", module = "wasi_snapshot_preview1")
+    public static native int sockGetSendBufSize(int fd, Address size);
+
+    @Import(name = "sock_set_send_buf_size", module = "wasi_snapshot_preview1")
+    public static native int sockSetSendBufSize(int fd, int size);
+
+    @Import(name = "sock_get_linger", module = "wasi_snapshot_preview1")
+    public static native int sockGetLinger(int fd, Address isEnabled, Address linger);
+
+    @Import(name = "sock_set_linger", module = "wasi_snapshot_preview1")
+    public static native int sockSetLinger(int fd, int isEnabled, int linger);
+
+    @Import(name = "sock_get_recv_timeout", module = "wasi_snapshot_preview1")
+    public static native int sockGetRecvTimeout(int fd, Address timeout);
+
+    @Import(name = "sock_set_recv_timeout", module = "wasi_snapshot_preview1")
+    public static native int sockSetRecvTimeout(int fd, int timeout);
+
+    @Import(name = "sock_get_tcp_no_delay", module = "wasi_snapshot_preview1")
+    public static native int sockGetTcpNoDelay(int fd, Address option);
+
+    @Import(name = "sock_set_tcp_no_delay", module = "wasi_snapshot_preview1")
+    public static native int sockSetTcpNoDelay(int fd, int option);
 }

--- a/core/src/main/java/org/teavm/runtime/net/SockAddr.java
+++ b/core/src/main/java/org/teavm/runtime/net/SockAddr.java
@@ -1,0 +1,28 @@
+/*
+ *  Copyright 2025 Maksim Tiushev.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.teavm.runtime.net;
+
+import java.net.SocketException;
+import org.teavm.interop.Address;
+
+public interface SockAddr {
+
+    Address sockAddr() throws SocketException;
+
+    int sockPort();
+
+    int sockFamily();
+}

--- a/core/src/main/java/org/teavm/runtime/net/VirtualSocket.java
+++ b/core/src/main/java/org/teavm/runtime/net/VirtualSocket.java
@@ -1,0 +1,74 @@
+/*
+ *  Copyright 2025 Maksim Tiushev.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.teavm.runtime.net;
+
+import java.net.SocketException;
+
+public interface VirtualSocket {
+
+    int socket(int proto, int sotype) throws SocketException;
+
+    void connect(int fd, SockAddr sa) throws SocketException;
+
+    void bind(int fd, SockAddr sa) throws SocketException;
+
+    void listen(int fd, int backlog) throws SocketException;
+
+    int sendTo(int fd, byte[] buf, int len, SockAddr sa) throws SocketException;
+
+    int recvFrom(int fd, byte[] buf, int len, SockAddr sa) throws SocketException;
+
+    void shutdown(int fd, int how) throws SocketException;
+
+    int accept(int fd, int flags) throws SocketException;
+
+    SockAddr getSockName(int fd) throws SocketException;
+
+    SockAddr getPeerName(int fd) throws SocketException;
+
+    void setSockBroadcast(int fd, int value) throws SocketException;
+
+    void setSockReuseAddr(int fd, int value) throws SocketException;
+
+    int getSockReuseAddr(int fd) throws SocketException;
+
+    SockAddr[] getAddrInfo(String name, String service, int proto, int sotype, int hintsEnabled)
+            throws SocketException;
+
+    int getSockKeepAlive(int fd) throws SocketException;
+
+    void setSockKeepAlive(int fd, int value) throws SocketException;
+
+    int getSockRecvBufSize(int fd) throws SocketException;
+
+    void setSockRecvBufSize(int fd, int size) throws SocketException;
+
+    int getSockSendBufSize(int fd) throws SocketException;
+
+    void setSockSendBufSize(int fd, int size) throws SocketException;
+
+    int getSockLinger(int fd) throws SocketException;
+
+    void setSockLinger(int fd, int value, int linger) throws SocketException;
+
+    int getSockRecvTimeout(int fd) throws SocketException;
+
+    void setSockRecvTimeout(int fd, int value) throws SocketException;
+
+    int getSockTcpNoDelay(int fd) throws SocketException;
+
+    void setSockTcpNoDelay(int fd, int value) throws SocketException;
+}

--- a/core/src/main/java/org/teavm/runtime/net/VirtualSocketImpl.java
+++ b/core/src/main/java/org/teavm/runtime/net/VirtualSocketImpl.java
@@ -1,0 +1,153 @@
+/*
+ *  Copyright 2025 Maksim Tiushev.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.teavm.runtime.net;
+
+import java.net.SocketException;
+
+public class VirtualSocketImpl implements VirtualSocket {
+
+    @Override
+    public int socket(int proto, int sotype) throws SocketException {
+        throw new SocketException("socket: not supported for JS and non-WASI Wasm");
+    }
+
+    @Override
+    public void connect(int fd, SockAddr sa) throws SocketException {
+        throw new SocketException("connect: not supported for JS and non-WASI Wasm");
+    }
+
+    @Override
+    public void bind(int fd, SockAddr sa) throws SocketException {
+        throw new SocketException("bind: not supported for JS and non-WASI Wasm");
+    }
+
+    @Override
+    public void listen(int fd, int backlog) throws SocketException {
+        throw new SocketException("listen: not supported for JS and non-WASI Wasm");
+    }
+
+    @Override
+    public int sendTo(int fd, byte[] buf, int len, SockAddr sa) throws SocketException {
+        throw new SocketException("send_to: not supported for JS and non-WASI Wasm");
+    }
+
+    @Override
+    public int recvFrom(int fd, byte[] buf, int len, SockAddr sa) throws SocketException {
+        throw new SocketException("recv_from: not supported for JS and non-WASI Wasm");
+    }
+
+    @Override
+    public void shutdown(int fd, int how) throws SocketException {
+        throw new SocketException("shutdown: not supported for JS and non-WASI Wasm");
+    }
+
+    @Override
+    public int accept(int fd, int flags) throws SocketException {
+        throw new SocketException("accept: not supported for JS and non-WASI Wasm");
+    }
+
+    @Override
+    public SockAddr getSockName(int fd) throws SocketException {
+        throw new SocketException("get_sock_name: not supported for JS and non-WASI Wasm");
+    }
+
+    @Override
+    public SockAddr getPeerName(int fd) throws SocketException {
+        throw new SocketException("get_peer_name: not supported for JS and non-WASI Wasm");
+    }
+
+    @Override
+    public void setSockBroadcast(int fd, int value) throws SocketException {
+        throw new SocketException("sock_set_broadcast: not supported for JS and non-WASI Wasm");
+    }
+
+    @Override
+    public void setSockReuseAddr(int fd, int value) throws SocketException {
+        throw new SocketException("sock_set_reuse_addr: not supported for JS and non-WASI Wasm");
+    }
+
+    @Override
+    public int getSockReuseAddr(int fd) throws SocketException {
+        throw new SocketException("sock_get_reuse_addr: not supported for JS and non-WASI Wasm");
+    }
+
+    @Override
+    public SockAddr[] getAddrInfo(
+            String name, String service, int proto, int sotype, int hintsEnabled)
+            throws SocketException {
+        throw new SocketException("get_addr_info: not supported for JS and non-WASI Wasm");
+    }
+
+    @Override
+    public int getSockKeepAlive(int fd) throws SocketException {
+        throw new SocketException("sock_get_keep_alive: not supported for JS and non-WASI Wasm");
+    }
+
+    @Override
+    public void setSockKeepAlive(int fd, int value) throws SocketException {
+        throw new SocketException("sock_set_keep_alive: not supported for JS and non-WASI Wasm");
+    }
+
+    @Override
+    public int getSockRecvBufSize(int fd) throws SocketException {
+        throw new SocketException("sock_get_recv_buf_size: not supported for JS and non-WASI Wasm");
+    }
+
+    @Override
+    public void setSockRecvBufSize(int fd, int size) throws SocketException {
+        throw new SocketException("sock_set_recv_buf_size: not supported for JS and non-WASI Wasm");
+    }
+
+    @Override
+    public int getSockSendBufSize(int fd) throws SocketException {
+        throw new SocketException("sock_get_send_buf_size: not supported for JS and non-WASI Wasm");
+    }
+
+    @Override
+    public void setSockSendBufSize(int fd, int size) throws SocketException {
+        throw new SocketException("sock_set_send_buf_size: not supported for JS and non-WASI Wasm");
+    }
+
+    @Override
+    public int getSockLinger(int fd) throws SocketException {
+        throw new SocketException("sock_get_linger: not supported for JS and non-WASI Wasm");
+    }
+
+    @Override
+    public void setSockLinger(int fd, int value, int linger) throws SocketException {
+        throw new SocketException("sock_set_linger: not supported for JS and non-WASI Wasm");
+    }
+
+    @Override
+    public int getSockRecvTimeout(int fd) throws SocketException {
+        throw new SocketException("sock_get_recv_timeout: not supported for JS and non-WASI Wasm");
+    }
+
+    @Override
+    public void setSockRecvTimeout(int fd, int value) throws SocketException {
+        throw new SocketException("sock_set_recv_timeout: not supported for JS and non-WASI Wasm");
+    }
+
+    @Override
+    public int getSockTcpNoDelay(int fd) throws SocketException {
+        throw new SocketException("sock_get_tcp_no_delay: not supported for JS and non-WASI Wasm");
+    }
+
+    @Override
+    public void setSockTcpNoDelay(int fd, int value) throws SocketException {
+        throw new SocketException("sock_set_tcp_no_delay: not supported for JS and non-WASI Wasm");
+    }
+}

--- a/core/src/main/java/org/teavm/runtime/net/VirtualSocketProvider.java
+++ b/core/src/main/java/org/teavm/runtime/net/VirtualSocketProvider.java
@@ -1,0 +1,38 @@
+/*
+ *  Copyright 2025 Maksim Tiushev.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.teavm.runtime.net;
+
+public final class VirtualSocketProvider {
+    private static VirtualSocket instance;
+
+    private VirtualSocketProvider() {
+    }
+
+    public static VirtualSocket getInstance() {
+        if (instance == null) {
+            instance = create();
+        }
+        return instance;
+    }
+
+    private static VirtualSocket create() {
+        return new VirtualSocketImpl();
+    }
+
+    public static void setInstance(VirtualSocket instance) {
+        VirtualSocketProvider.instance = instance;
+    }
+}

--- a/core/src/main/java/org/teavm/runtime/net/VirtualSocketProviderTransformer.java
+++ b/core/src/main/java/org/teavm/runtime/net/VirtualSocketProviderTransformer.java
@@ -1,0 +1,36 @@
+/*
+ *  Copyright 2025 Maksim Tiushev.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.teavm.runtime.net;
+
+import org.teavm.model.ClassHolder;
+import org.teavm.model.ClassHolderTransformer;
+import org.teavm.model.ClassHolderTransformerContext;
+import org.teavm.model.MethodDescriptor;
+import org.teavm.model.MethodHolder;
+
+public abstract class VirtualSocketProviderTransformer implements ClassHolderTransformer {
+    @Override
+    public void transformClass(ClassHolder cls, ClassHolderTransformerContext context) {
+        if (cls.getName().equals(VirtualSocketProvider.class.getName())) {
+            MethodHolder method =
+                    cls.getMethod(new MethodDescriptor("create", VirtualSocket.class));
+            transformCreateMethod(method, context);
+        }
+    }
+
+    protected abstract void transformCreateMethod(
+            MethodHolder method, ClassHolderTransformerContext context);
+}

--- a/tests/src/test/java/org/teavm/classlib/java/net/InetAddressTest.java
+++ b/tests/src/test/java/org/teavm/classlib/java/net/InetAddressTest.java
@@ -1,0 +1,159 @@
+/*
+ *  Copyright 2025 Maksim Tiushev.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.teavm.classlib.java.net;
+
+import static org.junit.Assert.assertTrue;
+import java.net.Inet4Address;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.util.Arrays;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.teavm.junit.TeaVMTestRunner;
+
+@RunWith(TeaVMTestRunner.class)
+public class InetAddressTest {
+
+    @Test
+    public void test_LocalhostInet4Address() throws Exception {
+        InetAddress addr1 = InetAddress.getByName("localhost");
+        assertTrue("1. should be an instance of Inet4Address", addr1 instanceof Inet4Address);
+        assertTrue("2. host address should be 127.0.0.1", addr1.getHostAddress().equals("127.0.0.1"));
+        assertTrue("3. toString() should return localhost/127.0.0.1",
+                addr1.toString().equals("localhost/127.0.0.1"));
+        assertTrue("4. address bytes should be [127, 0, 0, 1]",
+                Arrays.equals(addr1.getAddress(), new byte[]{127, 0, 0, 1}));
+        assertTrue("5. canonical host name should be localhost", addr1.getCanonicalHostName().equals("localhost"));
+        assertTrue("6. host name should be localhost", addr1.getHostName().equals("localhost"));
+        assertTrue("7. should not be any local address", !addr1.isAnyLocalAddress());
+        assertTrue("8. should not be a link-local address", !addr1.isLinkLocalAddress());
+        assertTrue("9. should be a loopback address", addr1.isLoopbackAddress());
+        assertTrue("10. should not be a global multicast address", !addr1.isMCGlobal());
+        assertTrue("11. should not be a node-local multicast address", !addr1.isMCNodeLocal());
+        assertTrue("12. should not be an organization-local multicast address", !addr1.isMCOrgLocal());
+        assertTrue("13. should not be a site-local multicast address", !addr1.isMCSiteLocal());
+        assertTrue("14. should not be a multicast address", !addr1.isMulticastAddress());
+        assertTrue("15. should not be a site-local address", !addr1.isSiteLocalAddress());
+    }
+
+    @Test
+    public void test_Inet4AddressBasicProperties() throws Exception {
+        Inet4Address addr2 = (Inet4Address) InetAddress.getByAddress(new byte[]{127, 0, 0, 1});
+        assertTrue("1. should be an instance of Inet4Address", addr2 instanceof Inet4Address);
+        assertTrue("2. host address should be 127.0.0.1", addr2.getHostAddress().equals("127.0.0.1"));
+        assertTrue("3. toString() should return /127.0.0.1", addr2.toString().equals("/127.0.0.1"));
+        assertTrue("4. address bytes should be [127, 0, 0, 1]",
+                Arrays.equals(addr2.getAddress(), new byte[]{127, 0, 0, 1}));
+        assertTrue("5. should not be any local address", !addr2.isAnyLocalAddress());
+        assertTrue("6. should not be a link-local address", !addr2.isLinkLocalAddress());
+        assertTrue("7. should be a loopback address", addr2.isLoopbackAddress());
+        assertTrue("8. should not be a global multicast address", !addr2.isMCGlobal());
+        assertTrue("9. should not be a node-local multicast address", !addr2.isMCNodeLocal());
+        assertTrue("10. should not be an organization-local multicast address", !addr2.isMCOrgLocal());
+        assertTrue("11. should not be a site-local multicast address", !addr2.isMCSiteLocal());
+        assertTrue("12. should not be a multicast address", !addr2.isMulticastAddress());
+        assertTrue("13. should not be a site-local address", !addr2.isSiteLocalAddress());
+    }
+
+    @Test
+    public void test_Inet4AddressCustomBytes() throws Exception {
+        Inet4Address addr3 = (Inet4Address) InetAddress.getByAddress(new byte[]{(byte) 192, (byte) 168, 1, 1});
+        assertTrue("1. should be an instance of Inet4Address", addr3 instanceof Inet4Address);
+        assertTrue("2. host address should be 192.168.1.1", addr3.getHostAddress().equals("192.168.1.1"));
+        assertTrue("3. toString() should return /192.168.1.1", addr3.toString().equals("/192.168.1.1"));
+        assertTrue("4. address bytes should be [192, 168, 1, 1]",
+                Arrays.equals(addr3.getAddress(), new byte[]{(byte) 192, (byte) 168, 1, 1}));
+        assertTrue("5. should not be any local address", !addr3.isAnyLocalAddress());
+        assertTrue("6. should not be a link-local address", !addr3.isLinkLocalAddress());
+        assertTrue("7. should not be a loopback address", !addr3.isLoopbackAddress());
+        assertTrue("8. should not be a multicast address", !addr3.isMulticastAddress());
+        assertTrue("9. should not be a site-local address", addr3.isSiteLocalAddress());
+    }
+
+    @Test
+    public void testLoopbackAddressIPv6() throws Exception {
+        Inet6Address addr4 = (Inet6Address) InetAddress.getByAddress(new byte[]{
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+        });
+        assertTrue("1. should be an instance of Inet6Address", addr4 instanceof Inet6Address);
+        assertTrue("2. host address should be ::1", addr4.getHostAddress().equals("::1"));
+        assertTrue("3. toString() should return /::1", addr4.toString().equals("/::1"));
+        assertTrue("4. address bytes should be [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]",
+                Arrays.equals(addr4.getAddress(), new byte[]{
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+                }));
+        assertTrue("5. should not be any local address", !addr4.isAnyLocalAddress());
+        assertTrue("6. should not be a link-local address", !addr4.isLinkLocalAddress());
+        assertTrue("7. should be a loopback address", addr4.isLoopbackAddress());
+        assertTrue("8. should not be a global multicast address", !addr4.isMCGlobal());
+        assertTrue("9. should not be a node-local multicast address", !addr4.isMCNodeLocal());
+        assertTrue("10. should not be an organization-local multicast address", !addr4.isMCOrgLocal());
+        assertTrue("11. should not be a site-local multicast address", !addr4.isMCSiteLocal());
+        assertTrue("12. should not be a multicast address", !addr4.isMulticastAddress());
+        assertTrue("13. should not be a site-local address", !addr4.isSiteLocalAddress());
+    }
+
+    @Test
+    public void testCustomAddressIPv6() throws Exception {
+        Inet6Address addr5 = (Inet6Address) InetAddress.getByAddress(new byte[]{
+            (byte) 0x20, (byte) 0x01, 0x0d, (byte) 0xb8, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01
+        });
+        assertTrue("1. should be an instance of Inet6Address", addr5 instanceof Inet6Address);
+        assertTrue("2. host address should be 2001:db8::1", addr5.getHostAddress().equals("2001:db8::1"));
+        assertTrue("3. toString() should return /2001:db8::1", addr5.toString().equals("/2001:db8::1"));
+        assertTrue("4. address bytes should be [32, 1, 13, -72, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]",
+                Arrays.equals(addr5.getAddress(), new byte[]{
+                    (byte) 0x20, (byte) 0x01, 0x0d, (byte) 0xb8, 0x00, 0x00, 0x00, 0x00,
+                    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01
+                }));
+        assertTrue("5. should not be any local address", !addr5.isAnyLocalAddress());
+        assertTrue("6. should not be a link-local address", !addr5.isLinkLocalAddress());
+        assertTrue("7. should not be a loopback address", !addr5.isLoopbackAddress());
+        assertTrue("8. should not be a global multicast address", !addr5.isMCGlobal());
+        assertTrue("9. should not be a node-local multicast address", !addr5.isMCNodeLocal());
+        assertTrue("10. should not be an organization-local multicast address", !addr5.isMCOrgLocal());
+        assertTrue("11. should not be a site-local multicast address", !addr5.isMCSiteLocal());
+        assertTrue("12. should not be a multicast address", !addr5.isMulticastAddress());
+        assertTrue("13. should not be a site-local address", !addr5.isSiteLocalAddress());
+    }
+
+
+    @Test
+    public void testMulticastAddressIPv6() throws Exception {
+        Inet6Address addr6 = (Inet6Address) InetAddress.getByAddress(new byte[]{
+            (byte) 0xff, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01
+        });
+        assertTrue("1. should be an instance of Inet6Address", addr6 instanceof Inet6Address);
+        assertTrue("2. host address should be ff02::1", addr6.getHostAddress().equals("ff02::1"));
+        assertTrue("3. toString() should return /ff02::1", addr6.toString().equals("/ff02::1"));
+        assertTrue("4. address bytes should be [255, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]",
+                Arrays.equals(addr6.getAddress(), new byte[]{
+                    (byte) 0xff, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01
+                }));
+        assertTrue("5. should not be any local address", !addr6.isAnyLocalAddress());
+        assertTrue("6. should not be a link-local address", !addr6.isLinkLocalAddress());
+        assertTrue("7. should not be a loopback address", !addr6.isLoopbackAddress());
+        assertTrue("8. should not be a global multicast address", !addr6.isMCGlobal());
+        assertTrue("9. should not be a node-local multicast address", !addr6.isMCNodeLocal());
+        assertTrue("10. should not be an organization-local multicast address", !addr6.isMCOrgLocal());
+        assertTrue("11. should not be a site-local multicast address", !addr6.isMCSiteLocal());
+        assertTrue("12. should be a multicast address", addr6.isMulticastAddress());
+        assertTrue("13. should not be a site-local address", !addr6.isSiteLocalAddress());
+    }
+}

--- a/tests/src/test/java/org/teavm/classlib/java/net/InetSocketAddressTest.java
+++ b/tests/src/test/java/org/teavm/classlib/java/net/InetSocketAddressTest.java
@@ -1,0 +1,80 @@
+/*
+ *  Copyright 2025 Maksim Tiushev.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.teavm.classlib.java.net;
+
+import static org.junit.Assert.assertTrue;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.Arrays;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.teavm.junit.TeaVMTestRunner;
+
+@RunWith(TeaVMTestRunner.class)
+public class InetSocketAddressTest {
+
+    @Test
+    public void test_loopback_address_with_port() throws Exception {
+        InetSocketAddress addr1 = new InetSocketAddress(InetAddress.getByAddress(new byte[]{
+            127, 0, 0, 1
+        }), 8080);
+        assertTrue("1. should be an instance of InetSocketAddress", addr1 instanceof InetSocketAddress);
+        assertTrue("2. host string should be 127.0.0.1", addr1.getHostString().equals("127.0.0.1"));
+        assertTrue("3. port should be 8080", addr1.getPort() == 8080);
+        assertTrue("4. address bytes should be [127, 0, 0, 1]",
+                Arrays.equals(addr1.getAddress().getAddress(), new byte[]{127, 0, 0, 1}));
+        assertTrue("5. should be a loopback address", addr1.getAddress().isLoopbackAddress());
+        assertTrue("6. should not be any local address", !addr1.getAddress().isAnyLocalAddress());
+        assertTrue("7. should not be a multicast address", !addr1.getAddress().isMulticastAddress());
+        assertTrue("8. should not be a site-local address", !addr1.getAddress().isSiteLocalAddress());
+    }
+
+    @Test
+    public void test_custom_ipv4_address_with_port() throws Exception {
+        InetSocketAddress addr2 = new InetSocketAddress(InetAddress.getByAddress(new byte[]{
+            (byte) 192, (byte) 168, 1, 1
+        }), 9090);
+        assertTrue("1. should be an instance of InetSocketAddress", addr2 instanceof InetSocketAddress);
+        assertTrue("2. host string should be 192.168.1.1", addr2.getHostString().equals("192.168.1.1"));
+        assertTrue("3. port should be 9090", addr2.getPort() == 9090);
+        assertTrue("4. address bytes should be [192, 168, 1, 1]",
+                Arrays.equals(addr2.getAddress().getAddress(), new byte[]{(byte) 192, (byte) 168, 1, 1}));
+        assertTrue("5. should not be a loopback address", !addr2.getAddress().isLoopbackAddress());
+        assertTrue("6. should not be any local address", !addr2.getAddress().isAnyLocalAddress());
+        assertTrue("7. should not be a multicast address", !addr2.getAddress().isMulticastAddress());
+        assertTrue("8. should be a site-local address", addr2.getAddress().isSiteLocalAddress());
+    }
+
+    @Test
+    public void test_ipv6_address_with_port() throws Exception {
+        InetSocketAddress addr3 = new InetSocketAddress(InetAddress.getByAddress(new byte[]{
+            (byte) 0x20, (byte) 0x01, 0x0d, (byte) 0xb8, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01
+        }), 443);
+        assertTrue("1. should be an instance of InetSocketAddress", addr3 instanceof InetSocketAddress);
+        assertTrue("2. host string should be /2001:db8::1", addr3.getHostString().equals("2001:db8::1"));
+        assertTrue("3. port should be 443", addr3.getPort() == 443);
+        assertTrue("4. address bytes should match 2001:db8::1",
+                Arrays.equals(addr3.getAddress().getAddress(), new byte[]{
+                    (byte) 0x20, (byte) 0x01, 0x0d, (byte) 0xb8, 0x00, 0x00, 0x00, 0x00,
+                    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01
+                }));
+        assertTrue("5. should not be a loopback address", !addr3.getAddress().isLoopbackAddress());
+        assertTrue("6. should not be any local address", !addr3.getAddress().isAnyLocalAddress());
+        assertTrue("7. should not be a multicast address", !addr3.getAddress().isMulticastAddress());
+        assertTrue("8. should not be a site-local address", !addr3.getAddress().isSiteLocalAddress());
+    }
+}


### PR DESCRIPTION
This pull request introduces two key updates to enhance networking capabilities in a WASI-based environment:  

### Patch 1: **WASI: VirtualSocket Interface**  
This patch provides the core functionality required for socket operations within the WASI environment. Key features include:  
- Creating, binding, connecting, and listening to sockets.  
- Sending and receiving data.  
- Configuring socket options such as broadcast and reuse.  
- Retrieving peer and socket names.  

⚠️ This interface is specific to WASI-based WebAssembly and is not supported for JavaScript or non-WASI WebAssembly environments.  

### Patch 2: **classlib: Implement java.net.Socket**  
This patch introduces the implementation of the java.net.Socket class, enabling developers to work with sockets in a WASI-based environment. Additionally, the following related networking classes are implemented:  
- java.net.ServerSocket
- java.net.InetAddress  
- java.net.Inet4Address  
- java.net.Inet6Address  
- java.net.SocketAddress  
- java.net.InetSocketAddress  
- java.net.Proxy 
- java.net.NetworkInterface  
- java.net.SocketException  
- java.net.UnknownHostException  