### PR TITLE
Add PropertyChangeSupport with an minimal implemention. 

### DIFF
--- a/classlib/src/main/java/org/teavm/classlib/java/beans/TIndexedPropertyChangeEvent.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/beans/TIndexedPropertyChangeEvent.java
@@ -1,0 +1,18 @@
+package org.teavm.classlib.java.beans;
+
+import java.beans.PropertyChangeEvent;
+
+public class TIndexedPropertyChangeEvent extends PropertyChangeEvent {
+
+    private final int index;
+
+    public TIndexedPropertyChangeEvent(final Object source, final String propertyName, final Object oldValue, final Object newValue, final int index) {
+        super(source, propertyName, oldValue, newValue);
+        this.index = index;
+    }
+
+    public int getIndex() {
+        return index;
+    }
+
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/beans/TPropertyChangeEvent.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/beans/TPropertyChangeEvent.java
@@ -1,0 +1,42 @@
+package org.teavm.classlib.java.beans;
+
+import java.util.EventObject;
+
+public class TPropertyChangeEvent extends EventObject {
+
+    private final String propertyName;
+    private final Object oldValue;
+    private final Object newValue;
+    private Object propagationId;
+
+    public TPropertyChangeEvent(final Object source, final String propertyName, final Object oldValue, final Object newValue) {
+        super(source);
+        this.propertyName = propertyName;
+        this.oldValue = oldValue;
+        this.newValue = newValue;
+    }
+
+    public String getPropertyName() {
+        return propertyName;
+    }
+
+    public Object getNewValue() {
+        return newValue;
+    }
+
+    public Object getOldValue() {
+        return oldValue;
+    }
+
+    public void setPropagationId(Object propagationId) {
+        this.propagationId = propagationId;
+    }
+
+    public Object getPropagationId() {
+        return propagationId;
+    }
+
+    public String toString() {
+        return "[propertyName=" + propertyName + "; oldValue=" + oldValue + "; newValue=" + newValue + "; propagationId=" + propagationId + "; source=" + source + "]";
+    }
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/beans/TPropertyChangeListener.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/beans/TPropertyChangeListener.java
@@ -1,0 +1,8 @@
+package org.teavm.classlib.java.beans;
+
+import java.beans.PropertyChangeEvent;
+import java.util.EventListener;
+
+public interface TPropertyChangeListener extends EventListener {
+    public void propertyChange(final PropertyChangeEvent propertyChangeEvent);
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/beans/TPropertyChangeListenerProxy.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/beans/TPropertyChangeListenerProxy.java
@@ -1,0 +1,25 @@
+package org.teavm.classlib.java.beans;
+
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.util.EventListenerProxy;
+
+public class TPropertyChangeListenerProxy extends EventListenerProxy<PropertyChangeListener> implements PropertyChangeListener {
+
+    private final String propertyName;
+
+    public TPropertyChangeListenerProxy(final String propertyName, final PropertyChangeListener propertyChangeListener) {
+        super(propertyChangeListener);
+        this.propertyName = propertyName;
+    }
+
+    public String getPropertyName() {
+        return propertyName;
+    }
+
+    @Override
+    public void propertyChange(PropertyChangeEvent propertyChangeEvent) {
+        getListener().propertyChange(propertyChangeEvent);
+    }
+
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/beans/TPropertyChangeSupport.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/beans/TPropertyChangeSupport.java
@@ -1,0 +1,148 @@
+package org.teavm.classlib.java.beans;
+
+import java.beans.IndexedPropertyChangeEvent;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.beans.PropertyChangeListenerProxy;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+public class TPropertyChangeSupport {
+
+    private final Object sourceBean;
+
+    private final HashMap<String, ArrayList<PropertyChangeListener>> eventToListenerMap = new HashMap<>();
+
+    public TPropertyChangeSupport(final Object sourceBean) {
+        this.sourceBean = sourceBean;
+    }
+
+    public synchronized void addPropertyChangeListener(final PropertyChangeListener propertyChangeListener) {
+        if (propertyChangeListener == null) {
+            return;
+        }
+        if (propertyChangeListener instanceof PropertyChangeListenerProxy) {
+            PropertyChangeListenerProxy propertyChangeListenerProxy = (PropertyChangeListenerProxy) propertyChangeListener;
+            addPropertyChangeListener(propertyChangeListenerProxy.getPropertyName(), propertyChangeListenerProxy.getListener());
+        } else {
+            addToMap(null, propertyChangeListener);
+        }
+    }
+
+    public synchronized void removePropertyChangeListener(final PropertyChangeListener propertyChangeListener) {
+        if (propertyChangeListener == null) {
+            return;
+        }
+        if (propertyChangeListener instanceof PropertyChangeListenerProxy) {
+            PropertyChangeListenerProxy propertyChangeListenerProxy = (PropertyChangeListenerProxy) propertyChangeListener;
+            removePropertyChangeListener(propertyChangeListenerProxy.getPropertyName(), propertyChangeListenerProxy.getListener());
+        } else {
+            removeFromMap(null, propertyChangeListener);
+        }
+    }
+
+    public synchronized PropertyChangeListener[] getPropertyChangeListeners() {
+        final ArrayList<PropertyChangeListener> propertyChangeListeners = new ArrayList<>();
+        for (final String key : eventToListenerMap.keySet()) {
+            propertyChangeListeners.addAll(eventToListenerMap.get(key));
+        }
+        return propertyChangeListeners.toArray(new PropertyChangeListener[propertyChangeListeners.size()]);
+    }
+
+    public synchronized void addPropertyChangeListener(final String propertyName, final PropertyChangeListener propertyChangeListener) {
+        if (propertyName == null || propertyChangeListener == null) {
+            return;
+        }
+        addToMap(propertyName, unwrap(propertyChangeListener));
+    }
+
+    public synchronized void removePropertyChangeListener(final String propertyName, final PropertyChangeListener propertyChangeListener) {
+        if (propertyName == null || propertyChangeListener == null) {
+            return;
+        }
+        removeFromMap(propertyName, unwrap(propertyChangeListener));
+    }
+
+    public synchronized PropertyChangeListener[] getPropertyChangeListeners(final String propertyName) {
+        if (propertyName == null) {
+            return new PropertyChangeListener[0];
+        }
+        final List<PropertyChangeListener> propertyChangeListeners = eventToListenerMap.get(propertyName);
+        if (propertyChangeListeners == null) {
+            return new PropertyChangeListener[0];
+        }
+        return propertyChangeListeners.toArray(new PropertyChangeListener[propertyChangeListeners.size()]);
+    }
+
+    public void firePropertyChange(final String propertyName, final Object oldValue, final Object newValue) {
+        firePropertyChange(new PropertyChangeEvent(sourceBean, propertyName, oldValue, newValue));
+    }
+
+    public void firePropertyChange(final String propertyName, final int oldValue, final int newValue) {
+        firePropertyChange(propertyName, oldValue, newValue);
+    }
+
+    public void firePropertyChange(final String propertyName, final boolean oldValue, final boolean newValue) {
+        firePropertyChange(propertyName, oldValue, newValue);
+    }
+
+    public synchronized void firePropertyChange(final PropertyChangeEvent event) {
+        if (event == null || event.getOldValue() == null || event.getNewValue() == null || event.getOldValue().equals(event.getNewValue()) == false) {
+            List<PropertyChangeListener> fireList = new ArrayList<>();
+            if (eventToListenerMap.get(null) != null) {
+                fireList.addAll(eventToListenerMap.get(null));
+            }
+            if (eventToListenerMap.get(event.getPropertyName()) != null) {
+                fireList.addAll(eventToListenerMap.get(event.getPropertyName()));
+            }
+            for (PropertyChangeListener propertyChangeListener : fireList) {
+                propertyChangeListener.propertyChange(event);
+            }
+        }
+    }
+
+    public void fireIndexedPropertyChange(final String propertyName, final int index, final Object oldValue, final Object newValue) {
+        firePropertyChange(new IndexedPropertyChangeEvent(sourceBean, propertyName, oldValue, newValue, index));
+    }
+
+    public void fireIndexedPropertyChange(final String propertyName, final int index, final int oldValue, final int newValue) {
+        fireIndexedPropertyChange(propertyName, index, oldValue, newValue);
+    }
+
+    public void fireIndexedPropertyChange(final String propertyName, final int index, final boolean oldValue, final boolean newValue) {
+        fireIndexedPropertyChange(propertyName, index, oldValue, newValue);
+    }
+
+    public synchronized boolean hasListeners(final String propertyName) {
+        return propertyName != null && eventToListenerMap.get(propertyName) != null && eventToListenerMap.get(propertyName).size() != 0;
+    }
+
+    private void addToMap(final String key, final PropertyChangeListener propertyChangeListener) {
+        ArrayList<PropertyChangeListener> propertyChangeListeners = eventToListenerMap.get(key);
+        if (propertyChangeListeners == null) {
+            propertyChangeListeners = new ArrayList<>();
+            eventToListenerMap.put(key, propertyChangeListeners);
+        }
+        propertyChangeListeners.add(propertyChangeListener);
+    }
+
+    private void removeFromMap(final String key, final PropertyChangeListener propertyChangeListener) {
+        final ArrayList<PropertyChangeListener> propertyChangeListeners = eventToListenerMap.get(key);
+        if (propertyChangeListeners == null) {
+            return;
+        }
+        propertyChangeListeners.remove(propertyChangeListener);
+    }
+
+    private static PropertyChangeListener unwrap(PropertyChangeListener propertyChangeListener) {
+        while (propertyChangeListener instanceof PropertyChangeListenerProxy) {
+            if (((PropertyChangeListenerProxy) propertyChangeListener).getListener() != null) {
+                propertyChangeListener = ((PropertyChangeListenerProxy) propertyChangeListener).getListener();
+            }
+        }
+        return propertyChangeListener;
+    }
+
+}

--- a/classlib/src/main/java/org/teavm/classlib/java/util/TEventListenerProxy.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/util/TEventListenerProxy.java
@@ -1,0 +1,15 @@
+package org.teavm.classlib.java.util;
+
+public abstract class TEventListenerProxy<T extends TEventListener> implements TEventListener {
+
+    private final T eventListener;
+
+    public TEventListenerProxy(final T eventListener) {
+        this.eventListener = eventListener;
+    }
+
+    public T getListener() {
+        return eventListener;
+    }
+
+}


### PR DESCRIPTION
Hi, I would like to contribute the PropertyChangeSupport class. It is a minimalist implementation. So it has no Serializable support. For the implementation itself I took the public API and implemented it myself. Sometimes as a help I looked at the Apache Harmony Project. Do I need to add the Apache license to every file? Also I hope those classes are far enough from the core.
Best regards pizza_dox_9999