### PR TITLE
Replaces lambda serialization in Scala with no-op

### DIFF
--- a/classlib/src/main/java/org/teavm/classlib/impl/EmptyBootstrapSubstitutor.java
+++ b/classlib/src/main/java/org/teavm/classlib/impl/EmptyBootstrapSubstitutor.java
@@ -1,0 +1,29 @@
+/*
+ *  Copyright 2025 Nacho Cordon.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.teavm.classlib.impl;
+
+import org.teavm.dependency.BootstrapMethodSubstitutor;
+import org.teavm.dependency.DynamicCallSite;
+import org.teavm.model.ValueType;
+import org.teavm.model.emit.ProgramEmitter;
+import org.teavm.model.emit.ValueEmitter;
+
+public class EmptyBootstrapSubstitutor implements BootstrapMethodSubstitutor {
+    @Override
+    public ValueEmitter substitute(DynamicCallSite callSite, ProgramEmitter pe) {
+        return pe.constantNull(ValueType.object(callSite.getCalledMethod().getName()));
+    }
+}

--- a/classlib/src/main/java/org/teavm/classlib/impl/JCLPlugin.java
+++ b/classlib/src/main/java/org/teavm/classlib/impl/JCLPlugin.java
@@ -172,6 +172,13 @@ public class JCLPlugin implements TeaVMPlugin {
         if (!isBootstrap()) {
             host.add(new ScalaHacks());
             host.add(new KotlinHacks());
+            host.add(new MethodReference("scala.runtime.LambdaDeserialize", "bootstrap",
+                            ValueType.object("java.lang.invoke.MethodHandles$Lookup"),
+                            ValueType.object("java.lang.String"),
+                            ValueType.object("java.lang.invoke.MethodType"),
+                            ValueType.arrayOf(ValueType.object("java.lang.invoke.MethodHandle")),
+                            ValueType.object("java.lang.invoke.CallSite")),
+                    new EmptyBootstrapSubstitutor());
         }
 
         host.add(new NumericClassTransformer());


### PR DESCRIPTION
Addresses #1020.

## What

It makes `scala.runtime.LambdaDeserialize.bootstrap` behave as no-op. 

My understanding is that `scala.runtime.LambdaDeserialize.bootstrap` would only be used in case we serialize / deserialize a lambda, which is not possible in TeaVM anyway (because there's no implementation for `ObjectInputStream` or `ObjectOutputStream`).

## Why 

In the previous version of the library (`0.10.x`) the `processInvokeDynamic` lived inside the `DependencyAnalyzer` class and it was moved inside `DependencyClassSource` in commit 383fee6. So this does not change the behaviour prior to that commit, where `processInvokeDynamic` could never get called with `scala.runtime.LambdaDeserialize`. Maybe there's a more elegant way to achieve what I want in this PR.

The code in [`samples/scala`](https://github.com/konsoletyper/teavm/tree/master/samples/scala) would not transpile before and now it does by doing `./gradlew :scala:build` inside the `samples` folder.
