### PR TITLE
Fix program parser creating some unnecessary basic blocks

### DIFF
--- a/core/src/main/java/org/teavm/parsing/ProgramParser.java
+++ b/core/src/main/java/org/teavm/parsing/ProgramParser.java
@@ -298,7 +298,7 @@ public class ProgramParser {
             instructions.get(index).accept(methodVisitor);
             stackAfter[index] = stack;
             flushInstructions();
-            if (nextIndexes.length != 1) {
+            if (nextIndexes.length > 1) {
                 emitNextBasicBlock();
             }
             for (int next : nextIndexes) {


### PR DESCRIPTION
Fixes the program parser sometimes parsing unreachable instructions into extra basic blocks that have no proper terminating instruction