### PR TITLE
close BufferedWriter in write

### DIFF
--- a/classlib/src/main/java/org/teavm/classlib/impl/tz/TimeZoneCache.java
+++ b/classlib/src/main/java/org/teavm/classlib/impl/tz/TimeZoneCache.java
@@ -23,16 +23,17 @@ import org.teavm.classlib.impl.CharFlow;
 
 public class TimeZoneCache {
     public void write(OutputStream output, Collection<StorableDateTimeZone> timeZones) throws IOException {
-        BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(output, StandardCharsets.UTF_8));
-        StringBuilder sb = new StringBuilder();
-        for (StorableDateTimeZone timeZone : timeZones) {
-            writer.append(timeZone.getID()).append(' ');
-            timeZone.write(sb);
-            writer.append(sb);
-            sb.setLength(0);
-            writer.append('\n');
+        try (BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(output, StandardCharsets.UTF_8))) {
+            StringBuilder sb = new StringBuilder();
+            for (StorableDateTimeZone timeZone : timeZones) {
+                writer.append(timeZone.getID()).append(' ');
+                timeZone.write(sb);
+                writer.append(sb);
+                sb.setLength(0);
+                writer.append('\n');
+            }
+            writer.flush();
         }
-        writer.flush();
     }
 
     public Map<String, StorableDateTimeZone> read(InputStream input) throws IOException {


### PR DESCRIPTION
While I was looking at write, I noticed the resource opened there can leak if write exits on an error path. this patch moves the allocation into try-with-resources so cleanup happens on every exit path. Apologies if this is already handled somewhere.

Happy to revise the approach or close this if it doesn’t fit — you know the codebase far better than I do.