### PR TITLE
Fix UnicodeData range parsing for character types

### DIFF
--- a/classlib/src/main/java/org/teavm/classlib/impl/unicode/UnicodeHelper.java
+++ b/classlib/src/main/java/org/teavm/classlib/impl/unicode/UnicodeHelper.java
@@ -172,7 +172,7 @@ public final class UnicodeHelper {
             byte b = bytes[i];
             if (i < bytes.length - 1 && b == bytes[i + 1]) {
                 int count = 0;
-                while (count < 16384 && bytes[i + count] == b) {
+                while (count < 16384 && i + count < bytes.length && bytes[i + count] == b) {
                     ++count;
                 }
                 i += count;
@@ -219,13 +219,16 @@ public final class UnicodeHelper {
                 count = 1;
             }
             if (b != 0 || count < 128) {
-                if (index + count >= buffer.length) {
-                    ranges[rangeIndex++] = new Range(codePoint, codePoint + index, Arrays.copyOf(buffer, index));
-                    codePoint += index + count;
-                    index = 0;
-                }
-                while (count-- > 0) {
-                    buffer[index++] = b;
+                while (count > 0) {
+                    if (index == buffer.length) {
+                        ranges[rangeIndex++] = new Range(codePoint, codePoint + index, Arrays.copyOf(buffer, index));
+                        codePoint += index;
+                        index = 0;
+                    }
+                    int chunk = Math.min(count, buffer.length - index);
+                    Arrays.fill(buffer, index, index + chunk, b);
+                    index += chunk;
+                    count -= chunk;
                 }
             } else {
                 if (index > 0) {
@@ -234,6 +237,9 @@ public final class UnicodeHelper {
                 codePoint += index + count;
                 index = 0;
             }
+        }
+        if (index > 0) {
+            ranges[rangeIndex++] = new Range(codePoint, codePoint + index, Arrays.copyOf(buffer, index));
         }
         return Arrays.copyOf(ranges, rangeIndex);
     }

--- a/classlib/src/main/java/org/teavm/classlib/impl/unicode/UnicodeSupport.java
+++ b/classlib/src/main/java/org/teavm/classlib/impl/unicode/UnicodeSupport.java
@@ -85,6 +85,8 @@ public final class UnicodeSupport {
         IntegerArray titleCaseMapping = new IntegerArray(256);
         IntegerArray upperCaseMapping = new IntegerArray(256);
         IntegerArray lowerCaseMapping = new IntegerArray(256);
+        int rangeStart = -1;
+        byte rangeClass = 0;
         try (BufferedReader reader = new BufferedReader(new InputStreamReader(resourceProvider
                 .getResource("org/teavm/classlib/impl/unicode/UnicodeData.txt").open(), StandardCharsets.UTF_8))) {
             while (true) {
@@ -97,6 +99,24 @@ public final class UnicodeSupport {
                 }
                 String[] fields = splitLine(line);
                 int charCode = parseHex(fields[0]);
+                Byte charClass = classMap.get(fields[2]);
+                String name = fields[1];
+                if (name.endsWith(", First>")) {
+                    rangeStart = charCode;
+                    rangeClass = charClass != null ? charClass.byteValue() : 0;
+                    continue;
+                }
+                if (name.endsWith(", Last>") && rangeStart >= 0) {
+                    while (classes.size() < rangeStart) {
+                        classes.add(0);
+                    }
+                    for (int codePoint = rangeStart; codePoint <= charCode; ++codePoint) {
+                        classes.add(rangeClass);
+                    }
+                    rangeStart = -1;
+                    rangeClass = 0;
+                    continue;
+                }
                 while (classes.size() < charCode) {
                     classes.add(0);
                 }
@@ -105,7 +125,6 @@ public final class UnicodeSupport {
                     digitValues.add(charCode);
                     digitValues.add(digit);
                 }
-                Byte charClass = classMap.get(fields[2]);
                 classes.add(charClass != null ? charClass.intValue() : 0);
 
                 int upperCaseCode = !fields[12].isEmpty() ? parseHex(fields[12]) : charCode;

--- a/classlib/src/test/java/org/teavm/classlib/impl/unicode/UnicodeHelperTest.java
+++ b/classlib/src/test/java/org/teavm/classlib/impl/unicode/UnicodeHelperTest.java
@@ -18,10 +18,7 @@ package org.teavm.classlib.impl.unicode;
 import static org.junit.Assert.assertArrayEquals;
 import java.util.Arrays;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.teavm.junit.TeaVMTestRunner;
 
-@RunWith(TeaVMTestRunner.class)
 public class UnicodeHelperTest {
     @Test
     public void longRunsRoundTrip() {

--- a/tests/src/test/java/org/teavm/classlib/impl/unicode/UnicodeHelperTest.java
+++ b/tests/src/test/java/org/teavm/classlib/impl/unicode/UnicodeHelperTest.java
@@ -1,0 +1,39 @@
+/*
+ *  Copyright 2026 TeaVM contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.teavm.classlib.impl.unicode;
+
+import static org.junit.Assert.assertArrayEquals;
+import java.util.Arrays;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.teavm.junit.TeaVMTestRunner;
+
+@RunWith(TeaVMTestRunner.class)
+public class UnicodeHelperTest {
+    @Test
+    public void longRunsRoundTrip() {
+        byte[] data = new byte[50000];
+        Arrays.fill(data, 50, 40000, (byte) Character.OTHER_LETTER);
+        Arrays.fill(data, 45000, 50000, (byte) Character.PRIVATE_USE);
+
+        byte[] decoded = new byte[data.length];
+        for (var range : UnicodeHelper.extractRle(UnicodeHelper.compressRle(data))) {
+            System.arraycopy(range.data, 0, decoded, range.start, range.data.length);
+        }
+
+        assertArrayEquals(data, decoded);
+    }
+}

--- a/tests/src/test/java/org/teavm/classlib/java/lang/CharacterTest.java
+++ b/tests/src/test/java/org/teavm/classlib/java/lang/CharacterTest.java
@@ -42,6 +42,22 @@ public class CharacterTest {
     }
 
     @Test
+    public void unicodeDataRangesRecognized() {
+        assertEquals(Character.OTHER_LETTER, Character.getType(0x3400));
+        assertEquals(Character.OTHER_LETTER, Character.getType(0x4DBF));
+        assertEquals(Character.OTHER_LETTER, Character.getType(0x4E00));
+        assertEquals(Character.OTHER_LETTER, Character.getType(0x767A));
+        assertEquals(Character.OTHER_LETTER, Character.getType(0x6F22));
+        assertEquals(Character.OTHER_LETTER, Character.getType(0x9FFF));
+        assertEquals(Character.OTHER_LETTER, Character.getType(0xAC00));
+        assertEquals(Character.OTHER_LETTER, Character.getType(0xD7A3));
+        assertEquals(Character.OTHER_LETTER, Character.getType(0x20000));
+        assertEquals(Character.OTHER_LETTER, Character.getType(0x2A6DF));
+        assertEquals(Character.PRIVATE_USE, Character.getType(0xF0000));
+        assertEquals(Character.PRIVATE_USE, Character.getType(0x10FFFD));
+    }
+
+    @Test
     public void lowerCase() {
         assertEquals('1', Character.toLowerCase('1'));
         assertEquals('a', Character.toLowerCase('a'));

--- a/tests/src/test/java/org/teavm/classlib/java/util/regex/MatcherTest.java
+++ b/tests/src/test/java/org/teavm/classlib/java/util/regex/MatcherTest.java
@@ -614,6 +614,10 @@ public class MatcherTest {
 
         // assertTrue(Pattern.matches("[\\p{L}&&[^\\p{Lu}&&[^K]]]", "K"));
         assertFalse(Pattern.matches("[\\p{L}&&[^\\p{Lu}&&[^G]]]", "K"));
+
+        assertTrue(Pattern.matches("\\p{L}+", "\u767A"));
+        assertTrue(Pattern.matches("\\p{L}+", "\u6F22"));
+        assertTrue(Pattern.matches("\\p{L}+", "\u3042\u30A2\u4E00\u767A\u6F22"));
     }
 
     @Test


### PR DESCRIPTION
Fixes #1175.

## Summary

This updates UnicodeData.txt parsing to expand `<..., First>` / `<..., Last>` code point ranges when generating character type tables. These ranges include CJK ideographs, Hangul syllables, private-use areas, and other blocks that previously did not get their proper `Character.getType` values in TeaVM.

It also fixes Unicode RLE compression/extraction edge cases for long runs, so generated Unicode tables round-trip correctly.

## Testing

- `git diff --check origin/master..HEAD`
- `./gradlew :tests:test --tests org.teavm.classlib.java.lang.CharacterTest --tests org.teavm.classlib.java.util.regex.MatcherTest --tests org.teavm.classlib.impl.unicode.UnicodeHelperTest -Pteavm.tests.js=true -Pteavm.tests.wasm=false -Pteavm.tests.wasi=false -Pteavm.tests.c=false --stacktrace`
- `./gradlew build -x test -x javadoc --stacktrace`
