### PR TITLE
Support record-style @JSProperty accessors

### DIFF
--- a/jso/core/src/main/java/org/teavm/jso/JSProperty.java
+++ b/jso/core/src/main/java/org/teavm/jso/JSProperty.java
@@ -23,9 +23,10 @@ import java.lang.annotation.Target;
 /**
  * <p>Marks abstract member method as either a getter or a setter.</p>
  *
- * <p>Getter's name must conform the Java Beans specification, i.e. start with <code>get</code> prefix
- * (or <code>is</code> in case of boolean getter). It must not take any parameters and must return a value.
- * For getter annotation is equivalent to the following:</p>
+ * <p>Getter's name may conform the Java Beans specification, i.e. start with <code>get</code> prefix
+ * (or <code>is</code> in case of boolean getter), or use record-style accessor naming where the method name
+ * is the property name. It must not take any parameters and must return a value. For getter annotation is
+ * equivalent to the following:</p>
  *
  * <pre>
  * {@literal @}JSBody(params = {}, script = "return this.propertyName;")
@@ -39,8 +40,9 @@ import java.lang.annotation.Target;
  * {@literal @}JSBody(params = "value", script = "this.propertyName = value;")
  * </pre>
  *
- * <p>By default <code>propertyName</code> is calculated from method's name according to Java Beans specification,
- * otherwise the name specified by annotation is taken.</p>
+ * <p>By default <code>propertyName</code> is calculated from method's name according to Java Beans specification
+ * when it has a getter or setter prefix. Otherwise, a getter method's name is used as is. The name specified by
+ * annotation overrides this computation.</p>
  *
  * @author Alexey Andreev
  */

--- a/jso/impl/src/main/java/org/teavm/jso/impl/JSClassProcessor.java
+++ b/jso/impl/src/main/java/org/teavm/jso/impl/JSClassProcessor.java
@@ -19,6 +19,10 @@ import static org.teavm.jso.impl.JSMethods.JS_CLASS;
 import static org.teavm.jso.impl.JSMethods.JS_OBJECT;
 import static org.teavm.jso.impl.JSMethods.JS_WRAPPER_CLASS;
 import static org.teavm.jso.impl.JSMethods.OBJECT;
+import static org.teavm.jso.impl.JSPropertyUtil.getGetterName;
+import static org.teavm.jso.impl.JSPropertyUtil.getSetterName;
+import static org.teavm.jso.impl.JSPropertyUtil.isProperGetter;
+import static org.teavm.jso.impl.JSPropertyUtil.isProperSetter;
 import java.io.IOException;
 import java.io.StringReader;
 import java.util.ArrayList;
@@ -1102,12 +1106,8 @@ class JSClassProcessor {
     private boolean processProperty(MethodReader method, String suggestedName, CallLocation callLocation,
             InvokeInstruction invoke) {
         boolean pure = method.getAnnotations().get(NO_SIDE_EFFECTS) != null;
-        if (isProperGetter(method, suggestedName)) {
-            var propertyName = suggestedName;
-            if (propertyName == null) {
-                propertyName = method.getName().charAt(0) == 'i' ? cutPrefix(method.getName(), 2)
-                        : cutPrefix(method.getName(), 3);
-            }
+        if (isProperGetter(method)) {
+            var propertyName = suggestedName != null ? suggestedName : getGetterName(method);
             Variable result = invoke.getReceiver() != null ? program.createVariable() : null;
             addPropertyGet(propertyName, getCallTarget(invoke), result, invoke.getLocation(), pure);
             if (result != null) {
@@ -1118,10 +1118,7 @@ class JSClassProcessor {
             return true;
         }
         if (isProperSetter(method, suggestedName)) {
-            var propertyName = suggestedName;
-            if (propertyName == null) {
-                propertyName = cutPrefix(method.getName(), 3);
-            }
+            var propertyName = suggestedName != null ? suggestedName : getSetterName(method);
             var value = invoke.getArguments().get(0);
             value = marshaller.wrapArgument(callLocation, value, method.parameterType(0), types.typeOf(value), false,
                     null);
@@ -1614,38 +1611,6 @@ class JSClassProcessor {
         return null;
     }
 
-    private boolean isProperGetter(MethodReader method, String suggestedName) {
-        if (method.parameterCount() > 0) {
-            return false;
-        }
-        if (suggestedName != null) {
-            return true;
-        }
-
-        if (method.getResultType().equals(ValueType.BOOLEAN)) {
-            if (isProperPrefix(method.getName(), "is")) {
-                return true;
-            }
-        }
-        return isProperPrefix(method.getName(), "get");
-    }
-
-    private boolean isProperSetter(MethodReader method, String suggestedName) {
-        if (method.parameterCount() != 1 || method.getResultType() != ValueType.VOID) {
-            return false;
-        }
-
-        return suggestedName != null || isProperPrefix(method.getName(), "set");
-    }
-
-    private boolean isProperPrefix(String name, String prefix) {
-        if (!name.startsWith(prefix) || name.length() == prefix.length()) {
-            return false;
-        }
-        char c = name.charAt(prefix.length());
-        return Character.isUpperCase(c) || !Character.isAlphabetic(c) && Character.isJavaIdentifierStart(c);
-    }
-
     private boolean isProperGetIndexer(MethodDescriptor desc) {
         return desc.parameterCount() == 1;
     }
@@ -1654,14 +1619,4 @@ class JSClassProcessor {
         return desc.parameterCount() == 2 && desc.getResultType() == ValueType.VOID;
     }
 
-    private static String cutPrefix(String name, int prefixLength) {
-        if (name.length() == prefixLength + 1) {
-            return name.substring(prefixLength).toLowerCase();
-        }
-        char c = name.charAt(prefixLength + 1);
-        if (Character.isUpperCase(c)) {
-            return name.substring(prefixLength);
-        }
-        return Character.toLowerCase(name.charAt(prefixLength)) + name.substring(prefixLength + 1);
-    }
 }

--- a/jso/impl/src/main/java/org/teavm/jso/impl/JSObjectClassTransformer.java
+++ b/jso/impl/src/main/java/org/teavm/jso/impl/JSObjectClassTransformer.java
@@ -19,6 +19,9 @@ import static org.teavm.jso.impl.JSMethods.JS_OBJECT;
 import static org.teavm.jso.impl.JSMethods.JS_OBJECT_CLASS;
 import static org.teavm.jso.impl.JSMethods.JS_WRAPPER_CLASS;
 import static org.teavm.jso.impl.JSMethods.OBJECT;
+import static org.teavm.jso.impl.JSPropertyUtil.getGetterName;
+import static org.teavm.jso.impl.JSPropertyUtil.getSetterName;
+import static org.teavm.jso.impl.JSPropertyUtil.isProperSetter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -541,25 +544,15 @@ class JSObjectClassTransformer implements ClassHolderTransformer {
                             name = nameStr;
                         }
                     }
-                    String expectedPrefix;
                     if (method.parameterCount() == 0) {
-                        if (method.getResultType() == ValueType.BOOLEAN) {
-                            expectedPrefix = "is";
-                        } else {
-                            expectedPrefix = "get";
-                        }
                         kind = MethodKind.GETTER;
+                        if (name == null) {
+                            name = getGetterName(method);
+                        }
                     } else {
-                        expectedPrefix = "set";
                         kind = MethodKind.SETTER;
-                    }
-
-                    if (name == null) {
-                        name = method.getName();
-                        if (name.startsWith(expectedPrefix) && name.length() > expectedPrefix.length()
-                                && Character.isUpperCase(name.charAt(expectedPrefix.length()))) {
-                            name = Character.toLowerCase(name.charAt(expectedPrefix.length()))
-                                    + name.substring(expectedPrefix.length() + 1);
+                        if (name == null) {
+                            name = isProperSetter(method, null) ? getSetterName(method) : method.getName();
                         }
                     }
                 }

--- a/jso/impl/src/main/java/org/teavm/jso/impl/JSPropertyUtil.java
+++ b/jso/impl/src/main/java/org/teavm/jso/impl/JSPropertyUtil.java
@@ -1,0 +1,66 @@
+/*
+ *  Copyright 2026 Alexey Andreev.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.teavm.jso.impl;
+
+import org.teavm.model.MethodReader;
+import org.teavm.model.ValueType;
+
+final class JSPropertyUtil {
+    private JSPropertyUtil() {
+    }
+
+    static boolean isProperGetter(MethodReader method) {
+        return method.parameterCount() == 0 && method.getResultType() != ValueType.VOID;
+    }
+
+    static boolean isProperSetter(MethodReader method, String suggestedName) {
+        return method.parameterCount() == 1 && method.getResultType() == ValueType.VOID
+                && (suggestedName != null || isProperPrefix(method.getName(), "set"));
+    }
+
+    static String getGetterName(MethodReader method) {
+        if (method.getResultType() == ValueType.BOOLEAN && isProperPrefix(method.getName(), "is")) {
+            return cutPrefix(method.getName(), 2);
+        }
+        if (isProperPrefix(method.getName(), "get")) {
+            return cutPrefix(method.getName(), 3);
+        }
+        return method.getName();
+    }
+
+    static String getSetterName(MethodReader method) {
+        return cutPrefix(method.getName(), 3);
+    }
+
+    private static boolean isProperPrefix(String name, String prefix) {
+        if (!name.startsWith(prefix) || name.length() == prefix.length()) {
+            return false;
+        }
+        char c = name.charAt(prefix.length());
+        return Character.isUpperCase(c) || !Character.isAlphabetic(c) && Character.isJavaIdentifierStart(c);
+    }
+
+    private static String cutPrefix(String name, int prefixLength) {
+        if (name.length() == prefixLength + 1) {
+            return name.substring(prefixLength).toLowerCase();
+        }
+        char c = name.charAt(prefixLength + 1);
+        if (Character.isUpperCase(c)) {
+            return name.substring(prefixLength);
+        }
+        return Character.toLowerCase(name.charAt(prefixLength)) + name.substring(prefixLength + 1);
+    }
+}

--- a/tests/src/test/java/org/teavm/jso/test/AnnotationsTest.java
+++ b/tests/src/test/java/org/teavm/jso/test/AnnotationsTest.java
@@ -60,6 +60,14 @@ public class AnnotationsTest {
         assertEquals(13, obj.renamedMethod(6));
     }
 
+    @Test
+    public void recordStylePropertyAccessorsWork() {
+        RecordStyleWrapper obj = createRecordStyleWrapper();
+        assertEquals(23, obj.value());
+        assertEquals("green", obj.color());
+        assertEquals(true, obj.active());
+    }
+
     @JSBody(params = { "a", "b" }, script = "return a + b;")
     private static native int add(int a, int b);
 
@@ -116,4 +124,18 @@ public class AnnotationsTest {
                 + "renamedJSMethod : function(num) { return this.value + num + 2; }"
             + "};")
     public static native InterfaceWrapper createWrapper(int value);
+
+    @JSBody(script = "return { value: 23, color: 'green', active: true };")
+    public static native RecordStyleWrapper createRecordStyleWrapper();
+
+    interface RecordStyleWrapper extends JSObject {
+        @JSProperty
+        int value();
+
+        @JSProperty
+        String color();
+
+        @JSProperty
+        boolean active();
+    }
 }


### PR DESCRIPTION
Allow using `@JSProperty` on record-style accessor methods (i.e. no `get` / `is` prefix) without specifying an explicit property name.