### PR TITLE
Add System.Logger and friends to class library.

### DIFF
--- a/classlib/src/main/java/org/teavm/classlib/java/lang/TSystem.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/lang/TSystem.java
@@ -18,6 +18,8 @@ package org.teavm.classlib.java.lang;
 import java.lang.reflect.Array;
 import java.util.Enumeration;
 import java.util.Properties;
+import java.util.ResourceBundle;
+import java.util.function.Supplier;
 import org.teavm.backend.c.intrinsic.RuntimeInclude;
 import org.teavm.backend.c.runtime.Memory;
 import org.teavm.backend.c.runtime.fs.CFileSystem;
@@ -302,5 +304,123 @@ public final class TSystem extends TObject {
     
     public static String getenv(String name) {
         return null;
+    }
+
+    public static Logger getLogger(String name) {
+        return ConsoleLogger.INSTANCE;
+    }
+
+    public static Logger getLogger(String name, ResourceBundle bundle) {
+        return ConsoleLogger.INSTANCE;
+    }
+
+    public interface Logger {
+
+        public enum Level {
+            ALL(Integer.MIN_VALUE),
+            TRACE(400),
+            DEBUG(500),
+            INFO(800),
+            WARNING(900),
+            ERROR(1000),
+            OFF(Integer.MAX_VALUE);
+
+            private final int severity;
+
+            private Level(int severity) {
+                this.severity = severity;
+            }
+
+            public final String getName() {
+                return name();
+            }
+
+            public final int getSeverity() {
+                return severity;
+            }
+        }
+
+        public String getName();
+
+        public boolean isLoggable(Level level);
+
+        public default void log(Level level, String msg) {
+            log(level, (ResourceBundle) null, msg, (Object[]) null);
+        }
+
+        public default void log(Level level, Supplier<String> msgSupplier) {
+            if (isLoggable(level)) {
+                log(level, (ResourceBundle) null, msgSupplier.get(), (Object[]) null);
+            }
+        }
+
+        public default void log(Level level, Object obj) {
+            if (isLoggable(level)) {
+                log(level, (ResourceBundle) null, obj.toString(), (Object[]) null);
+            }
+        }
+
+        public default void log(Level level, String msg, Throwable thrown) {
+            log(level, null, msg, thrown);
+        }
+
+        public default void log(Level level, Supplier<String> msgSupplier, Throwable thrown) {
+            if (isLoggable(level)) {
+                log(level, null, msgSupplier.get(), thrown);
+            }
+        }
+
+        public void log(Level level, ResourceBundle bundle, String msg, Throwable thrown);
+
+        public void log(Level level, ResourceBundle bundle, String format, Object... params);
+    }
+
+    public abstract static class LoggerFinder {
+
+        protected LoggerFinder() {
+        }
+
+        public abstract Logger getLogger(String name, Module module);
+
+        public Logger getLocalizedLogger(String name, ResourceBundle bundle, Module module) {
+            return getLogger(name, module);
+        }
+
+        public static LoggerFinder getLoggerFinder() {
+            return ConsoleLogger.INSTANCE;
+        }
+    }
+
+    private static class ConsoleLogger extends LoggerFinder implements Logger {
+
+        private static final ConsoleLogger INSTANCE = new ConsoleLogger();
+
+        @Override
+        public Logger getLogger(String name, Module module) {
+            return this;
+        }
+
+        @Override
+        public String getName() {
+            return "ConsoleLogger";
+        }
+
+        @Override
+        public boolean isLoggable(Level level) {
+            return level.getSeverity() >= Level.INFO.getSeverity();
+        }
+
+        @Override
+        public void log(Level level, ResourceBundle bundle, String msg, Throwable thrown) {
+            System.err.println(level.getName() + ": " + msg);
+            if (thrown != null) {
+                thrown.printStackTrace(System.err);
+            }
+        }
+
+        @Override
+        public void log(Level level, ResourceBundle bundle, String format, Object... params) {
+            log(level, bundle, format, (Throwable) null);
+        }
     }
 }

--- a/classlib/src/main/java/org/teavm/classlib/java/lang/TSystem.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/lang/TSystem.java
@@ -316,7 +316,7 @@ public final class TSystem extends TObject {
 
     public interface Logger {
 
-        public enum Level {
+        enum Level {
             ALL(Integer.MIN_VALUE),
             TRACE(400),
             DEBUG(500),

--- a/classlib/src/main/java/org/teavm/classlib/java/lang/TSystem.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/lang/TSystem.java
@@ -375,30 +375,9 @@ public final class TSystem extends TObject {
         void log(Level level, ResourceBundle bundle, String format, Object... params);
     }
 
-    public abstract static class LoggerFinder {
-
-        protected LoggerFinder() {
-        }
-
-        public abstract Logger getLogger(String name, Module module);
-
-        public Logger getLocalizedLogger(String name, ResourceBundle bundle, Module module) {
-            return getLogger(name, module);
-        }
-
-        public static LoggerFinder getLoggerFinder() {
-            return ConsoleLogger.INSTANCE;
-        }
-    }
-
-    private static class ConsoleLogger extends LoggerFinder implements Logger {
+    private static class ConsoleLogger implements Logger {
 
         private static final ConsoleLogger INSTANCE = new ConsoleLogger();
-
-        @Override
-        public Logger getLogger(String name, Module module) {
-            return this;
-        }
 
         @Override
         public String getName() {

--- a/classlib/src/main/java/org/teavm/classlib/java/lang/TSystem.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/lang/TSystem.java
@@ -340,39 +340,39 @@ public final class TSystem extends TObject {
             }
         }
 
-        public String getName();
+        String getName();
 
-        public boolean isLoggable(Level level);
+        boolean isLoggable(Level level);
 
-        public default void log(Level level, String msg) {
+        default void log(Level level, String msg) {
             log(level, (ResourceBundle) null, msg, (Object[]) null);
         }
 
-        public default void log(Level level, Supplier<String> msgSupplier) {
+        default void log(Level level, Supplier<String> msgSupplier) {
             if (isLoggable(level)) {
                 log(level, (ResourceBundle) null, msgSupplier.get(), (Object[]) null);
             }
         }
 
-        public default void log(Level level, Object obj) {
+        default void log(Level level, Object obj) {
             if (isLoggable(level)) {
                 log(level, (ResourceBundle) null, obj.toString(), (Object[]) null);
             }
         }
 
-        public default void log(Level level, String msg, Throwable thrown) {
+        default void log(Level level, String msg, Throwable thrown) {
             log(level, null, msg, thrown);
         }
 
-        public default void log(Level level, Supplier<String> msgSupplier, Throwable thrown) {
+        default void log(Level level, Supplier<String> msgSupplier, Throwable thrown) {
             if (isLoggable(level)) {
                 log(level, null, msgSupplier.get(), thrown);
             }
         }
 
-        public void log(Level level, ResourceBundle bundle, String msg, Throwable thrown);
+        void log(Level level, ResourceBundle bundle, String msg, Throwable thrown);
 
-        public void log(Level level, ResourceBundle bundle, String format, Object... params);
+        void log(Level level, ResourceBundle bundle, String format, Object... params);
     }
 
     public abstract static class LoggerFinder {


### PR DESCRIPTION
This was introduced in Java 9 to avoid a hard dependency from the JDK on `java.util.logging` for its own logging. It's comparable to a built-in SLF4J. I think it's rarely used outside of the JDK, but some libraries (in my case SnakeYAML) rely on it.

The `System.Logger` has two possible implementations: If the `java.util.logging` module is available, it uses that. If not, it uses a simple console logger as a fallback. I don't know if I can assume that `java.util.logging` is *always* available in TeaVM, so I'm using the simple console route.