### PR TITLE
js: skip abstract classes and interfaces in simple constructor table

### DIFF
--- a/core/src/main/java/org/teavm/backend/javascript/intrinsics/reflection/ClassInfoGenerator.java
+++ b/core/src/main/java/org/teavm/backend/javascript/intrinsics/reflection/ClassInfoGenerator.java
@@ -238,6 +238,12 @@ public class ClassInfoGenerator implements Injector, Generator {
             if (type instanceof ValueType.Object) {
                 var className = ((ValueType.Object) type).getClassName();
                 var cls = context.getClassSource().get(className);
+                if (cls.hasModifier(ElementModifier.ABSTRACT) || cls.hasModifier(ElementModifier.INTERFACE)) {
+                    // newInstance rejects abstract classes and interfaces at run time, and the
+                    // optimizer may eliminate their never-callable constructors, which would leave
+                    // dangling function references in the emitted table.
+                    continue;
+                }
                 var ctor = cls.getMethod(new MethodDescriptor("<init>", void.class));
                 if (ctor != null && !ctor.hasModifier(ElementModifier.ABSTRACT)
                         && ctor.getLevel() == AccessLevel.PUBLIC) {

--- a/tests/src/test/java/org/teavm/classlib/java/lang/ClassTest.java
+++ b/tests/src/test/java/org/teavm/classlib/java/lang/ClassTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
@@ -168,6 +169,36 @@ public class ClassTest {
         instance.run();
         assertEquals(TestObjectAsync.class, instance.getClass());
         assertEquals(2, ((TestObjectAsync) instance).getCounter());
+    }
+
+    @Test
+    public void newInstanceOnAbstractClassFails() throws Exception {
+        // The abstract class must reach the newInstance dependency node while its
+        // only regular constructor caller is a subclass, so the optimizer may inline
+        // and eliminate the constructor. Reflection metadata referring to it used to
+        // produce an invalid script that failed before reaching any test.
+        var instance = new ConcreteCaseOfAbstractClass();
+        assertEquals("concrete", instance.name());
+        try {
+            AbstractClassWithPublicConstructor.class.newInstance();
+            fail("InstantiationException expected");
+        } catch (InstantiationException e) {
+            // expected
+        }
+    }
+
+    public abstract static class AbstractClassWithPublicConstructor {
+        public AbstractClassWithPublicConstructor() {
+        }
+
+        abstract String name();
+    }
+
+    static class ConcreteCaseOfAbstractClass extends AbstractClassWithPublicConstructor {
+        @Override
+        String name() {
+            return "concrete";
+        }
     }
 
     @Test


### PR DESCRIPTION
Fixes #1210.

`writeSimpleConstructors` filtered only on the constructor's own modifiers (public, not abstract), so abstract classes with public implicit constructors were registered in `$rt_simpleConstructors`. Their `<init>` is only reachable through subclass `super()` chains; at `ADVANCED` optimization the inliner eliminates the standalone function and the emitted table references an undefined name, making the whole script fail before `main` (`ReferenceError` in plain deployments, `TypeError: <name> is not a function` in the test harness).

`TClass.newInstance()` already rejects abstract classes and interfaces with `InstantiationException` before consulting the table, so these entries are unreachable at any optimization level; skipping them changes no observable behavior. The new `ClassTest.newInstanceOnAbstractClassFails` reproduces the invalid-script failure in the optimized JS configuration without this change and asserts the `InstantiationException` contract with it.

Verified locally: `:tests:test --tests org.teavm.classlib.java.lang.ClassTest` with `teavm.tests.js=true`, `teavm.tests.optimized=true` fails on master and passes with the fix; `checkstyleMain`/`checkstyleTest` clean.
