### PR TITLE
Fix DAY_OF_WEEK when WEEK_OF_MONTH is set (#371)

### DIFF
--- a/classlib/src/main/java/org/teavm/classlib/java/util/TGregorianCalendar.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/util/TGregorianCalendar.java
@@ -525,7 +525,7 @@ public class TGregorianCalendar extends TCalendar {
                 }
                 if (isSet[WEEK_OF_MONTH] && lastDateFieldSet != DAY_OF_WEEK_IN_MONTH) {
                     int skew = mod7(days - 3 - (getFirstDayOfWeek() - 1));
-                    days += (fields[WEEK_OF_MONTH] - 1) * 7 + mod7(skew + dayOfWeek - (days - 2)) - skew;
+                    days += (fields[WEEK_OF_MONTH] - 1) * 7 + mod7(skew + dayOfWeek - (days - 3)) - skew;
                 } else if (isSet[DAY_OF_WEEK_IN_MONTH]) {
                     if (fields[DAY_OF_WEEK_IN_MONTH] >= 0) {
                         days += mod7(dayOfWeek - (days - 3)) + (fields[DAY_OF_WEEK_IN_MONTH] - 1) * 7;

--- a/tests/src/test/java/org/teavm/classlib/java/util/CalendarTest.java
+++ b/tests/src/test/java/org/teavm/classlib/java/util/CalendarTest.java
@@ -106,8 +106,8 @@ public class CalendarTest {
         cal.clear();
         cal.set(Calendar.YEAR, 2002);
         cal.set(Calendar.WEEK_OF_MONTH, 2);
-        //assertTrue("Incorrect result 0d: " + cal.getTime(), cal.getTime()
-        //        .getTime() == 1010293200000L);
+        assertTrue("Incorrect result 0d: " + cal.getTime(), cal.getTime()
+                .getTime() == 1010293200000L);
 
         cal.clear();
         cal.set(Calendar.YEAR, 2002);
@@ -163,7 +163,7 @@ public class CalendarTest {
                 .getTime());
 
         // WEEK_OF_MONTH has priority
-        /*cal.clear();
+        cal.clear();
         cal.set(Calendar.YEAR, 2002);
         cal.set(Calendar.WEEK_OF_YEAR, 12);
         cal.set(Calendar.DAY_OF_WEEK_IN_MONTH, 1);
@@ -171,7 +171,7 @@ public class CalendarTest {
         cal.set(Calendar.MONTH, Calendar.MARCH);
         cal.set(Calendar.DATE, 5);
         cal.set(Calendar.DAY_OF_WEEK, Calendar.MONDAY);
-        assertEquals("Incorrect result 2", new Date(1015822800000L), cal.getTime());*/
+        assertEquals("Incorrect result 2", new Date(1015822800000L), cal.getTime());
 
         // DAY_OF_WEEK_IN_MONTH has priority over WEEK_OF_YEAR
         cal.clear();
@@ -184,14 +184,14 @@ public class CalendarTest {
         assertEquals("Incorrect result 3", new Date(1015822800000L), cal.getTime());
 
         // WEEK_OF_MONTH has priority, MONTH not set
-        /*cal.clear();
+        cal.clear();
         cal.set(Calendar.YEAR, 2002);
         cal.set(Calendar.WEEK_OF_YEAR, 12);
         cal.set(Calendar.DAY_OF_WEEK_IN_MONTH, 1);
         cal.set(Calendar.WEEK_OF_MONTH, 3);
         cal.set(Calendar.DATE, 25);
         cal.set(Calendar.DAY_OF_WEEK, Calendar.MONDAY);
-        assertEquals("Incorrect result 4", new Date(1010984400000L), cal.getTime());*/
+        assertEquals("Incorrect result 4", new Date(1010984400000L), cal.getTime());
 
         // WEEK_OF_YEAR has priority when MONTH set last and DAY_OF_WEEK set
         cal.clear();
@@ -223,7 +223,7 @@ public class CalendarTest {
                 .getTime() == 1015822800000L);
 
         // WEEK_OF_MONTH has priority
-        /*cal.clear();
+        cal.clear();
         cal.set(Calendar.YEAR, 2002);
         cal.set(Calendar.WEEK_OF_YEAR, 12);
         cal.set(Calendar.DATE, 5);
@@ -231,7 +231,7 @@ public class CalendarTest {
         cal.set(Calendar.DAY_OF_WEEK, Calendar.MONDAY);
         cal.set(Calendar.MONTH, Calendar.MARCH);
         assertTrue("Incorrect result 5c: " + cal.getTime(), cal.getTime()
-                .getTime() == 1015822800000L);*/
+                .getTime() == 1015822800000L);
 
         // DATE has priority when set last
         cal.clear();


### PR DESCRIPTION
Fixes #371.

`TGregorianCalendar` line 528 uses `days - 2` where every neighbouring branch uses `days - 3` — including `skew`, computed on the line directly above it:

```java
int skew = mod7(days - 3 - (getFirstDayOfWeek() - 1));
days += (fields[WEEK_OF_MONTH] - 1) * 7 + mod7(skew + dayOfWeek - (days - 2)) - skew;
```

Apache Harmony's `GregorianCalendar`, which this is ported from, uses `days - 3` here — the original spans two lines, and the `- 2` looks like a slip when the expression was joined:

```java
days += (fields[WEEK_OF_MONTH] - 1) * 7
        + mod7(skew + dayOfWeek - (days - 3)) - skew;
```

### Effect

With `YEAR=2002, WEEK_OF_MONTH=2` (`America/New_York`, `en_US`): the JVM returns `Sun Jan 06 2002`, TeaVM returns `Sat Jan 12 2002`.

### Tests

`CalendarTest.test_setII` has four assertions that reach this line, commented out since 2015. This re-enables them rather than adding new ones — they fail on master and pass with this change. No live test reached line 528, so the existing suite could not have caught this.

Verified with `-Pteavm.tests.js=true -Pteavm.tests.browser=browser-chrome`; the full Calendar/Date suite stays green.

### Not addressed here

`minimalDaysInFirstWeek` is still unhandled in this branch (no mirror of the `:557-559` logic), so locales with `minDays > 1` remain wrong for `WEEK_OF_MONTH`. Happy to follow up separately — keeping this to the one-line fix.

Found while auditing TeaVM's JVM-vs-browser behaviour: I use TeaVM to ship a Java game engine to the browser, and I look for places where the port and the JVM quietly disagree.