### PR TITLE
Wasm GC: stale stack depth in the coroutine transformation

### DIFF
--- a/core/src/main/java/org/teavm/backend/wasm/model/instruction/WasmTypeInference.java
+++ b/core/src/main/java/org/teavm/backend/wasm/model/instruction/WasmTypeInference.java
@@ -30,6 +30,7 @@ public class WasmTypeInference implements WasmInstructionVisitor {
     @Override
     public void visit(WasmUnreachable instruction) {
         typeStack.clear();
+        depthBeforeLastInstructionOut = 0;
     }
 
     @Override
@@ -39,6 +40,8 @@ public class WasmTypeInference implements WasmInstructionVisitor {
             popN(type.getInputTypes().size());
             depthBeforeLastInstructionOut = typeStack.size();
             typeStack.addAll(type.getOutputTypes());
+        } else {
+            depthBeforeLastInstructionOut = typeStack.size();
         }
     }
 
@@ -50,12 +53,15 @@ public class WasmTypeInference implements WasmInstructionVisitor {
             popN(type.getInputTypes().size());
             depthBeforeLastInstructionOut = typeStack.size();
             typeStack.addAll(type.getOutputTypes());
+        } else {
+            depthBeforeLastInstructionOut = typeStack.size();
         }
     }
 
     @Override
     public void visit(WasmBranch instruction) {
         pop();
+        depthBeforeLastInstructionOut = typeStack.size();
     }
 
     @Override
@@ -87,16 +93,19 @@ public class WasmTypeInference implements WasmInstructionVisitor {
     @Override
     public void visit(WasmBreak instruction) {
         typeStack.clear();
+        depthBeforeLastInstructionOut = 0;
     }
 
     @Override
     public void visit(WasmSwitch instruction) {
         typeStack.clear();
+        depthBeforeLastInstructionOut = 0;
     }
 
     @Override
     public void visit(WasmReturn instruction) {
         typeStack.clear();
+        depthBeforeLastInstructionOut = 0;
     }
 
     @Override
@@ -341,8 +350,8 @@ public class WasmTypeInference implements WasmInstructionVisitor {
 
     @Override
     public void visit(WasmThrow instruction) {
-        depthBeforeLastInstructionOut = typeStack.size();
         typeStack.clear();
+        depthBeforeLastInstructionOut = 0;
     }
 
     @Override

--- a/tests/src/test/java/org/teavm/vm/WasmAsyncTest.java
+++ b/tests/src/test/java/org/teavm/vm/WasmAsyncTest.java
@@ -16,6 +16,7 @@
 package org.teavm.vm;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.teavm.interop.Async;
@@ -42,11 +43,42 @@ public class WasmAsyncTest {
         assertEquals(4111, generatedMethod(4));
     }
 
+    @Test
+    public void suspendingLoopAfterBranch() {
+        assertEquals(100, loopAfterBranch(1));
+        assertEquals(7, loopAfterBranch(0));
+    }
+
+    @Test
+    public void suspendingLoopAfterThrow() {
+        assertEquals(100, loopAfterThrow(1));
+        try {
+            loopAfterThrow(0);
+            fail("Exception expected");
+        } catch (RuntimeException e) {
+            assertEquals("generated", e.getMessage());
+        }
+    }
+
     @Async
     @NativeAsync
     @Intrinsified
     private static native int generatedMethod(int n);
-    
+
+    @Async
+    @NativeAsync
+    @Intrinsified
+    private static native int loopAfterBranch(int n);
+
+    @Async
+    @NativeAsync
+    @Intrinsified
+    private static native int loopAfterThrow(int n);
+
+    static RuntimeException newException() {
+        return new RuntimeException("generated");
+    }
+
     @Async
     private static native int sum(int a, int b);
 

--- a/tests/src/test/java/org/teavm/vm/WasmAsyncTestDependency.java
+++ b/tests/src/test/java/org/teavm/vm/WasmAsyncTestDependency.java
@@ -23,8 +23,20 @@ import org.teavm.model.MethodReference;
 public class WasmAsyncTestDependency extends AbstractDependencyListener {
     @Override
     public void methodReached(DependencyAgent agent, MethodDependency method) {
-        if (method.getMethod().getName().equals("generatedMethod")) {
-            agent.linkMethod(new MethodReference(WasmAsyncTest.class, "sum", int.class, int.class, int.class)).use();
+        switch (method.getMethod().getName()) {
+            case "generatedMethod":
+            case "loopAfterBranch":
+                agent.linkMethod(new MethodReference(WasmAsyncTest.class, "sum", int.class, int.class,
+                        int.class)).use();
+                break;
+            case "loopAfterThrow":
+                agent.linkMethod(new MethodReference(WasmAsyncTest.class, "sum", int.class, int.class,
+                        int.class)).use();
+                agent.linkMethod(new MethodReference(WasmAsyncTest.class, "newException",
+                        RuntimeException.class)).use();
+                break;
+            default:
+                break;
         }
     }
 }

--- a/tests/src/test/java/org/teavm/vm/WasmAsyncTestGenerator.java
+++ b/tests/src/test/java/org/teavm/vm/WasmAsyncTestGenerator.java
@@ -35,20 +35,87 @@ public class WasmAsyncTestGenerator implements WasmGCBodyIntrinsic {
 
     @Override
     public void apply(MethodReference method, WasmFunction function) {
-        if (method.getName().equals("generatedMethod")) {
-            var param = new WasmLocal(WasmType.INT32, "n");
-            function.add(param);
-            var generator = new Generator(context, param);
-            generator.generate(function.getBody().builder());
+        switch (method.getName()) {
+            case "generatedMethod":
+                new Generator(addParam(function)).generate(function.getBody().builder());
+                break;
+            case "loopAfterBranch":
+                generateLoopAfterBranch(function, addParam(function));
+                break;
+            case "loopAfterThrow":
+                generateLoopAfterThrow(function, addParam(function));
+                break;
+            default:
+                break;
         }
     }
 
-    private static class Generator {
-        final WasmGCCodeGenContext context;
+    private static WasmLocal addParam(WasmFunction function) {
+        var param = new WasmLocal(WasmType.INT32, "n");
+        function.add(param);
+        return param;
+    }
+
+    // A suspending loop that follows a block whose body ends with a branch. The branch empties the
+    // type stack, so a stale depth recorded by an earlier instruction indexes an empty snapshot.
+    private void generateLoopAfterBranch(WasmFunction function, WasmLocal param) {
+        var outer = function.getBody().builder().block(WasmType.INT32);
+        escapeIfNonZero(outer, param);
+        outer.block()
+                .i32Const(1)
+                .i32Const(2)
+                .call(sumFn(), true)
+                .i32Const(7)
+                .breakTo(outer.list);
+        suspendingLoop(outer);
+        outer.i32Const(0);
+    }
+
+    // Same shape, with the type stack emptied by throw instead of by a branch. This is what Kotlin
+    // coroutine state machines produce.
+    private void generateLoopAfterThrow(WasmFunction function, WasmLocal param) {
+        var outer = function.getBody().builder().block(WasmType.INT32);
+        escapeIfNonZero(outer, param);
+        outer.block()
+                .i32Const(1)
+                .i32Const(2)
+                .call(sumFn(), true)
+                .drop()
+                .call(newExceptionFn(), false)
+                .throw_(context.exceptionTag());
+        suspendingLoop(outer);
+        outer.i32Const(0);
+    }
+
+    private void escapeIfNonZero(WasmInstructionBuilder outer, WasmLocal param) {
+        outer.getLocal(param);
+        outer.conditional().getThenBlock().builder()
+                .i32Const(100)
+                .breakTo(outer.list);
+    }
+
+    private void suspendingLoop(WasmInstructionBuilder builder) {
+        builder.loop()
+                .i32Const(1)
+                .i32Const(2)
+                .call(sumFn(), true)
+                .drop();
+    }
+
+    private WasmFunction sumFn() {
+        return context.functions().forStaticMethod(new MethodReference(WasmAsyncTest.class, "sum", int.class,
+                int.class, int.class));
+    }
+
+    private WasmFunction newExceptionFn() {
+        return context.functions().forStaticMethod(new MethodReference(WasmAsyncTest.class, "newException",
+                RuntimeException.class));
+    }
+
+    private class Generator {
         final WasmLocal param;
 
-        Generator(WasmGCCodeGenContext context, WasmLocal param) {
-            this.context = context;
+        Generator(WasmLocal param) {
             this.param = param;
         }
 
@@ -86,15 +153,10 @@ public class WasmAsyncTestGenerator implements WasmGCBodyIntrinsic {
             });
             builder.intBinary(WasmIntType.INT32, WasmIntBinaryOperation.ADD);
         }
-        
+
         private void block(WasmInstructionBuilder builder, Consumer<WasmInstructionBuilder> body) {
             var block = builder.block(WasmType.INT32);
             body.accept(block);
-        }
-        
-        private WasmFunction sumFn() {
-            return context.functions().forStaticMethod(new MethodReference(WasmAsyncTest.class, "sum", int.class,
-                    int.class, int.class));
         }
     }
 }


### PR DESCRIPTION
WasmTypeInference updated depthBeforeLastInstructionOut only in instructions that
push a result. After an instruction that pushes nothing the field kept a depth
recorded by some earlier instruction, which may exceed the current stack depth.

CoroutineTransformation reads the field right after visiting a suspending
instruction and uses it to index the stack snapshot taken just before it. When
the suspending instruction is an untyped loop that follows a branch or a throw,
the field still holds the depth from before the stack was emptied, and
createSaveInstructions throws IndexOutOfBoundsException. Kotlin coroutine state
machines produce this shape. 

Now every visitor leaves the field equal to the depth of the stack it produced.
