### PR TITLE
Wasm GC: local.tee pushes the local's type, not the value's

### DIFF
--- a/core/src/main/java/org/teavm/backend/wasm/model/instruction/WasmTypeInference.java
+++ b/core/src/main/java/org/teavm/backend/wasm/model/instruction/WasmTypeInference.java
@@ -150,7 +150,9 @@ public class WasmTypeInference implements WasmInstructionVisitor {
 
     @Override
     public void visit(WasmTeeLocal instruction) {
-        depthBeforeLastInstructionOut = typeStack.size() - 1;
+        pop();
+        depthBeforeLastInstructionOut = typeStack.size();
+        typeStack.add(instruction.getLocal().getType());
     }
 
     @Override

--- a/tests/src/test/java/org/teavm/vm/WasmTeeTypeDependency.java
+++ b/tests/src/test/java/org/teavm/vm/WasmTeeTypeDependency.java
@@ -1,0 +1,35 @@
+/*
+ *  Copyright 2026 Alexey Andreev.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.teavm.vm;
+
+import org.teavm.dependency.AbstractDependencyListener;
+import org.teavm.dependency.DependencyAgent;
+import org.teavm.dependency.MethodDependency;
+import org.teavm.model.MethodReference;
+
+public class WasmTeeTypeDependency extends AbstractDependencyListener {
+    @Override
+    public void methodReached(DependencyAgent agent, MethodDependency method) {
+        if (method.getMethod().getName().equals("teeThenSuspend")) {
+            agent.linkMethod(new MethodReference(WasmTeeTypeTest.class, "sum", int.class, int.class,
+                    int.class)).use();
+            agent.linkMethod(new MethodReference(WasmTeeTypeTest.class, "newError",
+                    IllegalStateException.class)).use();
+            agent.linkMethod(new MethodReference(WasmTeeTypeTest.class, "lengthOf", Throwable.class,
+                    int.class)).use();
+        }
+    }
+}

--- a/tests/src/test/java/org/teavm/vm/WasmTeeTypeGenerator.java
+++ b/tests/src/test/java/org/teavm/vm/WasmTeeTypeGenerator.java
@@ -1,0 +1,82 @@
+/*
+ *  Copyright 2026 Alexey Andreev.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.teavm.vm;
+
+import org.teavm.backend.wasm.intrinsics.WasmGCBodyIntrinsic;
+import org.teavm.backend.wasm.intrinsics.WasmGCCodeGenContext;
+import org.teavm.backend.wasm.model.WasmFunction;
+import org.teavm.backend.wasm.model.WasmLocal;
+import org.teavm.backend.wasm.model.WasmType;
+import org.teavm.backend.wasm.model.instruction.WasmInstructionBuilder;
+import org.teavm.backend.wasm.model.instruction.WasmIntBinaryOperation;
+import org.teavm.backend.wasm.model.instruction.WasmIntType;
+import org.teavm.model.MethodReference;
+
+public class WasmTeeTypeGenerator implements WasmGCBodyIntrinsic {
+    private WasmGCCodeGenContext context;
+
+    public WasmTeeTypeGenerator(WasmGCCodeGenContext context) {
+        this.context = context;
+    }
+
+    @Override
+    public void apply(MethodReference method, WasmFunction function) {
+        if (!method.getName().equals("teeThenSuspend")) {
+            return;
+        }
+
+        var throwableType = context.classInfoProvider().getClassInfo("java.lang.Throwable").getType();
+        var wider = new WasmLocal(throwableType, "wider");
+        var sum = new WasmLocal(WasmType.INT32, "sum");
+        function.add(wider);
+        function.add(sum);
+
+        generate(function.getBody().builder(), wider, sum);
+    }
+
+    /*
+     * An IllegalStateException is tee'd into a java.lang.Throwable local, so what local.tee leaves
+     * on the stack is a Throwable. It is still there across the suspending call, which makes the
+     * coroutine transformation record its type and rebuild it into a block signature on resume.
+     */
+    private void generate(WasmInstructionBuilder builder, WasmLocal wider, WasmLocal sum) {
+        builder
+                .call(newErrorFn(), false)
+                .teeLocal(wider)
+                .i32Const(20)
+                .i32Const(25)
+                .call(sumFn(), true)
+                .setLocal(sum)
+                .call(lengthOfFn(), false)
+                .getLocal(sum)
+                .intBinary(WasmIntType.INT32, WasmIntBinaryOperation.ADD);
+    }
+
+    private WasmFunction sumFn() {
+        return context.functions().forStaticMethod(new MethodReference(WasmTeeTypeTest.class, "sum", int.class,
+                int.class, int.class));
+    }
+
+    private WasmFunction newErrorFn() {
+        return context.functions().forStaticMethod(new MethodReference(WasmTeeTypeTest.class, "newError",
+                IllegalStateException.class));
+    }
+
+    private WasmFunction lengthOfFn() {
+        return context.functions().forStaticMethod(new MethodReference(WasmTeeTypeTest.class, "lengthOf",
+                Throwable.class, int.class));
+    }
+}

--- a/tests/src/test/java/org/teavm/vm/WasmTeeTypeTest.java
+++ b/tests/src/test/java/org/teavm/vm/WasmTeeTypeTest.java
@@ -1,0 +1,69 @@
+/*
+ *  Copyright 2026 Alexey Andreev.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.teavm.vm;
+
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.teavm.interop.Async;
+import org.teavm.interop.AsyncCallback;
+import org.teavm.interop.Intrinsified;
+import org.teavm.interop.NativeAsync;
+import org.teavm.jso.browser.Window;
+import org.teavm.junit.EachTestCompiledSeparately;
+import org.teavm.junit.OnlyPlatform;
+import org.teavm.junit.SkipJVM;
+import org.teavm.junit.TeaVMTestRunner;
+import org.teavm.junit.TestPlatform;
+
+@RunWith(TeaVMTestRunner.class)
+@EachTestCompiledSeparately
+@OnlyPlatform(TestPlatform.WEBASSEMBLY_GC)
+@SkipJVM
+public class WasmTeeTypeTest {
+    /**
+     * local.tee yields the type of the local it writes, not the type of the value handed to it.
+     * Here a subclass value is tee'd into a local declared at the superclass and is still on the
+     * stack across a suspension point, so the coroutine transformation turns the recorded stack
+     * type into a block signature. Recording the value's type rather than the local's produced a
+     * label typed at the subclass with a superclass value branching to it.
+     */
+    @Test
+    public void suspendWithValueTeedIntoWiderLocal() {
+        // sum(20, 25) plus the length of "generated"
+        assertEquals(54, teeThenSuspend());
+    }
+
+    @Async
+    @NativeAsync
+    @Intrinsified
+    private static native int teeThenSuspend();
+
+    static IllegalStateException newError() {
+        return new IllegalStateException("generated");
+    }
+
+    static int lengthOf(Throwable t) {
+        return t.getMessage().length();
+    }
+
+    @Async
+    private static native int sum(int a, int b);
+
+    private static void sum(int a, int b, AsyncCallback<Integer> callback) {
+        Window.setTimeout(() -> callback.complete(a + b), 0);
+    }
+}

--- a/tests/src/test/java/org/teavm/vm/WasmTestPlugin.java
+++ b/tests/src/test/java/org/teavm/vm/WasmTestPlugin.java
@@ -27,9 +27,12 @@ public class WasmTestPlugin implements TeaVMPlugin {
         if (wasmGC != null) {
             wasmGC.contributeToCodeGen((context, registry) -> {
                 registry.bodyIntrinsics().registerIntrinsic(WasmAsyncTest.class, new WasmAsyncTestGenerator(context));
+                registry.bodyIntrinsics().registerIntrinsic(WasmTeeTypeTest.class,
+                        new WasmTeeTypeGenerator(context));
             });
         }
         host.add(gen);
+        host.add(new WasmTeeTypeDependency());
         host.add(new WasmTestClassTransformer());
     }
 }


### PR DESCRIPTION
The spec defines local.tee as local.set followed by local.get, so what stays on
the stack is the local's declared type. WasmTypeInference left the type of the
value instead. The two differ whenever a value is stored into a local declared at
a supertype, which register allocation produces routinely.

CoroutineTransformation reads that stack to build the block signature its resume
path branches to. A subclass type recorded for a superclass value gives a label
typed at the subclass with a superclass value branching to it: "type error in
branch[0] (expected (ref null 342), got (ref null 40))". Compiling the IntelliJ
platform reaches this in java.lang.System.getProperty, where java.util.Properties
is recorded for a java.util.Hashtable local.