### PR TITLE
Wasm GC: a flattened conditional leaves the type it declares

### DIFF
--- a/core/src/main/java/org/teavm/backend/wasm/transformation/CoroutineTransformation.java
+++ b/core/src/main/java/org/teavm/backend/wasm/transformation/CoroutineTransformation.java
@@ -329,6 +329,12 @@ public class CoroutineTransformation {
                 replacement.visit(wrapper);
             }
 
+            // Whichever arm was walked last left its own types on the stack, but what the wrapper
+            // block leaves behind is the type it is declared to produce. Recording the arm's types
+            // hands a later suspension point a narrower type than the value it will actually see.
+            typeInference.typeStack.clear();
+            typeInference.typeStack.addAll(outputTypes);
+
             conditional.insertPrevious(wrapper);
             conditional.delete();
         }

--- a/tests/src/test/java/org/teavm/vm/WasmFlattenedConditionalDependency.java
+++ b/tests/src/test/java/org/teavm/vm/WasmFlattenedConditionalDependency.java
@@ -1,0 +1,37 @@
+/*
+ *  Copyright 2026 Alexey Andreev.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.teavm.vm;
+
+import org.teavm.dependency.AbstractDependencyListener;
+import org.teavm.dependency.DependencyAgent;
+import org.teavm.dependency.MethodDependency;
+import org.teavm.model.MethodReference;
+
+public class WasmFlattenedConditionalDependency extends AbstractDependencyListener {
+    @Override
+    public void methodReached(DependencyAgent agent, MethodDependency method) {
+        if (method.getMethod().getName().equals("conditionalThenSuspend")) {
+            agent.linkMethod(new MethodReference(WasmFlattenedConditionalTest.class, "sum", int.class, int.class,
+                    int.class)).use();
+            agent.linkMethod(new MethodReference(WasmFlattenedConditionalTest.class, "newObject",
+                    Object.class)).use();
+            agent.linkMethod(new MethodReference(WasmFlattenedConditionalTest.class, "newString",
+                    String.class)).use();
+            agent.linkMethod(new MethodReference(WasmFlattenedConditionalTest.class, "tag", Object.class,
+                    int.class)).use();
+        }
+    }
+}

--- a/tests/src/test/java/org/teavm/vm/WasmFlattenedConditionalGenerator.java
+++ b/tests/src/test/java/org/teavm/vm/WasmFlattenedConditionalGenerator.java
@@ -1,0 +1,97 @@
+/*
+ *  Copyright 2026 Alexey Andreev.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.teavm.vm;
+
+import org.teavm.backend.wasm.intrinsics.WasmGCBodyIntrinsic;
+import org.teavm.backend.wasm.intrinsics.WasmGCCodeGenContext;
+import org.teavm.backend.wasm.model.WasmFunction;
+import org.teavm.backend.wasm.model.WasmLocal;
+import org.teavm.backend.wasm.model.WasmType;
+import org.teavm.backend.wasm.model.instruction.WasmInstructionBuilder;
+import org.teavm.backend.wasm.model.instruction.WasmIntBinaryOperation;
+import org.teavm.backend.wasm.model.instruction.WasmIntType;
+import org.teavm.model.MethodReference;
+
+public class WasmFlattenedConditionalGenerator implements WasmGCBodyIntrinsic {
+    private WasmGCCodeGenContext context;
+
+    public WasmFlattenedConditionalGenerator(WasmGCCodeGenContext context) {
+        this.context = context;
+    }
+
+    @Override
+    public void apply(MethodReference method, WasmFunction function) {
+        if (!method.getName().equals("conditionalThenSuspend")) {
+            return;
+        }
+
+        var param = new WasmLocal(WasmType.INT32, "n");
+        var sum = new WasmLocal(WasmType.INT32, "sum");
+        function.add(param);
+        function.add(sum);
+
+        generate(function.getBody().builder(), param, sum);
+    }
+
+    private void generate(WasmInstructionBuilder builder, WasmLocal param, WasmLocal sum) {
+        var objectType = context.classInfoProvider().getClassInfo("java.lang.Object").getType();
+
+        builder.getLocal(param);
+        var conditional = builder.conditional(objectType);
+
+        // the suspension point in here is what makes the transformation flatten the conditional
+        conditional.getThenBlock().builder()
+                .i32Const(1)
+                .i32Const(2)
+                .call(sumFn(), true)
+                .drop()
+                .call(newObjectFn(), false);
+
+        // the arm walked last, and the one that pushes a subclass of the declared Object
+        conditional.getElseBlock().builder()
+                .call(newStringFn(), false);
+
+        // a second suspension point with the conditional's value still beneath it on the stack
+        builder
+                .i32Const(3)
+                .i32Const(4)
+                .call(sumFn(), true)
+                .setLocal(sum)
+                .call(tagFn(), false)
+                .getLocal(sum)
+                .intBinary(WasmIntType.INT32, WasmIntBinaryOperation.ADD);
+    }
+
+    private WasmFunction sumFn() {
+        return context.functions().forStaticMethod(new MethodReference(WasmFlattenedConditionalTest.class, "sum",
+                int.class, int.class, int.class));
+    }
+
+    private WasmFunction newObjectFn() {
+        return context.functions().forStaticMethod(new MethodReference(WasmFlattenedConditionalTest.class,
+                "newObject", Object.class));
+    }
+
+    private WasmFunction newStringFn() {
+        return context.functions().forStaticMethod(new MethodReference(WasmFlattenedConditionalTest.class,
+                "newString", String.class));
+    }
+
+    private WasmFunction tagFn() {
+        return context.functions().forStaticMethod(new MethodReference(WasmFlattenedConditionalTest.class, "tag",
+                Object.class, int.class));
+    }
+}

--- a/tests/src/test/java/org/teavm/vm/WasmFlattenedConditionalTest.java
+++ b/tests/src/test/java/org/teavm/vm/WasmFlattenedConditionalTest.java
@@ -1,0 +1,73 @@
+/*
+ *  Copyright 2026 Alexey Andreev.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.teavm.vm;
+
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.teavm.interop.Async;
+import org.teavm.interop.AsyncCallback;
+import org.teavm.interop.Intrinsified;
+import org.teavm.interop.NativeAsync;
+import org.teavm.jso.browser.Window;
+import org.teavm.junit.EachTestCompiledSeparately;
+import org.teavm.junit.OnlyPlatform;
+import org.teavm.junit.SkipJVM;
+import org.teavm.junit.TeaVMTestRunner;
+import org.teavm.junit.TestPlatform;
+
+@RunWith(TeaVMTestRunner.class)
+@EachTestCompiledSeparately
+@OnlyPlatform(TestPlatform.WEBASSEMBLY_GC)
+@SkipJVM
+public class WasmFlattenedConditionalTest {
+    /**
+     * A conditional declared to produce Object, whose arms push different subclasses, is flattened
+     * away by the coroutine transformation because it contains a suspension point. What the block
+     * leaves on the stack is an Object; the arm walked last pushed a String. A second suspension
+     * point downstream turns whichever of the two was recorded into a block signature, so recording
+     * the arm's type gave a label typed at String with an Object branching to it.
+     */
+    @Test
+    public void suspendAfterFlattenedConditional() {
+        assertEquals(9, conditionalThenSuspend(1));
+        assertEquals(8, conditionalThenSuspend(0));
+    }
+
+    @Async
+    @NativeAsync
+    @Intrinsified
+    private static native int conditionalThenSuspend(int n);
+
+    static Object newObject() {
+        return new Object();
+    }
+
+    static String newString() {
+        return "s";
+    }
+
+    static int tag(Object o) {
+        return o instanceof String ? 1 : 2;
+    }
+
+    @Async
+    private static native int sum(int a, int b);
+
+    private static void sum(int a, int b, AsyncCallback<Integer> callback) {
+        Window.setTimeout(() -> callback.complete(a + b), 0);
+    }
+}

--- a/tests/src/test/java/org/teavm/vm/WasmTestPlugin.java
+++ b/tests/src/test/java/org/teavm/vm/WasmTestPlugin.java
@@ -27,9 +27,12 @@ public class WasmTestPlugin implements TeaVMPlugin {
         if (wasmGC != null) {
             wasmGC.contributeToCodeGen((context, registry) -> {
                 registry.bodyIntrinsics().registerIntrinsic(WasmAsyncTest.class, new WasmAsyncTestGenerator(context));
+                registry.bodyIntrinsics().registerIntrinsic(WasmFlattenedConditionalTest.class,
+                        new WasmFlattenedConditionalGenerator(context));
             });
         }
         host.add(gen);
+        host.add(new WasmFlattenedConditionalDependency());
         host.add(new WasmTestClassTransformer());
     }
 }


### PR DESCRIPTION
processOptimizedConditional replaces a conditional containing a suspension point
with a block, walking one arm and then the other with the same type inference, so
the recorded stack ends up holding whatever the arm walked last pushed. What the
emitted block actually leaves behind is its declared output type.

The two differ when the arms push different subtypes of the conditional's type:
the block is declared to produce Object, the else arm pushes a String, and String
is what gets recorded. A suspension point further down the same list turns that
stack into the block signature its resume path branches to, so the label ends up
typed at String while an Object reaches it: "type error in branch[1] (expected
(ref null 37), got (ref null 5))".