### PR TITLE
wasm gc: split the module initializer into separate functions

### DIFF
--- a/core/src/main/java/org/teavm/backend/wasm/generate/classes/WasmGCClassGenerator.java
+++ b/core/src/main/java/org/teavm/backend/wasm/generate/classes/WasmGCClassGenerator.java
@@ -48,7 +48,6 @@ import org.teavm.backend.wasm.model.WasmStructure;
 import org.teavm.backend.wasm.model.WasmType;
 import org.teavm.backend.wasm.model.instruction.WasmFunctionReference;
 import org.teavm.backend.wasm.model.instruction.WasmInstructionBuilder;
-import org.teavm.backend.wasm.model.instruction.WasmInstructionList;
 import org.teavm.backend.wasm.model.instruction.WasmNullCondition;
 import org.teavm.backend.wasm.model.instruction.WasmNullConstant;
 import org.teavm.backend.wasm.model.instruction.WasmSignedType;
@@ -113,7 +112,11 @@ public class WasmGCClassGenerator implements WasmGCClassInfoProvider, WasmGCInit
     private final ReflectionTypes reflectionTypes;
     public final WasmGCTypeMapper typeMapper;
     private final WasmGCNameProvider names;
-    private WasmInstructionBuilder initializerFunctionStatements = new WasmInstructionList().builder();
+    private static final int INIT_PART_INSTRUCTION_BUDGET = 4096;
+    private final List<WasmFunction> initializerParts = new ArrayList<>();
+    private WasmFunction currentInitializerPart;
+    private WasmInstructionBuilder currentInitializerPartBuilder;
+    private int currentInitializerPartSize;
     private WasmFunction createPrimitiveClassFunction;
     private WasmFunction getArrayClassFunction;
     private WasmFunction fillArrayClassFunction;
@@ -254,10 +257,25 @@ public class WasmGCClassGenerator implements WasmGCClassInfoProvider, WasmGCInit
     public void contributeToInitializerDefinitions(WasmFunction function) {
     }
 
+    private WasmInstructionBuilder initializerPartBuilder() {
+        if (currentInitializerPart == null || currentInitializerPartSize >= INIT_PART_INSTRUCTION_BUDGET) {
+            var part = new WasmFunction(functionTypes.of(null));
+            part.setName(names.topLevel("teavm@initClasses@part" + initializerParts.size()));
+            module.functions.add(part);
+            initializerParts.add(part);
+            currentInitializerPart = part;
+            currentInitializerPartBuilder = part.getBody().builder();
+            currentInitializerPartSize = 0;
+        }
+        return currentInitializerPartBuilder;
+    }
+
     @Override
     public void contributeToInitializer(WasmFunction function) {
         var builder = function.getBody().builder();
-        builder.transferFrom(initializerFunctionStatements);
+        for (var part : initializerParts) {
+            builder.call(part);
+        }
         var classInfoType = reflectionTypes.classInfo();
         for (var classInfo : classInfoMap.values()) {
             if (classInfo.supertypeFunction != null) {
@@ -300,8 +318,15 @@ public class WasmGCClassGenerator implements WasmGCClassInfoProvider, WasmGCInit
             var finalClassInfo = classInfo;
             queue.add(() -> {
                 if (finalClassInfo.initializer != null) {
-                    finalClassInfo.initializer.accept(initializerFunctionStatements);
+                    var builder = initializerPartBuilder();
+                    var lastBefore = currentInitializerPart.getBody().getLast();
+                    finalClassInfo.initializer.accept(builder);
                     finalClassInfo.initializer = null;
+                    var body = currentInitializerPart.getBody();
+                    for (var instruction = lastBefore == null ? body.getFirst() : lastBefore.getNext();
+                            instruction != null; instruction = instruction.getNext()) {
+                        ++currentInitializerPartSize;
+                    }
                 }
             });
             classInfoMap.put(type, classInfo);

--- a/core/src/main/java/org/teavm/backend/wasm/generate/strings/WasmGCStringPool.java
+++ b/core/src/main/java/org/teavm/backend/wasm/generate/strings/WasmGCStringPool.java
@@ -82,17 +82,25 @@ public class WasmGCStringPool implements WasmGCStringProvider, WasmGCInitializer
             body.call(internInit);
         }
         var stringIterator = stringMap.values().iterator();
+        var partIndex = 0;
         while (stringIterator.hasNext()) {
+            var part = new WasmFunction(functionTypes.of(null));
+            part.setName(names.topLevel("teavm@initStrings@part" + partIndex++));
+            module.functions.add(part);
+            var partBody = part.getBody().builder();
+
             var elementCount = 0;
             // WasmArrayNewFixed cannot be larger than 10000 elements
 
             while (elementCount < 10000 && stringIterator.hasNext()) {
-                body.getGlobal(stringIterator.next().global);
+                partBody.getGlobal(stringIterator.next().global);
                 ++elementCount;
             }
-            body
+            partBody
                     .arrayNewFixed(stringsArray, elementCount)
                     .call(initStringsFunction);
+
+            body.call(part);
         }
     }
 

--- a/core/src/main/java/org/teavm/backend/wasm/intrinsics/reflection/ReflectionMetadataGenerator.java
+++ b/core/src/main/java/org/teavm/backend/wasm/intrinsics/reflection/ReflectionMetadataGenerator.java
@@ -88,7 +88,11 @@ public class ReflectionMetadataGenerator {
     private Map<PrimitiveType, WasmFunction> writerConverters = new EnumMap<>(PrimitiveType.class);
     private WasmFunction referenceWriterConverter;
 
+    private static final int PART_INSTRUCTION_BUDGET = 6144;
     private WasmFunction initFunction;
+    private WasmFunction currentPart;
+    private int currentPartBudget;
+    private int partCount;
 
     public ReflectionMetadataGenerator(WasmGCNameProvider names, WasmModule module, WasmFunctionTypes functionTypes,
             DependencyInfo dependencies, ReflectionDependencyListener reflection, ListableClassReaderSource classes,
@@ -154,7 +158,19 @@ public class ReflectionMetadataGenerator {
             var metadata = generateClassMetadata(className, annotations, fields, methods, typeParameters,
                     innerClasses);
             if (metadata != null) {
-                var builder = initFunction.getBody().builder();
+                var size = 0;
+                for (var instruction : metadata) {
+                    ++size;
+                }
+                if (currentPart == null || currentPartBudget < size + 2) {
+                    currentPart = new WasmFunction(functionTypes.of(null));
+                    currentPart.setName(names.topLevel("teavm@initReflection@part" + partCount++));
+                    module.functions.add(currentPart);
+                    initFunction.getBody().builder().call(currentPart);
+                    currentPartBudget = PART_INSTRUCTION_BUDGET;
+                }
+                currentPartBudget -= size + 2;
+                var builder = currentPart.getBody().builder();
                 builder
                         .getGlobal(classInfoProvider.getClassInfo(className).getPointer())
                         .transferFrom(metadata.builder())


### PR DESCRIPTION
Large applications produce a start function that no engine will compile.

In the app I hit this with, class initialization, string pool initialization and reflection metadata are all appended into the module's start function, which grew to **3.7 MB of code in a single function** — 1,027,444 top-level instructions, 99.99% of the whole initializer. V8 then refuses to instantiate the module:

```
A single code object needs more than half of the code space size
```

which arrives as a SIGTRAP (exit 133) under Node and as a failed instantiation in Chromium. The threshold depends on the platform's code space, so the same module could still load on macOS while dying on Linux, which made it look like a memory problem for a while.

### Change

Each contributor now emits into its own functions and the initializer only calls them, in the same order as before:

* `WasmGCClassGenerator` → `teavm@initClasses@partN`
* `WasmGCStringPool` → `teavm@initStrings@partN`
* `ReflectionMetadataGenerator` → `teavm@initReflection@partN`

The split has to happen while the statements are produced, not by slicing the finished initializer afterwards: within a class, and within a string batch that pushes N values before consuming them with `array.new_fixed`, the statements push and consume values on the operand stack, so cutting at an arbitrary point leaves values behind and the module fails to validate with `expected 0 elements on the stack for fallthru`. A class (and a string batch) is the smallest self-contained unit, so parts are rotated on that boundary once the instruction budget is exceeded.

While here, `initializerFunctionStatements` is removed: nothing writes to it once class initializers go into parts, so the `transferFrom` was always transferring an empty list.

### Result

On the same application the largest function went from 3,768,336 bytes to 93,620 bytes and the module instantiates. Output is otherwise unchanged: same instructions, same order, one call indirection per part.

### Notes for review

* The budgets (4096 / 6144 instructions) only decide how many parts get produced; any value well below the engine limit works.
* Counting the instructions a class contributed means walking the list, because `WasmInstructionList` exposes only `isEmpty()`. If you would rather have a maintained `size` on the list, I am happy to do that instead.
* Small modules now also get one part function each. If you want the initializer to stay as-is below a threshold, that is a small addition.
* I did not add a test — reproducing it needs a module large enough to cross the engine limit. Suggestions welcome.
