### PR TITLE
model: use the full binary name for inner-class erasure in GenericValueType.asValueType

### DIFF
--- a/core/src/main/java/org/teavm/model/GenericValueType.java
+++ b/core/src/main/java/org/teavm/model/GenericValueType.java
@@ -224,7 +224,7 @@ public abstract class GenericValueType {
 
         @Override
         public ValueType asValueType() {
-            return arguments == null || arguments.length == 0 ? ValueType.object(className) : null;
+            return arguments == null || arguments.length == 0 ? ValueType.object(getFullClassName()) : null;
         }
 
         @Override

--- a/core/src/test/java/org/teavm/model/GenericValueTypeTest.java
+++ b/core/src/test/java/org/teavm/model/GenericValueTypeTest.java
@@ -1,0 +1,37 @@
+/*
+ *  Copyright 2026 thesupersupersigma.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.teavm.model;
+
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+public class GenericValueTypeTest {
+    @Test
+    public void innerClassErasureUsesFullName() {
+        var position = new GenericValueType.ParsePosition();
+        var type = GenericValueType.parse("Ljava/lang/ref/ReferenceQueue<TT;>.RemoveCallback;", position);
+        var objectType = (GenericValueType.Object) type;
+        assertEquals("java.lang.ref.ReferenceQueue$RemoveCallback", objectType.getFullClassName());
+        assertEquals(ValueType.object("java.lang.ref.ReferenceQueue$RemoveCallback"), objectType.asValueType());
+    }
+
+    @Test
+    public void topLevelErasureUnchanged() {
+        var position = new GenericValueType.ParsePosition();
+        var type = GenericValueType.parse("Ljava/lang/String;", position);
+        assertEquals(ValueType.object("java.lang.String"), ((GenericValueType.Object) type).asValueType());
+    }
+}


### PR DESCRIPTION
Fixes #1232.

`GenericValueType.Object.asValueType()` built the erasure from the segment-only `className`, so a chained inner type parsed from `Ljava/lang/ref/ReferenceQueue<TT;>.RemoveCallback;` erased to `ValueType.object("RemoveCallback")` — a class that does not exist. Downstream, `ClassReflectionInfoGenerator.generateGenericType`'s raw branch feeds that into `RenderingUtil.typeToClsString` → `appendClass`, which mints a fresh alias for the unknown name and emits reflection field metadata referencing an undefined identifier:

```js
["next", 0, jlr_ReferenceQueue$RemoveCallback, ..., {t: [6, RemoveCallback]}],
```

→ `ReferenceError: RemoveCallback is not defined` at script evaluation, before `main`.

The fix uses `getFullClassName()` (parent-aware binary name); the erasure of `Outer<X>.Inner` is `Outer$Inner`. Unit test covers the chained and the top-level case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
