### PR TITLE
reflection: link types referenced by accessible member metadata

### DIFF
--- a/core/src/main/java/org/teavm/reflection/ReflectionDependencyListener.java
+++ b/core/src/main/java/org/teavm/reflection/ReflectionDependencyListener.java
@@ -359,7 +359,7 @@ public class ReflectionDependencyListener extends AbstractDependencyListener {
                     ClassReader cls = agent.getClassSource().get(className);
                     if (cls != null) {
                         var skipPrivates = shouldSkipPrivates(cls);
-                        var reflectable = collectAccessibleMethods(className);
+                        var reflectable = collectAccessibleMethods(agent, className);
                         for (MethodReader reflectableMethod : cls.getMethods()) {
                             if (!reflectable.contains(reflectableMethod.getDescriptor())) {
                                 continue;
@@ -685,7 +685,7 @@ public class ReflectionDependencyListener extends AbstractDependencyListener {
                 return;
             }
 
-            Set<MethodDescriptor> accessibleMethods = collectAccessibleMethods(className);
+            Set<MethodDescriptor> accessibleMethods = collectAccessibleMethods(agent, className);
 
             var hasConstructors = false;
             for (MethodDescriptor methodDescriptor : accessibleMethods) {
@@ -755,7 +755,7 @@ public class ReflectionDependencyListener extends AbstractDependencyListener {
             }
 
             var className = ((ValueType.Object) reflectedType.getValueType()).getClassName();
-            Set<MethodDescriptor> accessibleMethods = collectAccessibleMethods(className);
+            Set<MethodDescriptor> accessibleMethods = collectAccessibleMethods(agent, className);
             ClassReader cls = agent.getClassSource().get(className);
             for (MethodDescriptor methodDescriptor : accessibleMethods) {
                 if (methodDescriptor.getName().equals("<init>")) {
@@ -1000,8 +1000,8 @@ public class ReflectionDependencyListener extends AbstractDependencyListener {
         return accessibleFieldCache.computeIfAbsent(className, key -> gatherAccessibleFields(agent, key));
     }
 
-    private Set<MethodDescriptor> collectAccessibleMethods(String className) {
-        return accessibleMethodCache.computeIfAbsent(className, this::gatherAccessibleMethods);
+    private Set<MethodDescriptor> collectAccessibleMethods(DependencyAgent agent, String className) {
+        return accessibleMethodCache.computeIfAbsent(className, key -> gatherAccessibleMethods(agent, key));
     }
 
     private Set<String> gatherAccessibleFields(DependencyAgent agent, String className) {
@@ -1010,15 +1010,44 @@ public class ReflectionDependencyListener extends AbstractDependencyListener {
         for (ReflectionSupplier supplier : reflectionSuppliers) {
             fields.addAll(supplier.getAccessibleFields(context, className));
         }
+        var cls = agent.getClassSource().get(className);
+        if (cls != null) {
+            for (var fieldName : fields) {
+                var field = cls.getField(fieldName);
+                if (field != null) {
+                    linkReflectedType(agent, field.getType());
+                }
+            }
+        }
         return fields;
     }
 
-    private Set<MethodDescriptor> gatherAccessibleMethods(String className) {
+    private Set<MethodDescriptor> gatherAccessibleMethods(DependencyAgent agent, String className) {
         Set<MethodDescriptor> methods = new LinkedHashSet<>();
         for (ReflectionSupplier supplier : reflectionSuppliers) {
             methods.addAll(supplier.getAccessibleMethods(reflectionContext, className));
         }
+        for (var descriptor : methods) {
+            for (var i = 0; i < descriptor.parameterCount(); ++i) {
+                linkReflectedType(agent, descriptor.parameterType(i));
+            }
+            linkReflectedType(agent, descriptor.getResultType());
+        }
         return methods;
+    }
+
+    /**
+     * Reflection metadata references a member's parameter, result and field types by
+     * their emitted aliases; a type that appears only in such a signature would otherwise
+     * never be emitted, leaving an undefined identifier in the output.
+     */
+    private void linkReflectedType(DependencyAgent agent, ValueType type) {
+        while (type instanceof ValueType.Array) {
+            type = ((ValueType.Array) type).getItemType();
+        }
+        if (type instanceof ValueType.Object) {
+            agent.linkClass(((ValueType.Object) type).getClassName());
+        }
     }
 
     private void propagateGet(DependencyAgent agent, ValueType type, DependencyNode sourceNode,


### PR DESCRIPTION
Fixes #1237.

`ReflectionDependencyListener` links granted members but never the classes their signatures mention, so metadata like

```js
["<init>", 1, $rt_voidcls, [jl_ThreadGroup, jl_Runnable, jl_String], jl_Thread__init_3]
```

references `jl_ThreadGroup` without any definition when nothing else in the program uses `ThreadGroup` — `ReferenceError` at script evaluation. Same family as #1210/#1232: reflection metadata pointing at entities absent from the output.

This links the object base of each accessible member's parameter types, result type and field type inside `gatherAccessibleFields`/`gatherAccessibleMethods` — the cached choke point every enumeration and access path funnels through — so the referenced classes exist in the output even when reflection metadata is their only user.

Reproduced with a blanket ReflectionSupplier over a small app (any granted constructor with a parameter type that is otherwise unused); verified against a large obfuscated app where the blanket grant previously produced an unparseable bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
