### PR TITLE
wasm gc: keep the shared reference writer converter type-agnostic

### DIFF
--- a/core/src/main/java/org/teavm/backend/wasm/intrinsics/reflection/ReflectionMetadataGenerator.java
+++ b/core/src/main/java/org/teavm/backend/wasm/intrinsics/reflection/ReflectionMetadataGenerator.java
@@ -851,9 +851,13 @@ public class ReflectionMetadataGenerator {
         function.add(boxedValueVar);
 
         var body = function.getBody().builder();
-        // Push obj, then unbox the value to get the raw primitive (or cast for reference types)
+        // Push obj, then unbox the value to get the raw primitive. Reference values are passed
+        // as Object: this converter is shared by all reference fields, and the setter itself
+        // casts to the field type.
         body.getLocal(objVar).getLocal(boxedValueVar);
-        unboxIfNecessary(body, fieldType);
+        if (fieldType instanceof ValueType.Primitive) {
+            unboxIfNecessary(body, fieldType);
+        }
         // Cast the raw writer funcref to the specific typed function, then call it
         body.getLocal(rawWriterVar)
                 .cast(typedWriterType.getReference())

--- a/tests/src/test/java/org/teavm/classlib/java/lang/reflect/FieldTest.java
+++ b/tests/src/test/java/org/teavm/classlib/java/lang/reflect/FieldTest.java
@@ -158,6 +158,15 @@ public class FieldTest {
     }
 
     @Test
+    public void setReferenceFieldsOfDifferentTypes() throws Exception {
+        var instance = new TwoReferenceFields();
+        TwoReferenceFields.class.getDeclaredField("first").set(instance, "foo");
+        TwoReferenceFields.class.getDeclaredField("second").set(instance, new StringBuilder("bar"));
+        assertEquals("foo", instance.first);
+        assertEquals("bar", instance.second.toString());
+    }
+
+    @Test
     public void primitiveGetters() throws Exception {
         var instance = new PrimitiveHolder();
         assertEquals(true, PrimitiveHolder.class.getDeclaredField("z").getBoolean(instance));
@@ -297,6 +306,11 @@ public class FieldTest {
         public static String foo;
     }
     
+    static class TwoReferenceFields {
+        @Reflectable String first;
+        @Reflectable StringBuilder second;
+    }
+
     static class PrimitiveHolder {
         @Reflectable boolean z = true;
         @Reflectable byte by = 42;


### PR DESCRIPTION
Disclaimer: PR created with Claude Fable 5's help.

Reflectively setting fields of two different reference types in the same program fails on the
Wasm GC backend. `ReflectionMetadataGenerator` generates the writer converter for reference
fields once and reuses it for every reference field, but its body casts the incoming value to
the field type of whichever field it was generated for first. Setting any other reference field
then traps:

```
RuntimeError: illegal cast
    at teavm@writerConverter_reference
```

The raw setter generated per field already casts the value to its own field's type, so the
shared converter does not need to narrow at all: this change makes it pass reference values
through as `Object` and only unbox primitives.

The new `FieldTest.setReferenceFieldsOfDifferentTypes` sets a `String` field and then a
`StringBuilder` field through `java.lang.reflect.Field`; without the fix it fails with the trap
above, with the fix it passes. Ran `FieldTest` on the JS and Wasm GC backends and
`checkstyleMain`/`checkstyleTest`.