### PR TITLE
wasm gc: type inference leaves local.tee at the local's type

### DIFF
--- a/core/src/main/java/org/teavm/backend/wasm/model/instruction/WasmTypeInference.java
+++ b/core/src/main/java/org/teavm/backend/wasm/model/instruction/WasmTypeInference.java
@@ -151,6 +151,10 @@ public class WasmTypeInference implements WasmInstructionVisitor {
     @Override
     public void visit(WasmTeeLocal instruction) {
         depthBeforeLastInstructionOut = typeStack.size() - 1;
+        if (!typeStack.isEmpty()) {
+            // local.tee leaves the value typed as the local, not as whatever was stored into it
+            typeStack.set(typeStack.size() - 1, instruction.getLocal().getType());
+        }
     }
 
     @Override

--- a/tests/src/test/java/org/teavm/vm/WasmTeeLocalDependency.java
+++ b/tests/src/test/java/org/teavm/vm/WasmTeeLocalDependency.java
@@ -1,0 +1,34 @@
+/*
+ *  Copyright 2026 Alexey Andreev.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.teavm.vm;
+
+import org.teavm.dependency.AbstractDependencyListener;
+import org.teavm.dependency.DependencyAgent;
+import org.teavm.dependency.MethodDependency;
+import org.teavm.model.MethodReference;
+
+public class WasmTeeLocalDependency extends AbstractDependencyListener {
+    @Override
+    public void methodReached(DependencyAgent agent, MethodDependency method) {
+        if (method.getMethod().getName().equals("teeThenSuspend")) {
+            agent.linkMethod(new MethodReference(WasmTeeLocalTest.class, "sum", int.class, int.class,
+                    int.class)).use();
+            agent.linkMethod(new MethodReference(WasmTeeLocalTest.class, "newString", String.class)).use();
+            agent.linkMethod(new MethodReference(WasmTeeLocalTest.class, "tag", Object.class,
+                    int.class)).use();
+        }
+    }
+}

--- a/tests/src/test/java/org/teavm/vm/WasmTeeLocalGenerator.java
+++ b/tests/src/test/java/org/teavm/vm/WasmTeeLocalGenerator.java
@@ -1,0 +1,79 @@
+/*
+ *  Copyright 2026 Alexey Andreev.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.teavm.vm;
+
+import org.teavm.backend.wasm.intrinsics.WasmGCBodyIntrinsic;
+import org.teavm.backend.wasm.intrinsics.WasmGCCodeGenContext;
+import org.teavm.backend.wasm.model.WasmFunction;
+import org.teavm.backend.wasm.model.WasmLocal;
+import org.teavm.backend.wasm.model.WasmType;
+import org.teavm.backend.wasm.model.instruction.WasmInstructionBuilder;
+import org.teavm.backend.wasm.model.instruction.WasmIntBinaryOperation;
+import org.teavm.backend.wasm.model.instruction.WasmIntType;
+import org.teavm.model.MethodReference;
+
+public class WasmTeeLocalGenerator implements WasmGCBodyIntrinsic {
+    private WasmGCCodeGenContext context;
+
+    public WasmTeeLocalGenerator(WasmGCCodeGenContext context) {
+        this.context = context;
+    }
+
+    @Override
+    public void apply(MethodReference method, WasmFunction function) {
+        if (!method.getName().equals("teeThenSuspend")) {
+            return;
+        }
+
+        var param = new WasmLocal(WasmType.INT32, "n");
+        var obj = new WasmLocal(context.classInfoProvider().getClassInfo("java.lang.Object").getType(), "obj");
+        function.add(param);
+        function.add(obj);
+
+        generate(function.getBody().builder(), obj);
+    }
+
+    private void generate(WasmInstructionBuilder builder, WasmLocal obj) {
+        // a String teed into an Object local stays on the stack at the local's type across the
+        // suspension point, so the snapshot taken there must record the local's type
+        builder
+                .call(newStringFn(), false)
+                .teeLocal(obj)
+                .i32Const(1)
+                .i32Const(2)
+                .call(sumFn(), true)
+                .drop()
+                .call(tagFn(), false)
+                .getLocal(obj)
+                .call(tagFn(), false)
+                .intBinary(WasmIntType.INT32, WasmIntBinaryOperation.ADD);
+    }
+
+    private WasmFunction sumFn() {
+        return context.functions().forStaticMethod(new MethodReference(WasmTeeLocalTest.class, "sum",
+                int.class, int.class, int.class));
+    }
+
+    private WasmFunction newStringFn() {
+        return context.functions().forStaticMethod(new MethodReference(WasmTeeLocalTest.class,
+                "newString", String.class));
+    }
+
+    private WasmFunction tagFn() {
+        return context.functions().forStaticMethod(new MethodReference(WasmTeeLocalTest.class, "tag",
+                Object.class, int.class));
+    }
+}

--- a/tests/src/test/java/org/teavm/vm/WasmTeeLocalTest.java
+++ b/tests/src/test/java/org/teavm/vm/WasmTeeLocalTest.java
@@ -1,0 +1,69 @@
+/*
+ *  Copyright 2026 Alexey Andreev.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.teavm.vm;
+
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.teavm.interop.Async;
+import org.teavm.interop.AsyncCallback;
+import org.teavm.interop.Intrinsified;
+import org.teavm.interop.NativeAsync;
+import org.teavm.jso.browser.Window;
+import org.teavm.junit.EachTestCompiledSeparately;
+import org.teavm.junit.OnlyPlatform;
+import org.teavm.junit.SkipJVM;
+import org.teavm.junit.TeaVMTestRunner;
+import org.teavm.junit.TestPlatform;
+
+@RunWith(TeaVMTestRunner.class)
+@EachTestCompiledSeparately
+@OnlyPlatform(TestPlatform.WEBASSEMBLY_GC)
+@SkipJVM
+public class WasmTeeLocalTest {
+    /**
+     * local.tee leaves a value typed as the local's declared type, not as the type of the value
+     * that was stored. When a String is teed into an Object local and a suspension point follows
+     * while the value is still on the stack, recording the value's own type gives the restore
+     * block a signature narrower than what the running code leaves there, so the branch over the
+     * restore path fails to validate: "type error in branch[0] (expected (ref null String),
+     * got (ref null Object))".
+     */
+    @Test
+    public void suspendOverTeeToWiderLocal() {
+        assertEquals(2, teeThenSuspend(0));
+    }
+
+    @Async
+    @NativeAsync
+    @Intrinsified
+    private static native int teeThenSuspend(int n);
+
+    static String newString() {
+        return "s";
+    }
+
+    static int tag(Object o) {
+        return o instanceof String ? 1 : 2;
+    }
+
+    @Async
+    private static native int sum(int a, int b);
+
+    private static void sum(int a, int b, AsyncCallback<Integer> callback) {
+        Window.setTimeout(() -> callback.complete(a + b), 0);
+    }
+}

--- a/tests/src/test/java/org/teavm/vm/WasmTestPlugin.java
+++ b/tests/src/test/java/org/teavm/vm/WasmTestPlugin.java
@@ -27,9 +27,12 @@ public class WasmTestPlugin implements TeaVMPlugin {
         if (wasmGC != null) {
             wasmGC.contributeToCodeGen((context, registry) -> {
                 registry.bodyIntrinsics().registerIntrinsic(WasmAsyncTest.class, new WasmAsyncTestGenerator(context));
+                registry.bodyIntrinsics().registerIntrinsic(WasmTeeLocalTest.class,
+                        new WasmTeeLocalGenerator(context));
             });
         }
         host.add(gen);
+        host.add(new WasmTeeLocalDependency());
         host.add(new WasmTestClassTransformer());
     }
 }


### PR DESCRIPTION
`WasmTypeInference` keeps the type of the stored value on its stack after a `local.tee`, but
validation types the instruction's result as the local's declared type. When a value of a
narrower type is teed into a wider local (a `String` into an `Object` local) and stays on the
stack across a suspension point, the coroutine transformation snapshots the narrower type into
the signature of the restore block, and the branch the normal path takes across it then carries
the wider type:

```
CompileError: WebAssembly.compileStreaming(): Compiling function
"...::teeThenSuspend" failed: type error in branch[0]
(expected (ref null $java.lang.String), got (ref null $java.lang.Object))
```

This change makes the inference set the stack top to the local's type, matching validation.

The test follows the pattern of `WasmAsyncTest`: a generated body tees a `String` into an
`Object` local, keeps the value on the stack across a suspending call, and consumes it
afterwards. Without the fix the module fails validation with the error above; with it, the test
passes and the value survives suspend/restore. Ran the `org.teavm.vm.*` and `org.teavm.jso.*`
suites on Wasm GC and `checkstyleMain`/`checkstyleTest`.