### PR TITLE
wasm gc: don't cache reflection call arguments in a non-defaultable local

### DIFF
--- a/core/src/main/java/org/teavm/backend/wasm/intrinsics/reflection/ReflectionMetadataGenerator.java
+++ b/core/src/main/java/org/teavm/backend/wasm/intrinsics/reflection/ReflectionMetadataGenerator.java
@@ -884,7 +884,8 @@ public class ReflectionMetadataGenerator {
         function.add(thisVar);
         var argsVar = new WasmLocal(objectArrayClass.getType(), "args");
         function.add(argsVar);
-        var argsDataVar = new WasmLocal(dataField.getUnpackedType(), "argsData");
+        var argsDataVar = new WasmLocal(((WasmType.Reference) dataField.getUnpackedType()).asNullable(),
+                "argsData");
         var body = function.getBody().builder();
         var args = new WasmInstructionList().builder();
 

--- a/tests/src/test/java/org/teavm/classlib/java/lang/reflect/MethodTest.java
+++ b/tests/src/test/java/org/teavm/classlib/java/lang/reflect/MethodTest.java
@@ -281,6 +281,14 @@ public class MethodTest {
         assertEquals(25, result);
     }
 
+    @Test
+    @SkipPlatform(TestPlatform.C)
+    public void asyncReflectionWithSeveralParameters() throws Exception {
+        var method = ClassWithAsyncMethodWithSeveralParameters.class.getMethod("foo", int.class, int.class);
+        var result = method.invoke(null, 23, 42);
+        assertEquals(67, result);
+    }
+
     private void callMethods() {
         new Foo().bar(null);
         new Foo().baz();
@@ -529,6 +537,17 @@ public class MethodTest {
             Thread.sleep(1);
             ++x;
             return x;
+        }
+    }
+
+    static class ClassWithAsyncMethodWithSeveralParameters {
+        @Reflectable
+        public static int foo(int x, int y) throws InterruptedException {
+            Thread.sleep(1);
+            ++x;
+            Thread.sleep(1);
+            ++y;
+            return x + y;
         }
     }
 }


### PR DESCRIPTION
Compiling a program that reflectively invokes a member with more than one parameter, where
that member is suspendable, produces a module that fails WebAssembly validation:

```
CompileError: WebAssembly.compileStreaming(): Compiling function #2994:
"com.badlogic.gdx.scenes.scene2d.ui.SplitPane::<..." failed:
uninitialized non-defaultable local: 2 @+845479
```

The caller functions generated for reflective invocation cache the argument array's data
field in a local when the target member has more than one parameter. That local is
non-defaultable, and when the target method is suspendable the caller goes through the
coroutine transformation, which restores locals inside the resume arm of a conditional — a
non-defaultable local's initialization status does not survive the end of the block that
assigned it.

Regular method bodies already avoid this: `WasmGCMethodGenerator` disables non-nullable
locals for suspendable methods. `generateCaller` builds its wasm body directly and bypasses
that guard. This PR reads the argument array through the (always initialized) `args`
parameter at each use instead of caching it; the cost is one extra `struct.get` per argument
in reflective calls. The coroutine transformation itself is unchanged.

The test is an ordinary reflective call — a `@Reflectable` two-parameter method that sleeps,
invoked via `Method.invoke` — and fails on current master with:

```
CompileError: WebAssembly.compileStreaming(): Compiling function #153:
"org.teavm.vm.WasmAsyncTest$ReflectiveTarget::co..." failed:
uninitialized non-defaultable local: 2
```

End-to-end reproduction with a libGDX game:
https://github.com/lucas-viva/gdx-teavm-1246-repro