### PR TITLE
Fix Character.toTitleCase mappings and identity

### DIFF
--- a/classlib/src/main/java/org/teavm/classlib/java/lang/TCharacter.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/lang/TCharacter.java
@@ -279,11 +279,12 @@ public class TCharacter extends TObject implements TComparable<TCharacter> {
     private static native StringResource acquireUpperCaseMapping();
 
     public static int toTitleCase(int codePoint) {
-        codePoint = mapChar(getTitleCaseMapping(), codePoint);
-        if (codePoint == codePoint) {
-            codePoint = toUpperCase(codePoint);
+        if (!isValidCodePoint(codePoint) || isTitleCase(codePoint)) {
+            return codePoint;
         }
-        return codePoint;
+        // TeaVM stores only title-case mappings that differ from uppercase.
+        int titleCase = mapChar(getTitleCaseMapping(), codePoint);
+        return titleCase != codePoint ? titleCase : toUpperCase(codePoint);
     }
 
     public static char toTitleCase(char c) {

--- a/tests/src/test/java/org/teavm/classlib/java/lang/CharacterTest.java
+++ b/tests/src/test/java/org/teavm/classlib/java/lang/CharacterTest.java
@@ -24,6 +24,29 @@ import org.teavm.junit.TeaVMTestRunner;
 @RunWith(TeaVMTestRunner.class)
 public class CharacterTest {
     @Test
+    public void titleCasePreservesDedicatedMappings() {
+        assertEquals(0x01F2, Character.toTitleCase(0x01F3));
+        assertEquals(0x01F2, Character.toTitleCase(0x01F1));
+        assertEquals(0x01F2, Character.toTitleCase(0x01F2));
+        assertEquals('\u01F2', Character.toTitleCase('\u01F3'));
+        assertEquals('\u01F2', Character.toTitleCase('\u01F2'));
+    }
+
+    @Test
+    public void titleCaseFallsBackToUppercase() {
+        assertEquals('A', Character.toTitleCase('a'));
+        assertEquals('A', Character.toTitleCase('A'));
+        assertEquals('1', Character.toTitleCase('1'));
+        assertEquals(0x10400, Character.toTitleCase(0x10428));
+    }
+
+    @Test
+    public void titleCasePreservesInvalidCodePoints() {
+        assertEquals(-1, Character.toTitleCase(-1));
+        assertEquals(0x110000, Character.toTitleCase(0x110000));
+    }
+
+    @Test
     public void digitsRecognized() {
         assertEquals(2, Character.digit('2', 10));
         assertEquals(-1, Character.digit('.', 10));


### PR DESCRIPTION
Hi! I came across a small issue in `Character.toTitleCase()` while checking Unicode handling in a project using TeaVM.

The method compares the mapped code point with itself, so it always takes the uppercase fallback. For example, `ǳ` becomes `Ǳ` rather than its title-case form, `ǲ`.

This fix preserves dedicated title-case mappings and characters already in title case, while keeping the usual uppercase fallback for ordinary letters. Invalid code points are returned unchanged, matching the Java API.

I've added regression coverage for both overloads, ordinary letters, supplementary characters and invalid inputs. All 12 Character tests and Checkstyle pass.

Validation used the JavaScript backend; Wasm GC, C and optimized variants were disabled for this focused run:

```sh
./gradlew :tests:test --tests org.teavm.classlib.java.lang.CharacterTest :classlib:checkstyleMain :tests:checkstyleTest -Pteavm.tests.js=true -Pteavm.tests.wasm-gc=false -Pteavm.tests.c=false -Pteavm.tests.optimized=false
```

Thanks for all your work on TeaVM - hoping to contribute a few useful libraries to the TeaVM ecosystem soon.
