### PR TITLE
Initialise suppressed exceptions in Throwable constructors

### DIFF
--- a/classlib/src/main/java/org/teavm/classlib/java/lang/TThrowable.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/lang/TThrowable.java
@@ -38,7 +38,7 @@ public class TThrowable extends RuntimeException {
     private TThrowable cause;
     private boolean suppressionEnabled;
     private boolean writableStackTrace;
-    private TThrowable[] suppressed = new TThrowable[0];
+    private TThrowable[] suppressed;
     private TStackTraceElement[] stackTrace;
     private LazyStackSupplier lazyStackTrace;
 
@@ -49,6 +49,7 @@ public class TThrowable extends RuntimeException {
 
     @Rename("<init>")
     public void init(String message, TThrowable cause, boolean enableSuppression, boolean writableStackTrace) {
+        suppressed = new TThrowable[0];
         initNativeException();
         if (writableStackTrace) {
             fillInStackTrace();
@@ -65,6 +66,7 @@ public class TThrowable extends RuntimeException {
 
     @Rename("<init>")
     private void init() {
+        suppressed = new TThrowable[0];
         initNativeException();
         this.suppressionEnabled = true;
         this.writableStackTrace = true;
@@ -77,6 +79,7 @@ public class TThrowable extends RuntimeException {
 
     @Rename("<init>")
     private void init(String message) {
+        suppressed = new TThrowable[0];
         initNativeException();
         this.suppressionEnabled = true;
         this.writableStackTrace = true;
@@ -91,6 +94,7 @@ public class TThrowable extends RuntimeException {
 
     @Rename("<init>")
     private void init(String message, TThrowable cause) {
+        suppressed = new TThrowable[0];
         initNativeException();
         this.suppressionEnabled = true;
         this.writableStackTrace = true;
@@ -106,6 +110,7 @@ public class TThrowable extends RuntimeException {
 
     @Rename("<init>")
     private void init(TThrowable cause) {
+        suppressed = new TThrowable[0];
         initNativeException();
         this.suppressionEnabled = true;
         this.writableStackTrace = true;

--- a/tests/src/test/java/org/teavm/classlib/java/lang/ThrowableTest.java
+++ b/tests/src/test/java/org/teavm/classlib/java/lang/ThrowableTest.java
@@ -16,6 +16,7 @@
 package org.teavm.classlib.java.lang;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -36,5 +37,74 @@ public class ThrowableTest {
     public void toStringWorks() {
         assertEquals("java.lang.RuntimeException: fail", new RuntimeException("fail").toString());
         assertEquals("java.lang.RuntimeException", new RuntimeException().toString());
+    }
+
+    @Test
+    public void suppressedExceptionsInitiallyEmpty() {
+        for (Throwable exception : createThrowables()) {
+            assertEquals(0, exception.getSuppressed().length);
+        }
+    }
+
+    @Test
+    public void suppressedExceptionsRetained() {
+        Throwable first = new Throwable("first");
+        Throwable second = new Throwable("second");
+        for (Throwable exception : createThrowables()) {
+            exception.addSuppressed(first);
+            exception.addSuppressed(second);
+            assertEquals(2, exception.getSuppressed().length);
+            assertSame(first, exception.getSuppressed()[0]);
+            assertSame(second, exception.getSuppressed()[1]);
+        }
+    }
+
+    @Test
+    public void suppressedExceptionsReturnedAsCopy() {
+        Throwable exception = new Throwable();
+        Throwable suppressed = new Throwable("suppressed");
+        exception.addSuppressed(suppressed);
+        exception.getSuppressed()[0] = null;
+        assertSame(suppressed, exception.getSuppressed()[0]);
+    }
+
+    @Test
+    public void suppressionCanBeDisabled() {
+        for (boolean writableStackTrace : new boolean[] {false, true}) {
+            Throwable exception = new ConfigurableThrowable(false, writableStackTrace);
+            assertEquals(0, exception.getSuppressed().length);
+            exception.addSuppressed(new Throwable("ignored"));
+            assertEquals(0, exception.getSuppressed().length);
+        }
+    }
+
+    @Test
+    public void tryWithResourcesRetainsCloseFailure() {
+        RuntimeException primary = new RuntimeException("primary");
+        RuntimeException secondary = new RuntimeException("close");
+        try (AutoCloseable resource = () -> {
+            throw secondary;
+        }) {
+            throw primary;
+        } catch (Exception exception) {
+            assertSame(primary, exception);
+            assertEquals(1, exception.getSuppressed().length);
+            assertSame(secondary, exception.getSuppressed()[0]);
+        }
+    }
+
+    private Throwable[] createThrowables() {
+        Throwable cause = new Throwable("cause");
+        return new Throwable[] {
+                new Throwable(), new Throwable("message"), new Throwable(cause),
+                new Throwable("message", cause), new ConfigurableThrowable(true, true),
+                new ConfigurableThrowable(true, false)
+        };
+    }
+
+    private static class ConfigurableThrowable extends Throwable {
+        ConfigurableThrowable(boolean enableSuppression, boolean writableStackTrace) {
+            super("configured", null, enableSuppression, writableStackTrace);
+        }
     }
 }


### PR DESCRIPTION
We encountered this when working with an `UmbrellaException` that retained multiple
exceptions.

We think `TThrowable.suppressed` is left uninitialised when the replacement
constructors annotated with `@Rename("<init>")` run: its field initialiser appears
to belong to the constructors renamed to `fakeInit`. Consequently,
`addSuppressed()` and even `getSuppressed()` on a new exception can throw a
`NullPointerException`.

Reproduce with:

```java
Throwable failure = new Throwable("primary");
failure.addSuppressed(new Throwable("secondary"));
assertEquals(1, failure.getSuppressed().length);
```

This change moves the array initialisation into every replacement
constructor. Regression tests cover the constructor variants, enabled/disabled
suppression, retained exception identity, defensive copies and failures from
`try`-with-resources.

Our downstream workaround is a small TeaVM compiler plugin that inserts the
missing initialisation during compilation. Fixing this in the class library would
let us remove that workaround when adopting a TeaVM release containing the fix.

Validation: the five new regression tests fail on the unmodified JavaScript
backend. With the fix, all seven `ThrowableTest` tests pass on JavaScript and
Wasm GC, including optimised runs. Class-library and test Checkstyle checks pass.

Thanks again for your work on TeaVM and for reviewing our contributions.
