### PR TITLE
Support JUnit TestRule in compiled TeaVM tests

### DIFF
--- a/classlib/src/main/java/org/teavm/classlib/java/util/concurrent/TConcurrentLinkedQueue.java
+++ b/classlib/src/main/java/org/teavm/classlib/java/util/concurrent/TConcurrentLinkedQueue.java
@@ -1,0 +1,132 @@
+/*
+ *  Copyright 2026 Carl Stainton.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.teavm.classlib.java.util.concurrent;
+
+import org.teavm.classlib.java.io.TSerializable;
+import org.teavm.classlib.java.lang.TNullPointerException;
+import org.teavm.classlib.java.util.TAbstractQueue;
+import org.teavm.classlib.java.util.TArrayDeque;
+import org.teavm.classlib.java.util.TCollection;
+import org.teavm.classlib.java.util.TIterator;
+import org.teavm.classlib.java.util.TQueue;
+
+/**
+ * A first-in, first-out queue for code compiled by TeaVM in a single-threaded runtime.
+ *
+ * <p>This class supplies TeaVM's implementation of {@link java.util.concurrent.ConcurrentLinkedQueue}
+ * in the class library. Use the standard Java queue type in application and test code rather
+ * than this class directly.
+ *
+ * <p>Elements are added at the tail and read or removed from the head. The queue grows as needed
+ * and does not accept {@code null} elements. Reading or polling an empty queue returns {@code null}.
+ *
+ * <p>The backing storage is a {@link TArrayDeque}. Despite the standard Java type's name, this
+ * implementation does not provide thread safety or its weakly consistent iterator behaviour.
+ * Use it only where access is single-threaded, such as the browser test runner.
+ *
+ * @param <E> the type of elements held in the queue
+ */
+public class TConcurrentLinkedQueue<E> extends TAbstractQueue<E> implements TQueue<E>, TSerializable {
+    private final TArrayDeque<E> elements = new TArrayDeque<>();
+
+    /** Creates an empty queue. */
+    public TConcurrentLinkedQueue() {
+    }
+
+    /**
+     * Creates a queue by copying the supplied collection in iteration order.
+     *
+     * <p>The first element returned by the collection's iterator becomes the queue's head.
+     * Later changes to the collection do not change the queue.
+     *
+     * @param c the collection to copy; neither the collection nor its elements may be {@code null}
+     * @throws NullPointerException if the collection is {@code null}
+     * @throws TNullPointerException if the collection contains a {@code null} element
+     */
+    public TConcurrentLinkedQueue(TCollection<? extends E> c) {
+        for (TIterator<? extends E> iterator = c.iterator(); iterator.hasNext();) {
+            offer(iterator.next());
+        }
+    }
+
+    /**
+     * Adds an element at the tail of the queue.
+     *
+     * @param e the non-null element to add
+     * @return {@code true} when the element has been added
+     * @throws TNullPointerException if the element is {@code null}
+     */
+    @Override
+    public boolean offer(E e) {
+        if (e == null) {
+            throw new TNullPointerException();
+        }
+        return elements.offer(e);
+    }
+
+    /**
+     * Removes and returns the element at the head of the queue.
+     *
+     * @return the oldest queued element, or {@code null} if the queue is empty
+     */
+    @Override
+    public E poll() {
+        return elements.poll();
+    }
+
+    /**
+     * Returns the element at the head without removing it.
+     *
+     * @return the oldest queued element, or {@code null} if the queue is empty
+     */
+    @Override
+    public E peek() {
+        return elements.peek();
+    }
+
+    /**
+     * Returns an iterator over the elements from head to tail.
+     *
+     * <p>This is the backing deque's iterator, not a snapshot or a weakly consistent iterator.
+     * Do not change the queue while traversing it except through the iterator's own remove method.
+     *
+     * @return an iterator in queue order
+     */
+    @Override
+    public TIterator<E> iterator() {
+        return elements.iterator();
+    }
+
+    /**
+     * Returns the number of elements currently in the queue.
+     *
+     * @return the element count, or zero if the queue is empty
+     */
+    @Override
+    public int size() {
+        return elements.size();
+    }
+
+    /**
+     * Reports whether the queue contains no elements.
+     *
+     * @return {@code true} if the queue is empty
+     */
+    @Override
+    public boolean isEmpty() {
+        return elements.isEmpty();
+    }
+}

--- a/tests/src/test/java/org/teavm/classlib/java/util/concurrent/ConcurrentLinkedQueueTest.java
+++ b/tests/src/test/java/org/teavm/classlib/java/util/concurrent/ConcurrentLinkedQueueTest.java
@@ -1,0 +1,149 @@
+/*
+ *  Copyright 2026 Carl Stainton.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.teavm.classlib.java.util.concurrent;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.teavm.junit.TeaVMTestRunner;
+
+/** Single-threaded queue operations, checked against the JVM and TeaVM implementations. */
+@RunWith(TeaVMTestRunner.class)
+public class ConcurrentLinkedQueueTest {
+    @Test
+    public void emptyQueue() {
+        var queue = new ConcurrentLinkedQueue<String>();
+        assertTrue(queue.isEmpty());
+        assertEquals(0, queue.size());
+        assertNull(queue.peek());
+        assertNull(queue.poll());
+        assertFalse(queue.iterator().hasNext());
+    }
+
+    @Test
+    public void retainsInsertionOrderAndDuplicates() {
+        var queue = new ConcurrentLinkedQueue<String>();
+        assertTrue(queue.offer("first"));
+        assertTrue(queue.offer("second"));
+        assertTrue(queue.offer("first"));
+        assertEquals("first", queue.peek());
+        assertEquals(3, queue.size());
+        assertEquals("first", queue.poll());
+        assertEquals("second", queue.poll());
+        assertEquals("first", queue.poll());
+        assertNull(queue.poll());
+        assertTrue(queue.isEmpty());
+    }
+
+    @Test
+    public void copiesCollectionInIterationOrder() {
+        var source = new ArrayList<>(Arrays.asList("first", "second"));
+        var queue = new ConcurrentLinkedQueue<>(source);
+        source.clear();
+        assertArrayEquals(new String[] { "first", "second" }, queue.toArray(new String[0]));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void rejectsNullCollection() {
+        new ConcurrentLinkedQueue<String>((Collection<String>) null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void rejectsNullCollectionElement() {
+        new ConcurrentLinkedQueue<>(Arrays.asList("first", null));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void rejectsNullOffer() {
+        new ConcurrentLinkedQueue<String>().offer(null);
+    }
+
+    @Test
+    public void iteratorFollowsQueueOrderAndCanRemoveHead() {
+        var queue = new ConcurrentLinkedQueue<>(Arrays.asList("first", "second", "third"));
+        Iterator<String> iterator = queue.iterator();
+        assertEquals("first", iterator.next());
+        iterator.remove();
+        assertEquals("second", iterator.next());
+        assertEquals("third", iterator.next());
+        assertFalse(iterator.hasNext());
+        assertEquals(2, queue.size());
+        assertEquals("second", queue.peek());
+    }
+
+    @Test
+    public void supportsInheritedQueueOperations() {
+        var queue = new ConcurrentLinkedQueue<String>();
+        assertTrue(queue.add("first"));
+        assertEquals("first", queue.element());
+        assertEquals("first", queue.remove());
+        assertTrue(queue.isEmpty());
+    }
+
+    @Test(expected = NoSuchElementException.class)
+    public void removeFromEmptyQueueFails() {
+        new ConcurrentLinkedQueue<String>().remove();
+    }
+
+    @Test(expected = NoSuchElementException.class)
+    public void elementFromEmptyQueueFails() {
+        new ConcurrentLinkedQueue<String>().element();
+    }
+
+    @Test
+    public void supportsCollectionOperationsAndReuseAfterClear() {
+        var queue = new ConcurrentLinkedQueue<String>();
+        assertTrue(queue.addAll(Arrays.asList("first", "second", "third")));
+        assertTrue(queue.contains("second"));
+        assertTrue(queue.remove("second"));
+        assertFalse(queue.contains("second"));
+        assertFalse(queue.remove("missing"));
+        assertArrayEquals(new String[] { "first", "third" }, queue.toArray(new String[0]));
+        queue.clear();
+        assertTrue(queue.isEmpty());
+        queue.offer("again");
+        assertEquals("again", queue.poll());
+    }
+
+    @Test
+    public void growsAfterInterleavedOffersAndPolls() {
+        var queue = new ConcurrentLinkedQueue<Integer>();
+        for (int i = 0; i < 32; ++i) {
+            queue.offer(i);
+        }
+        for (int i = 0; i < 24; ++i) {
+            assertEquals(Integer.valueOf(i), queue.poll());
+        }
+        for (int i = 32; i < 160; ++i) {
+            queue.offer(i);
+        }
+        assertEquals(136, queue.size());
+        for (int i = 24; i < 160; ++i) {
+            assertEquals(Integer.valueOf(i), queue.poll());
+        }
+        assertTrue(queue.isEmpty());
+    }
+}

--- a/tests/src/test/java/org/teavm/tests/JUnitRuleAfterFailureTest.java
+++ b/tests/src/test/java/org/teavm/tests/JUnitRuleAfterFailureTest.java
@@ -1,0 +1,56 @@
+/*
+ *  Copyright 2026 Carl Stainton.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.teavm.tests;
+
+import static org.junit.Assert.assertSame;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+import org.junit.runner.RunWith;
+import org.junit.runners.model.Statement;
+import org.teavm.junit.SkipJVM;
+import org.teavm.junit.TeaVMTestRunner;
+
+/** Checks that a teardown failure reaches the rule wrapping the compiled test. */
+@RunWith(TeaVMTestRunner.class)
+@SkipJVM // The JVM comparison runner invokes methods directly, without applying JUnit rules.
+public class JUnitRuleAfterFailureTest {
+    private static final AssertionError AFTER_FAILURE = new AssertionError("after failed");
+
+    @Rule
+    public TestRule expectAfterFailure = (base, description) -> new Statement() {
+        @Override
+        public void evaluate() throws Throwable {
+            try {
+                base.evaluate();
+            } catch (AssertionError failure) {
+                assertSame(AFTER_FAILURE, failure);
+                return;
+            }
+            throw new AssertionError("The @After failure was swallowed");
+        }
+    };
+
+    @After
+    public void failAfterwards() {
+        throw AFTER_FAILURE;
+    }
+
+    @Test
+    public void bodyPassesBeforeTeardownFails() {
+    }
+}

--- a/tests/src/test/java/org/teavm/tests/JUnitRuleOrderTest.java
+++ b/tests/src/test/java/org/teavm/tests/JUnitRuleOrderTest.java
@@ -1,0 +1,78 @@
+/*
+ *  Copyright 2026 Carl Stainton.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.teavm.tests;
+
+import static org.junit.Assert.assertEquals;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runner.RunWith;
+import org.junit.runners.model.Statement;
+import org.teavm.junit.SkipJVM;
+import org.teavm.junit.TeaVMTestRunner;
+
+/**
+ * The {@code order} attribute, which JUnit documents as "rules with a higher value are inner".
+ *
+ * <p>Declaration order here is the reverse of application order, so only {@code order} can be
+ * deciding the outcome.
+ */
+@RunWith(TeaVMTestRunner.class)
+@SkipJVM // The JVM comparison runner invokes methods directly, without applying JUnit rules.
+public class JUnitRuleOrderTest {
+
+    static final List<String> events = new ArrayList<>();
+
+    @Rule(order = 10)
+    public TestRule declaredFirstWithHighOrder = new RecordingRule("high");
+
+    @Rule(order = 1)
+    public TestRule declaredSecondWithLowOrder = new RecordingRule("low");
+
+    @Test
+    public void theHigherOrderRuleIsTheInnerOne() {
+        events.add("test");
+
+        assertEquals(Arrays.asList("low before", "high before", "test"), events);
+    }
+
+    static final class RecordingRule implements TestRule {
+
+        private final String name;
+
+        RecordingRule(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public Statement apply(Statement base, Description description) {
+            return new Statement() {
+                @Override
+                public void evaluate() throws Throwable {
+                    if (name.equals("low")) {
+                        events.clear();
+                    }
+                    events.add(name + " before");
+                    base.evaluate();
+                }
+            };
+        }
+    }
+}

--- a/tests/src/test/java/org/teavm/tests/JUnitRuleTest.java
+++ b/tests/src/test/java/org/teavm/tests/JUnitRuleTest.java
@@ -1,0 +1,118 @@
+/*
+ *  Copyright 2026 Carl Stainton.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.teavm.tests;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runner.RunWith;
+import org.junit.runners.model.Statement;
+import org.teavm.junit.SkipJVM;
+import org.teavm.junit.TeaVMTestRunner;
+
+/**
+ * JUnit rules wrapping a test that TeaVM compiled and a browser ran.
+ *
+ * <p>The rules are applied in declaration order, each wrapping the one before, so the last field
+ * declared is the outermost. That is what JUnit's own {@code RunRules} does with the list it is
+ * given.
+ */
+@RunWith(TeaVMTestRunner.class)
+@SkipJVM // The JVM comparison runner invokes methods directly, without applying JUnit rules.
+public class JUnitRuleTest {
+
+    static final List<String> events = new ArrayList<>();
+    static String describedAs;
+    static int depth;
+
+    @Rule
+    public TestRule first = new RecordingRule("first");
+
+    @Rule
+    public TestRule second = new RecordingRule("second");
+
+    @Rule
+    public TestRule fromMethod() {
+        return new RecordingRule("fromMethod");
+    }
+
+    @Test
+    public void bothRulesWrappedThisTest() {
+        events.add("test");
+
+        assertEquals(
+                Arrays.asList("second before", "first before", "fromMethod before", "test"), events);
+    }
+
+    @Test
+    public void theRuleSawTheTestDescription() {
+        assertTrue(describedAs, describedAs.contains("JUnitRuleTest"));
+        assertTrue(describedAs, describedAs.contains("theRuleSawTheTestDescription"));
+    }
+
+    @Test
+    public void theTestBodyStillRuns() {
+        assertEquals(4, 2 + 2);
+    }
+
+    @Test
+    public void aRuleDeclaredAsAMethodIsAppliedInsideTheFields() {
+        events.add("test");
+
+        // JUnit applies methods before fields, so the method rule sits inside both fields.
+        assertEquals(
+                Arrays.asList("second before", "first before", "fromMethod before", "test"), events);
+    }
+
+    static final class RecordingRule implements TestRule {
+
+        private final String name;
+
+        RecordingRule(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public Statement apply(Statement base, Description description) {
+            return new Statement() {
+                @Override
+                public void evaluate() throws Throwable {
+                    if (depth++ == 0) {
+                        events.clear();
+                    }
+                    describedAs = description.getDisplayName();
+                    events.add(name + " before");
+                    try {
+                        base.evaluate();
+                    } finally {
+                        depth--;
+                        events.add(name + " after");
+                        if (depth == 0) {
+                            assertEquals(Arrays.asList("fromMethod after", "first after", "second after"),
+                                    events.subList(events.size() - 3, events.size()));
+                        }
+                    }
+                }
+            };
+        }
+    }
+}

--- a/tools/junit/src/main/java/org/teavm/junit/TestEntryPoint.java
+++ b/tools/junit/src/main/java/org/teavm/junit/TestEntryPoint.java
@@ -17,6 +17,8 @@ package org.teavm.junit;
 
 import java.util.ArrayList;
 import java.util.List;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
 
 final class TestEntryPoint {
     private static Object testCase;
@@ -29,16 +31,7 @@ final class TestEntryPoint {
         testCase = createTestCase();
         launchers(name, launchers);
         for (Launcher launcher : launchers) {
-            before();
-            try {
-                launcher.launch(testCase);
-            } finally {
-                try {
-                    after();
-                } catch (Throwable e) {
-                    e.printStackTrace();
-                }
-            }
+            applyRules(new LaunchStatement(launcher), name).evaluate();
         }
     }
 
@@ -50,11 +43,51 @@ final class TestEntryPoint {
 
     private static native void after();
 
+    /**
+     * Wraps the statement in the test case's rules, and returns it unchanged when there are none.
+     */
+    private static native Statement applyRules(Statement base, String name);
+
+    static Description describe(String className, String name) {
+        return Description.createTestDescription(className, name != null ? name : className);
+    }
+
     public static void main(String[] args) throws Throwable {
         run(args.length == 1 ? args[0] : null);
     }
 
     interface Launcher {
         void launch(Object testCase) throws Throwable;
+    }
+
+    private static final class LaunchStatement extends Statement {
+        private final Launcher launcher;
+
+        LaunchStatement(Launcher launcher) {
+            this.launcher = launcher;
+        }
+
+        @Override
+        public void evaluate() throws Throwable {
+            before();
+            Throwable failure = null;
+            try {
+                launcher.launch(testCase);
+            } catch (Throwable e) {
+                failure = e;
+            }
+            try {
+                after();
+            } catch (Throwable e) {
+                if (failure == null) {
+                    failure = e;
+                } else {
+                    failure.addSuppressed(e);
+                }
+            }
+            if (failure != null) {
+                throw failure;
+            }
+        }
     }
 }

--- a/tools/junit/src/main/java/org/teavm/junit/TestEntryPointTransformer.java
+++ b/tools/junit/src/main/java/org/teavm/junit/TestEntryPointTransformer.java
@@ -38,6 +38,7 @@ import org.teavm.model.ClassReader;
 import org.teavm.model.ClassReaderSource;
 import org.teavm.model.ElementModifier;
 import org.teavm.model.FieldHolder;
+import org.teavm.model.FieldReader;
 import org.teavm.model.MethodHolder;
 import org.teavm.model.MethodReader;
 import org.teavm.model.MethodReference;
@@ -51,6 +52,12 @@ import org.teavm.vm.spi.TeaVMHost;
 import org.teavm.vm.spi.TeaVMPlugin;
 
 abstract class TestEntryPointTransformer implements ClassHolderTransformer, TeaVMPlugin {
+    private static final String JUNIT4_RULE = "org.junit.Rule";
+    private static final String TEST_RULE = "org.junit.rules.TestRule";
+    private static final String METHOD_RULE = "org.junit.rules.MethodRule";
+    private static final String STATEMENT = "org.junit.runners.model.Statement";
+    private static final String DESCRIPTION = "org.junit.runner.Description";
+
     private String testClassName;
     private int suffixGenerator;
 
@@ -83,6 +90,10 @@ abstract class TestEntryPointTransformer implements ClassHolderTransformer, TeaV
                         break;
                     case "after":
                         generateAfterProgram(method, context.getHierarchy());
+                        method.getModifiers().remove(ElementModifier.NATIVE);
+                        break;
+                    case "applyRules":
+                        generateApplyRulesProgram(method, context.getHierarchy());
                         method.getModifiers().remove(ElementModifier.NATIVE);
                         break;
                 }
@@ -131,6 +142,117 @@ abstract class TestEntryPointTransformer implements ClassHolderTransformer, TeaV
 
         pe.exit();
         return pe.getProgram();
+    }
+
+    /** Emits the body of {@code applyRules}, wrapping the statement in each rule in turn. */
+    private void generateApplyRulesProgram(MethodHolder method, ClassHierarchy hierarchy) {
+        ProgramEmitter pe = ProgramEmitter.create(method, hierarchy);
+        // Variable 0 is the receiver slot, so a static method's parameters start at 1.
+        ValueEmitter statement = pe.var(1, ValueType.object(STATEMENT));
+        ValueEmitter name = pe.var(2, ValueType.object("java.lang.String"));
+
+        List<RuleEntry> rules = collectRules(pe.getClassSource());
+        if (rules.isEmpty()) {
+            statement.returnValue();
+            return;
+        }
+
+        ValueEmitter testCaseVar = pe.getField(TestEntryPoint.class, "testCase", Object.class);
+        ValueEmitter description = pe.invoke(TestEntryPoint.class.getName(), "describe",
+                ValueType.object(DESCRIPTION), pe.constant(testClassName), name);
+
+        for (RuleEntry rule : rules) {
+            ValueEmitter owner = testCaseVar.cast(ValueType.object(rule.ownerName));
+            ValueEmitter ruleValue = rule.field != null
+                    ? owner.getField(rule.field.getName(), rule.field.getType())
+                    : owner.invokeVirtual(rule.method.getReference());
+            statement = ruleValue
+                    .cast(ValueType.object(TEST_RULE))
+                    .invokeVirtual("apply", ValueType.object(STATEMENT), statement, description);
+        }
+
+        statement.returnValue();
+    }
+
+    /**
+     * Collects the fields and methods a test class annotates with {@code @Rule}, in the order
+     * they are applied.
+     *
+     * <p>A higher {@code order} is applied first and so ends up inner. Where the order is equal,
+     * methods come before fields, and within either group, declaration order with superclasses
+     * first.
+     */
+    private List<RuleEntry> collectRules(ClassReaderSource classSource) {
+        List<ClassReader> classes = collectSuperClasses(classSource, testClassName);
+        Collections.reverse(classes);
+
+        List<RuleEntry> rules = new ArrayList<>();
+        for (ClassReader cls : classes) {
+            for (MethodReader method : cls.getMethods()) {
+                AnnotationReader annotation = method.getAnnotations().get(JUNIT4_RULE);
+                if (annotation == null || method.hasModifier(ElementModifier.STATIC)
+                        || method.parameterCount() > 0) {
+                    continue;
+                }
+                if (isTestRule(classSource, method.getResultType(), cls.getName(),
+                        method.getName())) {
+                    rules.add(new RuleEntry(cls.getName(), null, method, orderOf(annotation), 0));
+                }
+            }
+            for (FieldReader field : cls.getFields()) {
+                AnnotationReader annotation = field.getAnnotations().get(JUNIT4_RULE);
+                if (annotation == null || field.hasModifier(ElementModifier.STATIC)) {
+                    continue;
+                }
+                if (isTestRule(classSource, field.getType(), cls.getName(), field.getName())) {
+                    rules.add(new RuleEntry(cls.getName(), field, null, orderOf(annotation), 1));
+                }
+            }
+        }
+
+        rules.sort((first, second) -> first.order != second.order
+                ? Integer.compare(second.order, first.order)
+                : Integer.compare(first.kind, second.kind));
+        return rules;
+    }
+
+    private boolean isTestRule(ClassReaderSource classSource, ValueType type, String owner,
+            String member) {
+        if (!(type instanceof ValueType.Object)) {
+            return false;
+        }
+        String typeName = ((ValueType.Object) type).getClassName();
+        if (classSource.isSuperType(TEST_RULE, typeName).orElse(false)) {
+            return true;
+        }
+        if (classSource.isSuperType(METHOD_RULE, typeName).orElse(false)) {
+            throw new IllegalStateException(owner + "." + member + " of type " + typeName
+                    + " is a MethodRule, which TeaVM cannot run because it needs"
+                    + " java.lang.reflect.Method. Use a TestRule.");
+        }
+        return false;
+    }
+
+    private static int orderOf(AnnotationReader annotation) {
+        AnnotationValue order = annotation.getValue("order");
+        return order != null ? order.getInt() : -1;
+    }
+
+    private static final class RuleEntry {
+        private final String ownerName;
+        private final FieldReader field;
+        private final MethodReader method;
+        private final int order;
+        private final int kind;
+
+        private RuleEntry(String ownerName, FieldReader field, MethodReader method, int order,
+                int kind) {
+            this.ownerName = ownerName;
+            this.field = field;
+            this.method = method;
+            this.order = order;
+            this.kind = kind;
+        }
     }
 
     private List<ClassReader> collectSuperClasses(ClassReaderSource classSource, String className) {


### PR DESCRIPTION
# Support JUnit `TestRule` in compiled TeaVM tests

I found that `TestRule` instances declared through `@Rule` fields and methods
were silently ignored in tests compiled by TeaVM. Tests could pass without
running the rule's setup, cleanup, or assertions. This adds support for applying
those rules around the test's setup, body, and teardown.

The change handles rule fields, no-argument rule methods, inherited rules, and
`@Rule(order = ...)`. Rules receive a `Description` naming the test class and
method. Teardown failures are propagated rather than only printed.

It also adds `TConcurrentLinkedQueue`, which JUnit needs when constructing a
`Description`. This uses `TAbstractQueue` and `TArrayDeque`. It is intended for
single-threaded use and does not provide the JVM queue's concurrency or weakly
consistent iterator guarantees.

This focuses on per-test `TestRule` execution, which our downstream tests use.
Supporting `MethodRule` would also require making the test's reflective
`Method` available to its `FrameworkMethod`. Supporting `@ClassRule` would
require applying rules once around the whole class, including class-level setup
and teardown. Those need additional compiler and runner work beyond the
per-test execution added here; they are not inherently unsupported by TeaVM.

The JVM comparison runner is unchanged; the rule tests use `@SkipJVM` because
that runner invokes test methods directly without applying rules.

Downstream, we use a small jar containing the patched classes, placed ahead of
TeaVM's jars on the test classpath. An upstream release containing this support
would let us remove that workaround.

## Tests

All 29 selected tests passed: 12 queue tests, six rule tests, and the 11 existing
`BufferedWriterTest` tests. They cover queue operations, rule execution and
ordering, test descriptions, reverse unwinding, and teardown failure.

Validation used JavaScript and Wasm GC, including optimised builds. The queue
and BufferedWriter tests also ran on the JVM. Main-source and test-source
Checkstyle checks passed.

The C backend, full test suite, and combined test-body/teardown failure case
have not been tested.

Thanks for reviewing this contribution.
